### PR TITLE
fix(user-admin): refactor/clean up permission/feed selection

### DIFF
--- a/lib/admin/components/ProjectAccessSettings.js
+++ b/lib/admin/components/ProjectAccessSettings.js
@@ -46,9 +46,7 @@ export default class ProjectAccessSettings extends Component<Props, State> {
   messages = getComponentMessages('ProjectAccessSettings')
 
   componentWillMount () {
-    this.setState({
-      projectSettings: this.props.settings
-    })
+    this.setState({ projectSettings: this.props.settings })
     if (!this.props.project.feedSources) {
       this.props.fetchProjectFeeds(this.props.project.id)
     }
@@ -58,12 +56,19 @@ export default class ProjectAccessSettings extends Component<Props, State> {
     this.props.projectAccessUpdated(this.props.project.id, access)
   }
 
-  feedsUpdated = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+  /**
+   * Add/remove a access to a feed for a user.
+   */
+  onToggleFeedSource = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     const {project, projectFeedsUpdated} = this.props
     projectFeedsUpdated(project.id, evt.target.name, evt.target.checked)
   }
 
-  permissionsUpdated = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+  /**
+   * Add/remove a permission for a user on a specific project (applies to set of
+   * default feeds).
+   */
+  onTogglePermission = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     const {project, projectPermissionsUpdated} = this.props
     // Cast name to permission type to make flow happy.
     const type = ((evt.target.name: any): PermissionType)
@@ -112,7 +117,7 @@ export default class ProjectAccessSettings extends Component<Props, State> {
                       key={feed.id}
                       name={feed.id}
                       checked={settings.defaultFeeds.indexOf(feed.id) !== -1}
-                      onChange={this.feedsUpdated}>
+                      onChange={this.onToggleFeedSource}>
                       {feed.name === '' ? '(unnamed feed)' : feed.name}
                     </Checkbox>
                   ))
@@ -128,7 +133,7 @@ export default class ProjectAccessSettings extends Component<Props, State> {
                       key={permission.type}
                       name={permission.type}
                       checked={settings.permissions.indexOf(permission.type) !== -1}
-                      onChange={this.permissionsUpdated}>
+                      onChange={this.onTogglePermission}>
                       {permission.name}
                     </Checkbox>
                   ))

--- a/lib/admin/components/ProjectAccessSettings.js
+++ b/lib/admin/components/ProjectAccessSettings.js
@@ -8,6 +8,7 @@ import {getComponentMessages, isModuleEnabled} from '../../common/util/config'
 import * as feedActions from '../../manager/actions/feeds'
 import allPermissions from './permissions'
 
