### PR TITLE
Ensure user_id is set in user profile

### DIFF
--- a/lib/common/user/Auth0Manager.js
+++ b/lib/common/user/Auth0Manager.js
@@ -83,6 +83,13 @@ class Auth0Manager {
           profile.accessToken = accessToken
           // set data expiration timestamp to be 60 seconds into the future
           profile.dataExpirationTimestamp = (new Date()).getTime() + 60000
+          // The user_id might not be provided in certain cases, so try to use
+          // the `sub` field instead.
+          // See https://community.auth0.com/t/missing-user-id-from-user-profile/11457/7
+          profile.user_id = profile.user_id || profile.sub
+          if (!profile.user_id) {
+            return reject(new Error('Could not determine user_id for user!'))
+          }
           setProfile(profile)
           resolve(profile)
         }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

The user_id might not be provided in certain responses from Auth0 depending on how a client is configured. In most cases, if the user_id is not provided, the `sub` field can be used instead.

See https://community.auth0.com/t/missing-user-id-from-user-profile/11457/7

Fixes #476 