### PR TITLE
refactor: create better wording for bounds placeholders

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -87,6 +87,7 @@ components:
     success: Success!
     warning: Warning!
   DeploymentSettings:
+    boundsPlaceholder: 'min_lon, min_lat, max_lon, max_lat'
     buildConfig:
       elevationBucket:
         accessKey: Access Key
@@ -492,6 +493,7 @@ components:
     fields:
       location:
         boundingBox: 'Bounding box (W,S,E,N)'
+        boundingBoxPlaceHolder: 'min_lon, min_lat, max_lon, max_lat'
         defaultLanguage: Default language
         defaultLocation: 'Default location (lat, lng)'
         defaultTimeZone: Default time zone

--- a/i18n/espanol.yml
+++ b/i18n/espanol.yml
@@ -83,6 +83,7 @@ components:
     success: Success!
     warning: Warning!
   DeploymentSettings:
+    boundsPlaceholder: 'min_lon, min_lat, max_lon, max_lat'
     buildConfig:
       elevationBucket:
         accessKey: Access Key
@@ -488,6 +489,7 @@ components:
     fields:
       location:
         boundingBox: 'Bounding box (W,S,E,N)'
+        boundingBoxPlaceHolder: 'min_lon, min_lat, max_lon, max_lat'
         defaultLanguage: Default language
         defaultLocation: 'Default location (lat, lng)'
         defaultTimeZone: Default time zone

--- a/i18n/francais.yml
+++ b/i18n/francais.yml
@@ -83,6 +83,7 @@ components:
     success: Success!
     warning: Warning!
   DeploymentSettings:
+    boundsPlaceholder: 'min_lon, min_lat, max_lon, max_lat'
     buildConfig:
       elevationBucket:
         accessKey: Access Key
@@ -487,6 +488,7 @@ components:
     fields:
       location:
         boundingBox: 'Bounding box (W,S,E,N)'
+        boundingBoxPlaceHolder: 'min_lon, min_lat, max_lon, max_lat'
         defaultLanguage: Default language
         defaultLocation: 'Default location (lat, lng)'
         defaultTimeZone: Default time zone

--- a/lib/manager/components/DeploymentSettings.js
+++ b/lib/manager/components/DeploymentSettings.js
@@ -10,6 +10,7 @@ import {withRouter} from 'react-router'
 
 import {getComponentMessages} from '../../common/util/config'
 import CollapsiblePanel from './CollapsiblePanel'
+import {parseBounds} from '../util'
 import {FIELDS, SERVER_FIELDS, UPDATER_FIELDS} from '../util/deployment'
 
 import {updateProject} from '../actions/projects'
