### PR TITLE
Fix computation of pattern stop projection onto shape

### DIFF
--- a/lib/editor/components/map/PatternStopsLayer.js
+++ b/lib/editor/components/map/PatternStopsLayer.js
@@ -9,7 +9,7 @@ import * as tripPatternActions from '../../actions/tripPattern'
 import {POINT_TYPE} from '../../constants'
 import PatternStopMarker from './PatternStopMarker'
 
-import type {ControlPoint, Feed, GtfsStop, Pattern} from '../../../types'
+import type {ControlPoint, Feed, GtfsStop, Pattern, PatternStop} from '../../../types'
 import type {EditSettingsState} from '../../../types/reducers'
 
 type Props = {
@@ -45,29 +45,30 @@ export default class PatternStopsLayer extends Component<Props> {
     // pattern stop, but in PatternStopMarker begins to refer to the PatternStop
     // type. The below destructuring is to satisfy Flow.
     const {patternStop: activePatternStop, ...otherProps} = this.props
-    if (!activePatternStops || !activePattern || !editSettings.showStops || !activePattern.patternStops) {
+    if (!activePatternStops || !activePattern || !editSettings.showStops) {
       return null
     }
-    const activeStopNotFound = activePattern &&
-      activePatternStop &&
-      activePattern.patternStops &&
-      activePattern.patternStops.findIndex(ps => ps.id === activePatternStop.id) === -1
+    const {patternStops} = activePattern
+    const activeStopNotFound = activePatternStop &&
+      patternStops.findIndex(ps => ps.id === activePatternStop.id) === -1
     let cpIndex = 0
     let psIndex = 0
     const patternStopsWithControlPointIndexes = []
+    // Associate pattern stops with control point indices.
     while (controlPoints[cpIndex]) {
       if (controlPoints[cpIndex].pointType === POINT_TYPE.STOP) {
-        // $FlowFixMe
-        const clonedPatternStop: any = clone(activePattern.patternStops[psIndex])
+        const clonedPatternStop: PatternStop = clone(patternStops[psIndex])
         if (!clonedPatternStop) {
           console.warn(`No pattern stop for control point index ${cpIndex}.`)
           break
         }
-        clonedPatternStop.cpIndex = cpIndex
-        patternStopsWithControlPointIndexes.push(clonedPatternStop)
+        patternStopsWithControlPointIndexes.push({...clonedPatternStop, cpIndex})
         psIndex++
       }
       cpIndex++
+    }
+    if (cpIndex < patternStops.length) {
+      console.warn(`Fewer control points (${controlPoints.length}) than pattern stops (${patternStops.length})!`, controlPoints, patternStops)
     }
     return (
       <div id='PatternStops'>

--- a/lib/editor/selectors/index.js
+++ b/lib/editor/selectors/index.js
@@ -15,7 +15,8 @@ import point from 'turf-point'
 
 import {getEditorTable, getFareRuleFieldName} from '../util'
 import {getTableById, getEntityName} from '../util/gtfs'
-import {coordsToFeatureCollection, logGeojsonioUrl} from '../util/debug'
+// The below debug imports can be helpful for debugging pattern shapes.
+// import {coordsToFeatureCollection, logGeojsonioUrl} from '../util/debug'
 import {POINT_TYPE} from '../constants'
 import {
   generateControlPointsFromPatternStops,

--- a/lib/editor/selectors/index.js
+++ b/lib/editor/selectors/index.js
@@ -15,6 +15,7 @@ import point from 'turf-point'
 
 import {getEditorTable, getFareRuleFieldName} from '../util'
 import {getTableById, getEntityName} from '../util/gtfs'
+import {coordsToFeatureCollection, logGeojsonioUrl} from '../util/debug'
 import {POINT_TYPE} from '../constants'
 import {
   generateControlPointsFromPatternStops,
@@ -390,7 +391,6 @@ function addPatternStopsToShapePoints (
   if (oldShapePoints.length < 2) {
     throw new Error('Shape points must contain two or more coordinates.')
   }
-  // FIXME: should this be a clone operation?
   const shapePointsCopy = clone(oldShapePoints)
   const patternSegments = []
   const computedShapePoints = []
@@ -398,7 +398,8 @@ function addPatternStopsToShapePoints (
   // (this is an empty array if pattern shape has never been edited).
   // NOTE: This is a bit fragile. The shape points objects are currently linked
   // to the shape points copy. Updates to stopControlPoints will hence be applied
-  // to the shape points copy. FIXME: Unlink these, but still ensure that
+  // to the shape points copy. TODO: Unlink these, but still ensure that the
+  // updates are applied properly.
   const stopControlPoints = shapePointsCopy
     // .map(sp => ({...sp}))
     .filter(sp => sp.pointType === POINT_TYPE.STOP)
@@ -554,7 +555,8 @@ function addPatternStopsToShapePoints (
         }
         continue
       }
-      // console.log(`generating shape point for stop #${i} at distance: ${scaledDistanceInMeters}`, patternStop, remainingLine)
+      // const distPercentage = Math.round(scaledDistanceInMeters / patternLengthInMeters * 10000) / 100
+      // console.log(`generating shape point for stop #${i} at distance: ${scaledDistanceInMeters} ${distPercentage}%`, patternStop, remainingLine)
       if (i === 0 && scaledDistanceInMeters !== 0) {
         // First stop's distance is not zero.
         console.warn(`Distance for first stop is not zero. Coercing to zero.`)
@@ -621,7 +623,7 @@ function addPatternStopsToShapePoints (
         }
       }
     }
-    // Insert projected stop into shape points list
+    // Insert projected stop location into shape points list.
     const newShapePoint = {
       shapePtLat: insertPoint.geometry.coordinates[1],
       shapePtLon: insertPoint.geometry.coordinates[0],
@@ -698,7 +700,9 @@ function addPatternStopsToShapePoints (
   }
   // Renumber ID (sequence) based on index
   return {
-    shapePoints: shapePointsCopy.map((sp, index) => ({
+    // Make sure we're returning the computedShapePoints list (unlike some other
+    // return statements in this method).
+    shapePoints: computedShapePoints.map((sp, index) => ({
       ...sp,
       id: index,
       shapePtSequence: index


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #581. This PR essentially swaps out the return value for `addPatternStopsToShapePoints` from using `shapePointsCopy` to `computedShapePoints`. This was a tricky one to debug and I can't say 100% why we were ever returning `shapePointsCopy` (or if it ever worked), but yea, this PR fixes things.