### PR TITLE
build: do not deploy releases to npm, only deploy to github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,5 @@ sudo: false
 # Push results to codecov.io
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  # only deploy the release to github as the package is not needed on npm
   - semantic-release --prepare false --publish @semantic-release/github --verify-conditions @semantic-release/github

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ sudo: false
 # Push results to codecov.io
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - semantic-release
+  - semantic-release --prepare false --publish @semantic-release/github --verify-conditions @semantic-release/github


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This sets the plugins of semantic-release that are used such that deployment to npm does not occur.