@@ -193,10 +194,18 @@ class DeploymentSettings extends Component<Props, State> {
   }
 
   _onChangeBounds = (evt) => {
-    const bBox = evt.target.value.split(',')
-    if (bBox.length === 4) {
-      const stateUpdate = { $merge: { osmWest: bBox[0], osmSouth: bBox[1], osmEast: bBox[2], osmNorth: bBox[3] } }
-      this.setState(update(this.state, stateUpdate))
+    const parsedBoundsResult = parseBounds(evt.target.value)
+    if (parsedBoundsResult.valid) {
+      this.setState(
+        update(
+          this.state,
+          {
+            $set: {
+              bounds: parsedBoundsResult.bounds
+            }
+          }
+        )
+      )
     }
   }
 
@@ -329,7 +338,11 @@ class DeploymentSettings extends Component<Props, State> {
           </FormGroup>
           {project.useCustomOsmBounds || this.state.useCustomOsmBounds
             ? <FormGroup>
-              <ControlLabel>{(<span><Glyphicon glyph='fullscreen' /> {this.messages('osm.bounds')}</span>)}</ControlLabel>
+              <ControlLabel>
+                <span>
+                  <Glyphicon glyph='fullscreen' /> {this.messages('osm.bounds')}
+                </span>
+              </ControlLabel>
               <FormControl
                 type='text'
                 defaultValue={project.bounds

--- a/lib/manager/components/DeploymentSettings.js
+++ b/lib/manager/components/DeploymentSettings.js
@@ -336,7 +336,7 @@ class DeploymentSettings extends Component<Props, State> {
                   ? `${project.bounds.west},${project.bounds.south},${project.bounds.east},${project.bounds.north}`
                   : ''
                 }
-                placeholder='-88.45,33.22,-87.12,34.89'
+                placeholder={this.messages('boundsPlaceholder')}
                 name='osmBounds'
                 onChange={this._onChangeBounds} />
             </FormGroup>

--- a/lib/manager/components/ProjectSettingsForm.js
+++ b/lib/manager/components/ProjectSettingsForm.js
@@ -29,7 +29,7 @@ import MapModal from '../../common/components/MapModal.js'
 import ConfirmModal from '../../common/components/ConfirmModal'
 import TimezoneSelect from '../../common/components/TimezoneSelect'
 import {getComponentMessages} from '../../common/util/config'
-import {validationState} from '../util'
+import {parseBounds, validationState} from '../util'
 
 import type {Bounds, Project} from '../../types'
 
@@ -139,21 +139,15 @@ export default class ProjectSettingsForm extends Component<Props, State> {
   _onChangeBounds = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     // Parse values found in string into floats
     const {value} = evt.target
-    const bBox = value.split(',')
-      .map(parseFloat)
-      // Filter out any bad parsed values
-      .filter(parsedValue => !isNaN(parsedValue))
-    if (bBox.length === 4) {
-      // Update settings if and only if there are four valid parsed values
-      const [west, south, east, north] = bBox
-      const bounds = {west, south, east, north}
+    const boundsValidation = parseBounds(value)
+    if (boundsValidation.valid) {
       this.setState(update(this.state, {
         model: {
-          $merge: {bounds}
+          $merge: {bounds: boundsValidation.bounds}
         },
         validation: {
           bounds: {
-            $set: bBox.every(isNumeric)
+            $set: true
           }
         }
       }))
@@ -411,15 +405,4 @@ export default class ProjectSettingsForm extends Component<Props, State> {
       </div>
     )
   }
-}
-
-/**
- * Returns true if value looks like a number.
- * Copied from https://stackoverflow.com/a/1830844/269834
- *
- * @param  {any}  value
- * @return {Boolean}
- */
-function isNumeric (value: any): boolean {
-  return !isNaN(value - parseFloat(value))
 }

--- a/lib/manager/components/ProjectSettingsForm.js
+++ b/lib/manager/components/ProjectSettingsForm.js
@@ -339,7 +339,7 @@ export default class ProjectSettingsForm extends Component<Props, State> {
                       : ''
                     }
                     ref='boundingBox'
-                    placeholder='-88.45,33.22,-87.12,34.89'
+                    placeholder={this.messages('fields.location.boundingBoxPlaceHolder')}
                     onChange={this._onChangeBounds} />
                   {
                     <InputGroup.Button>

--- a/lib/manager/util/__tests__/__snapshots__/index.js.snap
+++ b/lib/manager/util/__tests__/__snapshots__/index.js.snap
@@ -79,3 +79,36 @@ Array [
   "test feed with no version",
 ]
 `;
+
+exports[`manager > util > index > parseBounds > invalid > should fail to parse invalid lat/lon coordinates 1`] = `
+Object {
+  "errors": Array [
+    "West value is invalid. Expected a value between 180 and -180, but found -200",
+    "East value is invalid. Expected a value between 180 and -180, but found 210",
+    "North value is invalid. Expected a value between 90 and -90, but found 120",
+    "South value is invalid. Expected a value between 90 and -90, but found -100",
+  ],
+  "valid": false,
+}
+`;
+
+exports[`manager > util > index > parseBounds > invalid > should fail to parse less than 3 values 1`] = `
+Object {
+  "errors": Array [
+    "Incorrect amount of values. Found 3, expected 4.",
+  ],
+  "valid": false,
+}
+`;
+
+exports[`manager > util > index > parseBounds > valid > should parse valid bounds 1`] = `
+Object {
+  "bounds": Object {
+    "east": -122.696827,
+    "north": 45.525433,
+    "south": 45.503841,
+    "west": -122.723842,
+  },
+  "valid": true,
+}
+`;

--- a/lib/manager/util/__tests__/index.js
+++ b/lib/manager/util/__tests__/index.js
@@ -3,7 +3,7 @@
 import clone from 'lodash/cloneDeep'
 import moment from 'moment'
 
-import {versionStatusFilters, feedSortOptions} from '../'
+import {feedSortOptions, parseBounds, versionStatusFilters} from '../'
 import {
   restoreDateNowBehavior,
   setTestTime
@@ -47,6 +47,24 @@ function setFeedValidDateName (feed: Feed): Feed {
 }
 
 describe('manager > util > index >', () => {
+  describe('parseBounds >', () => {
+    describe('invalid >', () => {
+      it('should fail to parse less than 3 values', () => {
+        expect(parseBounds('1,2,3')).toMatchSnapshot()
+      })
+
+      it('should fail to parse invalid lat/lon coordinates', () => {
+        expect(parseBounds('-200,-100,210,120')).toMatchSnapshot()
+      })
+    })
+
+    describe('valid >', () => {
+      it('should parse valid bounds', () => {
+        expect(parseBounds('-122.723842, 45.503841, -122.696827, 45.525433')).toMatchSnapshot()
+      })
+    })
+  })
+
   describe('versionStatusFilters', () => {
     const mockFeedsForSortTest = mockFeeds.map(setFeedValidDateName)
 

--- a/lib/manager/util/index.js
+++ b/lib/manager/util/index.js
@@ -297,32 +297,33 @@ export function parseBounds (val: string): {
     // Filter out any bad parsed values
     .filter(parsedValue => !isNaN(parsedValue))
 
-  if (bBox.length === 4) {
-    const [west, south, east, north] = bBox
-
-    // make sure all values are valid
-    validateVal(west, 'West', isValidLongitude)
-    validateVal(east, 'East', isValidLongitude)
-    validateVal(north, 'North', isValidLatitude)
-    validateVal(south, 'South', isValidLatitude)
-
-    if (errors.length > 0) {
-      return {
-        errors,
-        valid: false
-      }
-    }
-
-    // valid!
-    const bounds = {west, south, east, north}
+  if (bBox.length !== 4) {
     return {
-      bounds,
-      valid: true
+      errors: [`Incorrect amount of values. Found ${bBox.length}, expected 4.`],
+      valid: false
     }
   }
+
+  const [west, south, east, north] = bBox
+
+  // make sure all values are valid
+  validateVal(west, 'West', isValidLongitude)
+  validateVal(east, 'East', isValidLongitude)
+  validateVal(north, 'North', isValidLatitude)
+  validateVal(south, 'South', isValidLatitude)
+
+  if (errors.length > 0) {
+    return {
+      errors,
+      valid: false
+    }
+  }
+
+  // valid!
+  const bounds = {west, south, east, north}
   return {
-    errors: [`Incorrect amount of values. Found ${bBox.length}, expected 4.`],
-    valid: false
+    bounds,
+    valid: true
   }
 }
 

--- a/lib/manager/util/index.js
+++ b/lib/manager/util/index.js
@@ -5,7 +5,13 @@ import {get} from 'object-path'
 
 import {getVersionValidationSummaryByFilterStrategy} from './version'
 
-import type {Feed, FeedVersion, Project, ValidationSummary} from '../../types'
+import type {
+  Bounds,
+  Feed,
+  FeedVersion,
+  Project,
+  ValidationSummary
+} from '../../types'
 import type {
   FeedSourceTableFilterCountStrategies,
   FeedSourceTableSortStrategiesWithOrders,
@@ -232,6 +238,92 @@ export function isEditingDisabled (
       'edit-gtfs'
     )
   )
+}
+
+/**
+ * Checks if the given value is a valid value for a latitude
+ */
+function isValidLatitude (n: number): {
+  error?: string,
+  valid: boolean
+} {
+  if (n <= 90 && n >= -90) {
+    return { valid: true }
+  } else {
+    return {
+      error: `Expected a value between 90 and -90, but found ${n}`,
+      valid: false
+    }
+  }
+}
+
+/**
+ * Checks if the given value is a valid value for a latitude
+ */
+function isValidLongitude (n: number): {
+  error?: string,
+  valid: boolean
+} {
+  if (n <= 180 && n >= -180) {
+    return { valid: true }
+  } else {
+    return {
+      error: `Expected a value between 180 and -180, but found ${n}`,
+      valid: false
+    }
+  }
+}
+
+/**
+ * Attempts to parses a string into a bounds object. The success or failure and
+ * any errors that were encountered are returned.
+ */
+export function parseBounds (val: string): {
+  bounds?: Bounds,
+  errors?: Array<string>,
+  valid: boolean
+} {
+  const errors = []
+
+  function validateVal (val, label, validationFn) {
+    const validationResult = validationFn(val)
+    if (!validationResult.valid) {
+      errors.push(`${label} value is invalid. ${validationResult.error || ''}`)
+    }
+  }
+
+  const bBox = val.split(',')
+    .map(parseFloat)
+    // Filter out any bad parsed values
+    .filter(parsedValue => !isNaN(parsedValue))
+
+  if (bBox.length === 4) {
+    const [west, south, east, north] = bBox
+
+    // make sure all values are valid
+    validateVal(west, 'West', isValidLongitude)
+    validateVal(east, 'East', isValidLongitude)
+    validateVal(north, 'North', isValidLatitude)
+    validateVal(south, 'South', isValidLatitude)
+
+    if (errors.length > 0) {
+      return {
+        errors,
+        valid: false
+      }
+    }
+
+    // valid!
+    const bounds = {west, south, east, north}
+    return {
+      bounds,
+      valid: true
+    }
+  }
+  return {
+    errors: [`Incorrect amount of values. Found ${bBox.length}, expected 4.`],
+    valid: false
+  }
 }
 
 /**


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

I found the placeholders describing bounds to be very hard to understand. This PR changes the wording of the placeholders to a hopefully much more easy-to-understand value. And then after that, I found that the bounding box field doesn't work in the DeploymentSettings component (#471). So I made another commit that fixes #471.