### PR TITLE
Fix #452 by use of Local Storage

### DIFF
--- a/lib/common/user/Auth0Manager.js
+++ b/lib/common/user/Auth0Manager.js
@@ -59,10 +59,10 @@ class Auth0Manager {
 
   /**
    * Use the access token (token for API calls) to get the user's profile.
-   * We can't fetch the profile data all the time because we'll get 429'ed by
-   * Auth0.  Therfore, we also store the profile data in localStorage, but we
-   * assume that the profile data is only valid for 60 seconds since it is
-   * possible that the profile data could have changed since we last logged in.
+   * We can't fetch the profile data all the time from Auth0 because we'll get
+   * always the same stale data from the last login.
+   * Therfore, we store the profile data in localStorage and we update it whenever
+   * it changes.
    *
    * @param  {String} accessToken auth0 access token
    * @return {Object}             auth0 profile
@@ -72,8 +72,7 @@ class Auth0Manager {
       const profile = getProfile()
       if (
         profile &&
-        profile.accessToken === accessToken &&
-        profile.dataExpirationTimestamp > (new Date()).getTime()
+        profile.accessToken === accessToken
       ) {
         return resolve(profile)
       }
@@ -81,8 +80,6 @@ class Auth0Manager {
         if (err) reject(err)
         else {
           profile.accessToken = accessToken
-          // set data expiration timestamp to be 60 seconds into the future
-          profile.dataExpirationTimestamp = (new Date()).getTime() + 60000
           setProfile(profile)
           resolve(profile)
         }

--- a/lib/manager/actions/user.js
+++ b/lib/manager/actions/user.js
@@ -273,6 +273,9 @@ export function updateUserData (user: any, userData: any) {
         } else {
           dispatch(fetchUsers())
         }
+        // We need to update directly localStorage as Auth0 returns stale data
+        // see https://github.com/ibi-group/datatools-ui/issues/452
+        window.localStorage.setItem('profile', JSON.stringify(profile))
       })
   }
 }

--- a/lib/manager/actions/user.js
+++ b/lib/manager/actions/user.js
@@ -275,7 +275,7 @@ export function updateUserData (user: any, userData: any) {
         }
         // We need to update directly localStorage as Auth0 returns stale data
         // see https://github.com/ibi-group/datatools-ui/issues/452
-        window.localStorage.setItem('profile', JSON.stringify(profile))
+        auth0.setProfile(profile)
       })
   }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing


### Description

Store, update and retrieve user profile data using Local Storage. Seeks to resolve #452. 
- Auth0 /userinfo endpoint is called only during login phase, profile data is stored on Local Storage.
- any update on user profile is sent to Auth0 AND to Local Storage
- subsequent calls to userinfo are bypassed (data would be stale) and profile is returned from Local Storage
- During the logout phase the local storage entry is wiped

This is intended for patching the Auth0 unespected behaviour until the new work that will use MongoDB to store user information.

