### PR TITLE
Fix graphhopper handling into segments

### DIFF
--- a/lib/editor/components/pattern/EditShapePanel.js
+++ b/lib/editor/components/pattern/EditShapePanel.js
@@ -60,7 +60,7 @@ export default class EditShapePanel extends Component<Props> {
           }
         })
     }
-    if (patternSegments && patternSegments.length) {
+    if (patternSegments && patternSegments.length > 0) {
       const controlPoints = controlPointsFromSegments(pattern.patternStops, patternSegments)
       updatePatternGeometry({
         controlPoints,

--- a/lib/editor/util/debug.js
+++ b/lib/editor/util/debug.js
@@ -1,0 +1,26 @@
+// @flow
+
+import featurecollection from 'turf-featurecollection'
+import point from 'turf-point'
+
+import type {Coordinates, GeoJsonFeatureCollection} from '../../types'
+
+/**
+ * Log a link to the input feature collection rendered in geojson.io
+ */
+export function logGeojsonioUrl (features: GeoJsonFeatureCollection) {
+  console.log(`http://geojson.io/#data=data:application/json,${encodeURIComponent(JSON.stringify(features))}`)
+}
+
+/**
+ * Convert array of coordinates to a feature collection.
+ */
+export function logCoordsToGeojsonio (coords: Coordinates) {
+  const features = coordsToFeatureCollection(coords)
+  logGeojsonioUrl(features)
+}
+
+function coordsToFeatureCollection (coords: Coordinates): GeoJsonFeatureCollection {
+  // Feature collection used for debug logging to geojson.io
+  return featurecollection(coords.map(c => point(c)))
+}

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -865,6 +865,8 @@ export function controlPointsFromSegments (
 ): Array<ControlPoint> {
   const controlPoints = []
   let cumulativeDistance = 0
+  // Iterate over pattern segments and generate control points at the fence
+  // posts.
   for (let i = 0; i <= patternSegments.length; i++) {
     let coordinate
     if (i === patternSegments.length) {

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -5,7 +5,10 @@ import {decode as decodePolyline} from 'polyline'
 import {isEqual as coordinatesAreEqual} from '@conveyal/lonlat'
 import qs from 'qs'
 import lineString from 'turf-linestring'
-import lineSliceAlong from '@turf/line-slice-along'
+
+// This can be used for logging line strings to geojson.io URLs for easy
+// debugging.
+// import {logCoordsToGeojsonio} from '../../editor/util/debug'
 
 import type {
   Coordinates,
@@ -58,38 +61,29 @@ function handleGraphHopperRouting (path: Path, individualLegs: boolean = false):
   // Decode polyline and reverse coordinates.
   const decodedPolyline = decodePolyline(points).map(c => ([c[1], c[0]]))
   if (individualLegs) {
-    // Reconstruct individual legs from the instructions. NOTE: we do not simply
-    // use the waypoints found in the response because for lines that share
-    // street segments, slicing on these points results in unpredictable splits.
-    // Slicing the line along distances is much more reliable.
     const segments = []
-    const waypointDistances = [0]
-    let distance = 0
-    // Iterate over the instructions, accumulating distance and storing the
-    // distance at each waypoint encountered. Distances are used to slice the
-    // line geometry if individual legs are needed. NOTE: Waypoint === routing
-    // point provided in the request.
-    instructions.forEach(instruction => {
-      if (instruction.text.match(/Waypoint (\d+)/)) {
-        // Add distance value to list
-        waypointDistances.push(distance)
-      } else {
-        distance += instruction.distance
+    // Keep track of the segment point intervals to split the line segment at.
+    // This appears to be the most reliable way to split up the geometry
+    // (previously distance was used here, but that provided inconstent results).
+    const segmentPointIndeces = [0]
+    // Iterate over the instructions, accumulating segment point indeces at each
+    // waypoint encountered. Indeces are used to slice the line geometry when
+    // individual legs are needed. NOTE: Waypoint === routing point provided in
+    // the request.
+    instructions.forEach((instruction, i) => {
+      if (instruction.text.match(/Waypoint (\d+)/) || i === instructions.length - 1) {
+        segmentPointIndeces.push(instruction.interval[0])
       }
     })
-    // Add last distance measure.
-    // FIXME: Should this just be the length of the entire line?
-    // console.log(waypointDistances, json.paths[0].distance)
-    waypointDistances.push(distance)
-    const decodedLineString = lineString(decodedPolyline)
-    if (waypointDistances.length > 2) {
-      for (var i = 1; i < waypointDistances.length; i++) {
-        const slicedSegment = lineSliceAlong(
-          decodedLineString,
-          waypointDistances[i - 1] / 1000,
-          waypointDistances[i] / 1000
-        )
-        segments.push(slicedSegment.geometry.coordinates)
+    // Once all of the indeces have been found, slice the decoded polyline up
+    // at the provided indeces.
+    if (segmentPointIndeces.length > 2) {
+      for (var i = 1; i < segmentPointIndeces.length; i++) {
+        // Get the indeces of the points that the entire path should be sliced at
+        // Note: 'to' index is incremented by one because it is not inclusive.
+        const [from, to] = [segmentPointIndeces[i - 1], segmentPointIndeces[i] + 1]
+        const segment = decodedPolyline.slice(from, to)
+        segments.push(segment)
       }
       // console.log('individual legs', segments)
       return segments
@@ -132,9 +126,10 @@ export async function polyline (
       const endIndex = i + chunk + offset
       const chunkedPoints = points.slice(beginIndex, endIndex)
       json = await routeWithGraphHopper(chunkedPoints)
+      const path = json && json.paths && json.paths[0]
       // Route between chunked list of points
-      if (json && json.paths && json.paths[0]) {
-        const result = handleGraphHopperRouting(json.paths[0], individualLegs)
+      if (path) {
+        const result = handleGraphHopperRouting(path, individualLegs)
         geometry.push(...result)
       } else {
         // If any of the routed legs fails, default to straight line (return null).

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -65,23 +65,23 @@ function handleGraphHopperRouting (path: Path, individualLegs: boolean = false):
     // Keep track of the segment point intervals to split the line segment at.
     // This appears to be the most reliable way to split up the geometry
     // (previously distance was used here, but that provided inconstent results).
-    const segmentPointIndexes = [0]
-    // Iterate over the instructions, accumulating segment point indexes at each
-    // waypoint encountered. Indexes are used to slice the line geometry when
+    const segmentPointIndices = [0]
+    // Iterate over the instructions, accumulating segment point indices at each
+    // waypoint encountered. Indices are used to slice the line geometry when
     // individual legs are needed. NOTE: Waypoint === routing point provided in
     // the request.
     instructions.forEach((instruction, i) => {
       if (instruction.text.match(/Waypoint (\d+)/) || i === instructions.length - 1) {
-        segmentPointIndexes.push(instruction.interval[0])
+        segmentPointIndices.push(instruction.interval[0])
       }
     })
-    // Once all of the indexes have been found, slice the decoded polyline up
-    // at the provided indexes.
-    if (segmentPointIndexes.length > 2) {
-      for (var i = 1; i < segmentPointIndexes.length; i++) {
-        // Get the indexes of the points that the entire path should be sliced at
+    // Once all of the indices have been found, slice the decoded polyline up
+    // at the provided indices.
+    if (segmentPointIndices.length > 2) {
+      for (var i = 1; i < segmentPointIndices.length; i++) {
+        // Get the indices of the points that the entire path should be sliced at
         // Note: 'to' index is incremented by one because it is not inclusive.
-        const [from, to] = [segmentPointIndexes[i - 1], segmentPointIndexes[i] + 1]
+        const [from, to] = [segmentPointIndices[i - 1], segmentPointIndices[i] + 1]
         const segment = decodedPolyline.slice(from, to)
         segments.push(segment)
       }
@@ -120,7 +120,7 @@ export async function polyline (
     let count = 0
     const j = points.length
     for (let i = 0; i < j; i += chunk) {
-      // Offset the slice indexes so that the next chunk begins with the
+      // Offset the slice indices so that the next chunk begins with the
       const offset = count * -1
       const beginIndex = i + offset
       const endIndex = i + chunk + offset

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -65,23 +65,23 @@ function handleGraphHopperRouting (path: Path, individualLegs: boolean = false):
     // Keep track of the segment point intervals to split the line segment at.
     // This appears to be the most reliable way to split up the geometry
     // (previously distance was used here, but that provided inconstent results).
-    const segmentPointIndeces = [0]
-    // Iterate over the instructions, accumulating segment point indeces at each
-    // waypoint encountered. Indeces are used to slice the line geometry when
+    const segmentPointIndexes = [0]
+    // Iterate over the instructions, accumulating segment point indexes at each
+    // waypoint encountered. Indexes are used to slice the line geometry when
     // individual legs are needed. NOTE: Waypoint === routing point provided in
     // the request.
     instructions.forEach((instruction, i) => {
       if (instruction.text.match(/Waypoint (\d+)/) || i === instructions.length - 1) {
-        segmentPointIndeces.push(instruction.interval[0])
+        segmentPointIndexes.push(instruction.interval[0])
       }
     })
-    // Once all of the indeces have been found, slice the decoded polyline up
-    // at the provided indeces.
-    if (segmentPointIndeces.length > 2) {
-      for (var i = 1; i < segmentPointIndeces.length; i++) {
-        // Get the indeces of the points that the entire path should be sliced at
+    // Once all of the indexes have been found, slice the decoded polyline up
+    // at the provided indexes.
+    if (segmentPointIndexes.length > 2) {
+      for (var i = 1; i < segmentPointIndexes.length; i++) {
+        // Get the indexes of the points that the entire path should be sliced at
         // Note: 'to' index is incremented by one because it is not inclusive.
-        const [from, to] = [segmentPointIndeces[i - 1], segmentPointIndeces[i] + 1]
+        const [from, to] = [segmentPointIndexes[i - 1], segmentPointIndexes[i] + 1]
         const segment = decodedPolyline.slice(from, to)
         segments.push(segment)
       }

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -438,6 +438,11 @@ export type GeoJsonLinestring = {
   type: 'Feature'
 }
 
+export type GeoJsonFeatureCollection = {
+  features: Array<GeoJsonLinestring | GeoJsonPoint>,
+  type: 'FeatureCollection'
+}
+
 export type PatternStop = {
   defaultDwellTime: number,
   defaultTravelTime: number,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #571. The construction of pattern segments previously used what appears to be a pretty flimsy slicing of the line geometry by distance values. This has been replaced with exact slices specified by point indeces in the Graphhopper response. This appears to work much better with the sample case described in #571 (and is expected to perform better overall).

EDIT: btw, the piece of the Graphhopper response we're using is [`paths.instructions.interval`](https://docs.graphhopper.com/#operation/getRoute/responses/200/json/paths/instructions/interval).