### PR TITLE
Remove eTID; filter permissions on module

### DIFF
--- a/lib/admin/components/ProjectAccessSettings.js
+++ b/lib/admin/components/ProjectAccessSettings.js
@@ -135,15 +135,16 @@ export default class ProjectAccessSettings extends Component<Props, State> {
                 {allPermissions
                   .filter(permission => permission.module ? isModuleEnabled(permission.module) : true)
                   .map((permission, i) => (
-                  <Checkbox
-                    // $FlowFixMe
-                    inputRef={ref => { this[`permission-${permission.type}`] = ref }}
-                    key={permission.type}
-                    checked={settings.permissions.indexOf(permission.type) !== -1}
-                    onChange={this.permissionsUpdated}>
-                    {permission.name}
-                  </Checkbox>
-                ))}
+                    <Checkbox
+                      // $FlowFixMe
+                      inputRef={ref => { this[`permission-${permission.type}`] = ref }}
+                      key={permission.type}
+                      checked={settings.permissions.indexOf(permission.type) !== -1}
+                      onChange={this.permissionsUpdated}>
+                      {permission.name}
+                    </Checkbox>
+                  ))
+                }
               </Col>
             </Row>
             : ''

--- a/lib/admin/components/ProjectAccessSettings.js
+++ b/lib/admin/components/ProjectAccessSettings.js
@@ -4,7 +4,7 @@ import React, {Component} from 'react'
 import {Row, Col, Checkbox, ButtonGroup} from 'react-bootstrap'
 
 import OptionButton from '../../common/components/OptionButton'
-import {getComponentMessages} from '../../common/util/config'
+import {getComponentMessages, isModuleEnabled} from '../../common/util/config'
 import * as feedActions from '../../manager/actions/feeds'
 import allPermissions from './permissions'
 
@@ -132,7 +132,9 @@ export default class ProjectAccessSettings extends Component<Props, State> {
               </Col>
               <Col xs={6}>
                 <h4>{this.messages('permissions')}</h4>
-                {allPermissions.map((permission, i) => (
+                {allPermissions
+                  .filter(permission => permission.module ? isModuleEnabled(permission.module) : true)
+                  .map((permission, i) => (
                   <Checkbox
                     // $FlowFixMe
                     inputRef={ref => { this[`permission-${permission.type}`] = ref }}

--- a/lib/admin/components/permissions.js
+++ b/lib/admin/components/permissions.js
@@ -1,11 +1,6 @@
 // @flow
 
 export default [
-  /* {
-    type: 'administer-project',
-    name: 'Administer Project',
-    feedSpecific: false
-  }, */
   {
     type: 'manage-feed',
     name: 'Manage Feed Configuration',
@@ -24,21 +19,13 @@ export default [
   {
     type: 'edit-alert',
     name: 'Edit GTFS-RT Alerts',
-    feedSpecific: true
+    feedSpecific: true,
+    module: 'alerts'
   },
   {
     type: 'approve-alert',
     name: 'Approve GTFS-RT Alerts',
-    feedSpecific: true
-  },
-  {
-    type: 'edit-etid',
-    name: 'Edit eTID Configurations',
-    feedSpecific: true
-  },
-  {
-    type: 'approve-etid',
-    name: 'Approve eTID Configurations',
-    feedSpecific: true
+    feedSpecific: true,
+    module: 'alerts'
   }
 ]


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

In the user admin part of the application, only show the feed-specific permissions relevant for the enabled modules for the application instance. For example, if the alerts module is not enabled, do not show permissions relevant to editing/approving GTFS-rt alerts.
