### PR TITLE
Always require GTFS+ yml on config init

### DIFF
--- a/lib/common/util/config.js
+++ b/lib/common/util/config.js
@@ -83,11 +83,12 @@ function initializeConfig () {
     ...DEFAULT_CONFIG,
     ...JSON.parse(process.env.SETTINGS)
   }
-  if (config.modules.gtfsplus && config.modules.gtfsplus.enabled) {
-    // $FlowFixMe - assume file exists and make flow happy
-    const gtfsplus = require('../../../gtfsplus.yml')
-    config.specifications.gtfsplus = gtfsplus
-  }
+  // Note: The GTFS+ file should be required regardless of whether the module is
+  // enabled. Otherwise, it will not be loaded properly because the UI depends on
+  // the server config from the appinfo endpoint.
+  // $FlowFixMe - assume file exists and make flow happy
+  const gtfsplus = require('../../../gtfsplus.yml')
+  config.specifications.gtfsplus = gtfsplus
   // $FlowFixMe - assume file exists and make flow happy
   const gtfs = require('../../../gtfs.yml')
   config.specifications.gtfs = gtfs


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #486 by always requiring GTFS+ yml.