### PR TITLE
Timetable Editor: Save cell contents when cell loses focus.

### DIFF
--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -259,6 +259,10 @@ export default class EditableCell extends Component<Props, State> {
     }
   }
 
+  handleBlur = () => {
+    this.save()
+  }
+
   handleChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     this.setState({data: evt.target.value})
   }
@@ -335,7 +339,7 @@ export default class EditableCell extends Component<Props, State> {
         autoFocus
         defaultValue={renderCell(column, data)}
         className='cell-input'
-        onBlur={this.cancel}
+        onBlur={this.handleBlur}
         onChange={this.handleChange}
         onFocus={this._onInputFocus}
         onKeyDown={this.handleKeyDown}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR includes fix #562.
A new `handleBlur` event handler is added with the correct behavior.
