### PR TITLE
Correct semantic-release script so it uses cli in node project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ sudo: false
 # Push results to codecov.io
 after_success:
   # only deploy the release to github as the package is not needed on npm
-  - semantic-release --prepare false --publish @semantic-release/github --verify-conditions @semantic-release/github
+  - yarn run semantic-release

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint-messages": "node scripts/lint-messages.js",
     "predeploy": "yarn",
     "prestart": "yarn",
+    "semantic-release": "semantic-release --prepare false --publish @semantic-release/github --verify-conditions @semantic-release/github",
     "start": "mastarm build --env dev --serve --proxy http://localhost:4000/api",
     "test": "npm run lint && npm run lint-messages && yarn run flow && npm run test-client",
     "test-client": "TZ=America/Los_Angeles mastarm test -e test -c configurations/test --test-path-ignore-patterns \"__tests__/end-to-end __tests__/test-utils\"",


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

The [build of the master branch on Travis](https://travis-ci.org/ibi-group/datatools-ui/builds/593739104) didn't produce a release due to the following:

<img width="1044" alt="Screen Shot 2019-10-08 at 5 22 55 PM" src="https://user-images.githubusercontent.com/3112493/66442746-dcf55800-e9f0-11e9-8922-242b3d211519.png">

This PR corrects the running of semantic-release on Travis. Before, the script to run semantic-release was called via shell instead of an npm command, so since semantic-release wasn't installed globally, it was not found. This PR fixes that.