+import type {PermissionType} from '../../common/user/UserPermissions'
 import type {Project} from '../../types'
 
 type ProjectSettingsType = {
@@ -20,8 +21,8 @@ type Props = {
   fetchProjectFeeds: typeof feedActions.fetchProjectFeeds,
   project: Project,
   projectAccessUpdated: (string, string) => void,
-  projectFeedsUpdated: (string, Array<string>) => void,
-  projectPermissionsUpdated: (string, Array<string>) => void,
+  projectFeedsUpdated: (string, string, boolean) => void,
+  projectPermissionsUpdated: (string, PermissionType, boolean) => void,
   settings: ProjectSettingsType,
   visible: boolean
 }
@@ -57,27 +58,16 @@ export default class ProjectAccessSettings extends Component<Props, State> {
     this.props.projectAccessUpdated(this.props.project.id, access)
   }
 
-  feedsUpdated = () => {
+  feedsUpdated = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     const {project, projectFeedsUpdated} = this.props
-    const selectedFeeds = []
-    if (project.feedSources) {
-      project.feedSources.forEach((feed) => {
-        // $FlowFixMe
-        var checkbox = this[`feed-${feed.id}`]
-        if (checkbox.checked) selectedFeeds.push(feed.id)
-      })
-    }
-    projectFeedsUpdated(project.id, selectedFeeds)
+    projectFeedsUpdated(project.id, evt.target.name, evt.target.checked)
   }
 
-  permissionsUpdated = () => {
-    const selectedPermissions = []
-    allPermissions.forEach((permission) => {
-      // $FlowFixMe
-      var checkbox = this[`permission-${permission.type}`]
-      if (checkbox.checked) selectedPermissions.push(permission.type)
-    })
-    this.props.projectPermissionsUpdated(this.props.project.id, selectedPermissions)
+  permissionsUpdated = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    const {project, projectPermissionsUpdated} = this.props
+    // Cast name to permission type to make flow happy.
+    const type = ((evt.target.name: any): PermissionType)
+    projectPermissionsUpdated(project.id, type, evt.target.checked)
   }
 
   render () {
@@ -119,9 +109,8 @@ export default class ProjectAccessSettings extends Component<Props, State> {
                 {feedSources
                   ? feedSources.map((feed, i) => (
                     <Checkbox
-                      // $FlowFixMe
-                      inputRef={ref => { this[`feed-${feed.id}`] = ref }}
                       key={feed.id}
+                      name={feed.id}
                       checked={settings.defaultFeeds.indexOf(feed.id) !== -1}
                       onChange={this.feedsUpdated}>
                       {feed.name === '' ? '(unnamed feed)' : feed.name}
@@ -136,9 +125,8 @@ export default class ProjectAccessSettings extends Component<Props, State> {
                   .filter(permission => permission.module ? isModuleEnabled(permission.module) : true)
                   .map((permission, i) => (
                     <Checkbox
-                      // $FlowFixMe
-                      inputRef={ref => { this[`permission-${permission.type}`] = ref }}
                       key={permission.type}
+                      name={permission.type}
                       checked={settings.permissions.indexOf(permission.type) !== -1}
                       onChange={this.permissionsUpdated}>
                       {permission.name}

--- a/lib/admin/components/UserSettings.js
+++ b/lib/admin/components/UserSettings.js
@@ -61,7 +61,7 @@ export default class UserSettings extends Component<Props, State> {
       organization: null
     }
 
-    organizations.forEach((organization: Organization, i: number) => {
+    organizations.forEach((organization: Organization) => {
       if (permissions.hasOrganization(organization.id)) {
         this.state.organization = organization
         if (permissions.isOrganizationAdmin(organization.id)) {
@@ -75,22 +75,29 @@ export default class UserSettings extends Component<Props, State> {
         this.state.organization = organization
       }
     })
-    projects.forEach((project: Project, i: number) => {
-      let access: string = 'none'
-      let defaultFeeds: Array<string> = []
-      let newPermissions: Array<string> = []
-      if (permissions.hasProject(project.id, project.organizationId)) {
-        if (permissions.isProjectAdmin(project.id, project.organizationId)) {
-          access = 'admin'
-        } else {
-          access = 'custom'
-          const projectPermissions: Array<Permission> = permissions.getProjectPermissions(project.id)
-          newPermissions = projectPermissions.map((p: Permission) => p.type)
-          defaultFeeds = permissions.getProjectDefaultFeeds(project.id)
-        }
-      }
-      this.state.projectSettings[project.id] = { access, defaultFeeds, permissions: newPermissions }
+    projects.forEach((project: Project) => {
+      this.state.projectSettings[project.id] = this._initProjectSettings(project, permissions)
     })
+  }
+
+  /**
+   * Initialize project settings state from project and user permissions object.
+   */
+  _initProjectSettings = (project: Project, permissions: UserPermissions) => {
+    let access: string = 'none'
+    let defaultFeeds: Array<string> = []
+    let newPermissions: Array<string> = []
+    if (permissions.hasProject(project.id, project.organizationId)) {
+      if (permissions.isProjectAdmin(project.id, project.organizationId)) {
+        access = 'admin'
+      } else {
+        access = 'custom'
+        const projectPermissions: Array<Permission> = permissions.getProjectPermissions(project.id)
+        newPermissions = projectPermissions.map((p: Permission) => p.type)
+        defaultFeeds = permissions.getProjectDefaultFeeds(project.id)
+      }
+    }
+    return { access, defaultFeeds, permissions: newPermissions }
   }
 
   getSettings () {
@@ -193,6 +200,10 @@ export default class UserSettings extends Component<Props, State> {
     this.setState(update(this.state, stateUpdate))
   }
 
+  /**
+   * Handler to add or remove a feed for a user to a project's default feeds
+   * list (for which the project's permissions apply to).
+   */
   projectFeedsUpdated = (projectId: string, feedId: string, include: boolean) => {
     const index = this.state.projectSettings[projectId].defaultFeeds.indexOf(feedId)
     let stateUpdate = {}
@@ -203,11 +214,15 @@ export default class UserSettings extends Component<Props, State> {
       // Remove from state if feed found && should not be included
       stateUpdate = {projectSettings: {[projectId]: {defaultFeeds: {$splice: [[index, 1]]}}}}
     } else {
-      console.warn(`Unknown error occurred while ${include ? 'adding' : 'removing'} feed!`, this.state, feedId)
+      console.warn(`Unknown error occurred while ${include ? 'adding' : 'removing'} feed! Setting default feeds to empty list.`, this.state, feedId)
+      stateUpdate = {projectSettings: {[projectId]: {defaultFeeds: {$set: []}}}}
     }
     this.setState(update(this.state, stateUpdate))
   }
 
+  /**
+   * Handler to add or remove a project permission for a user.
+   */
   projectPermissionsUpdated = (projectId: string, type: PermissionType, include: boolean) => {
     const index = this.state.projectSettings[projectId].permissions.indexOf(type)
     let stateUpdate = {}
@@ -218,7 +233,8 @@ export default class UserSettings extends Component<Props, State> {
       // Remove from state if permission found && should not be included
       stateUpdate = {projectSettings: {[projectId]: {permissions: {$splice: [[index, 1]]}}}}
     } else {
-      console.warn(`Unknown error occurred while ${include ? 'adding' : 'removing'} permission!`, this.state, type)
+      console.warn(`Unknown error occurred while ${include ? 'adding' : 'removing'} permission! Setting permissions to empty list.`, this.state, type)
+      stateUpdate = {projectSettings: {[projectId]: {permissions: {$set: []}}}}
     }
     this.setState(update(this.state, stateUpdate))
   }

--- a/lib/admin/components/UserSettings.js
+++ b/lib/admin/components/UserSettings.js
@@ -10,7 +10,7 @@ import {getComponentMessages} from '../../common/util/config'
 import * as feedActions from '../../manager/actions/feeds'
 import ProjectAccessSettings from './ProjectAccessSettings'
 
-import type {Permission} from '../../common/user/UserPermissions'
+import type {Permission, PermissionType} from '../../common/user/UserPermissions'
 import type {Organization, Project} from '../../types'
 import type {ManagerUserState} from '../../types/reducers'
 
@@ -193,13 +193,33 @@ export default class UserSettings extends Component<Props, State> {
     this.setState(update(this.state, stateUpdate))
   }
 
-  projectFeedsUpdated = (projectId: string, newFeeds: Array<string>) => {
-    const stateUpdate = {projectSettings: {[projectId]: {$merge: {defaultFeeds: newFeeds}}}}
+  projectFeedsUpdated = (projectId: string, feedId: string, include: boolean) => {
+    const index = this.state.projectSettings[projectId].defaultFeeds.indexOf(feedId)
+    let stateUpdate = {}
+    if (index === -1 && include) {
+      // Add to state if feed not found and should be included.
+      stateUpdate = {projectSettings: {[projectId]: {defaultFeeds: {$push: [feedId]}}}}
+    } else if (index !== -1) {
+      // Remove from state if feed found && should not be included
+      stateUpdate = {projectSettings: {[projectId]: {defaultFeeds: {$splice: [[index, 1]]}}}}
+    } else {
+      console.warn(`Unknown error occurred while ${include ? 'adding' : 'removing'} feed!`, this.state, feedId)
+    }
     this.setState(update(this.state, stateUpdate))
   }
 
-  projectPermissionsUpdated = (projectId: string, newPermissions: Array<string>) => {
-    const stateUpdate = {projectSettings: {[projectId]: {$merge: {permissions: newPermissions}}}}
+  projectPermissionsUpdated = (projectId: string, type: PermissionType, include: boolean) => {
+    const index = this.state.projectSettings[projectId].permissions.indexOf(type)
+    let stateUpdate = {}
+    if (index === -1 && include) {
+      // Add to state if permission not found and should be included.
+      stateUpdate = {projectSettings: {[projectId]: {permissions: {$push: [type]}}}}
+    } else if (index !== -1) {
+      // Remove from state if permission found && should not be included
+      stateUpdate = {projectSettings: {[projectId]: {permissions: {$splice: [[index, 1]]}}}}
+    } else {
+      console.warn(`Unknown error occurred while ${include ? 'adding' : 'removing'} permission!`, this.state, type)
+    }
     this.setState(update(this.state, stateUpdate))
   }
 

--- a/lib/admin/components/permissions.js
+++ b/lib/admin/components/permissions.js
@@ -1,6 +1,8 @@
 // @flow
 
-export default [
+import type {Permission} from '../../common/user/UserPermissions'
+
+const permissions: Array<Permission> = [
   {
     type: 'manage-feed',
     name: 'Manage Feed Configuration',
@@ -29,3 +31,5 @@ export default [
     module: 'alerts'
   }
 ]
+
+export default permissions

--- a/lib/common/user/UserPermissions.js
+++ b/lib/common/user/UserPermissions.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type {Subscription} from './UserSubscriptions'
+import type {ModuleType} from '../../types'
 
 /**
  * The permission types that can be defined in the user profile object
@@ -20,6 +21,8 @@ export type PermissionType =
 
 export type Permission = {
   feeds?: Array<string>,
+  module?: ModuleType,
+  name?: string,
   type: PermissionType
 }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

fix #512. Refactor the user admin permissions/feed selection so that it doesn't use weird input refs.