### PR TITLE
build(deps): bump puppeteer to 1.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "mastarm": "^5.1.3",
     "md5-file": "^4.0.0",
     "nock": "^9.0.14",
-    "puppeteer": "^1.19.0",
+    "puppeteer": "^1.20.0",
     "react-addons-test-utils": "^15.6.2",
     "redux-mock-store": "^1.5.3",
     "request": "^2.88.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10907,10 +10907,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^1.19.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.19.0.tgz#e3b7b448c2c97933517078d7a2c53687361bebea"
-  integrity sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==
+puppeteer@^1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.20.0.tgz#e3d267786f74e1d87cf2d15acc59177f471bbe38"
+  integrity sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
@evansiroky, not sure why, but I was able to get your branch to work by bumping puppeteer. Probably had something to do with messed up node_modules locally, but if you're ok with this change I'm ready to approve #495.