### PR TITLE
Improve code dealing with project.otpServer field

### DIFF
--- a/lib/admin/components/AdminPage.js
+++ b/lib/admin/components/AdminPage.js
@@ -25,7 +25,7 @@ import OrganizationList from './OrganizationList'
 import ServerSettings from './ServerSettings'
 import UserList from './UserList'
 
-import type {OtpServer, Project} from '../../types'
+import type {Project} from '../../types'
 import type {AppState, ManagerUserState, RouterProps} from '../../types/reducers'
 
 type Props = RouterProps & {
@@ -34,7 +34,6 @@ type Props = RouterProps & {
   fetchProjects: typeof projectActions.fetchProjects,
   fetchServers: typeof adminActions.fetchServers,
   fetchUsers: typeof adminActions.fetchUsers,
-  otpServers: Array<OtpServer>,
   projects: Array<Project>,
   user: ManagerUserState
 }

--- a/lib/manager/components/DeploymentViewer.js
+++ b/lib/manager/components/DeploymentViewer.js
@@ -44,7 +44,12 @@ import DeploymentConfirmModal from './DeploymentConfirmModal'
 import DeploymentVersionsTable from './DeploymentVersionsTable'
 
 import type {Props as ContainerProps} from '../containers/ActiveDeploymentViewer'
-import type {Deployment, ReactSelectOption, ServerJob} from '../../types'
+import type {
+  Deployment,
+  ReactSelectOption,
+  ServerJob,
+  SummarizedFeedVersion
+} from '../../types'
 import type {ManagerUserState} from '../../types/reducers'
 
 type Props = ContainerProps & {
@@ -214,20 +219,128 @@ export default class DeploymentViewer extends Component<Props, State> {
     updateDeployment(deployment, props)
   }
 
-  render () {
+  renderHeader () {
     const {
-      deleteFeedVersion,
       deployJobs,
       deployment,
-      deployToTarget,
-      feedSources,
       project,
-      updateDeployment,
-      updateVersionForFeedSource,
       user
     } = this.props
-    const {target} = this.state
-    const {feedVersions} = deployment
+    const na = (<span style={{ color: 'lightGray' }}>N/A</span>)
+    const isWatchingDeployment = user.subscriptions &&
+      user.subscriptions.hasFeedSubscription(
+        project.id,
+        deployment.id,
+        'deployment-updated'
+      )
+
+    return (
+      <div>
+        <h4>
+          <ButtonGroup className='pull-right'>
+            <WatchButton
+              isWatching={isWatchingDeployment}
+              user={user}
+              target={deployment.id}
+              subscriptionType='deployment-updated' />
+            <Button
+              bsStyle='default'
+              onClick={this._onClickDownload}>
+              <span><Glyphicon glyph='download' /> {this.messages('download')}</span>
+            </Button>
+            <DropdownButton
+              bsStyle='primary'
+              id='deploy-server-dropdown'
+              pullRight
+              disabled={!project.otpServers || !project.otpServers.length}
+              title={project.otpServers && project.otpServers.length
+                ? <span>
+                  <Glyphicon glyph='globe' />{' '}
+                  {this.messages('deploy')}
+                </span>
+                : <span>{this.messages('noServers')}</span>
+              }
+              onSelect={this._onSelectTarget}>
+              {project.otpServers
+                ? project.otpServers.map((server, i) => (
+                  <MenuItem
+                    data-test-id={`deploy-server-${i}-button`}
+                    // Disable server if the server is missing a name,
+                    // has neither an internal URL or s3 bucket name,
+                    // or has a load balancer target group set, but is
+                    // set for a test feed source (with a non-default router).
+                    disabled={
+                      deployJobs.length > 0 ||
+                      !server.name ||
+                      (
+                        (!server.internalUrl || server.internalUrl.length === 0) &&
+                        !server.s3Bucket
+                      ) ||
+                      (server.ec2Info && server.ec2Info.targetGroupArn && deployment.feedSourceId)
+                    }
+                    eventKey={server.id}
+                    key={server.id}
+                  >
+                    {server.name || '[Unnamed]'}
+                  </MenuItem>
+                ))
+                : null
+              }
+              {project.otpServers && <MenuItem divider />}
+              <LinkContainer
+                to='/admin/servers'
+                key={project.id}>
+                <MenuItem>
+                  <Icon type='cog' /> Manage servers
+                </MenuItem>
+              </LinkContainer>
+            </DropdownButton>
+          </ButtonGroup>
+          <EditableTextField
+            inline
+            style={{marginLeft: '5px'}}
+            value={deployment.name}
+            onChange={this._onChangeName} />
+        </h4>
+        <small title={deployment.lastDeployed && formatTimestamp(deployment.lastDeployed)}>
+          <Icon type='clock-o' />
+          {' '}
+          Last deployed {deployment.lastDeployed ? fromNow(deployment.lastDeployed) : na}
+        </small>
+      </div>
+    )
+  }
+
+  renderMap () {
+    const { deployment } = this.props
+    const isMissingBounds = !deployment.projectBounds
+    const {east, north, south, west} = deployment.projectBounds ||
+      {east: 10, north: 10, west: -10, south: -10}
+    const boundsTooLarge = east - west > BOUNDS_LIMIT || north - south > BOUNDS_LIMIT
+    const bounds = this._getBounds()
+
+    return (
+      <Map
+        ref='map'
+        bounds={bounds}
+        scrollWheelZoom={false}
+        style={{width: '100%', height: '300px'}}>
+        <TileLayer {...defaultTileLayerProps()} />
+        {!isMissingBounds &&
+          <Rectangle
+            bounds={bounds}
+            // If bounds are too large, draw rectangle in red
+            // (otherwise use the default path color).
+            color={boundsTooLarge ? 'red' : '#3388ff'}
+            fillOpacity={0} />
+        }
+      </Map>
+    )
+  }
+
+  renderDeployentVersionsTableHeader (versions: Array<SummarizedFeedVersion>) {
+    const { deployment, feedSources, project } = this.props
+    const { feedVersions } = deployment
     if (!deployment || !project || !feedSources) return <Loading />
     // Only permit adding feed sources to non-feed source deployments.
     const deployableFeeds = !deployment.feedSourceId && feedSources
@@ -239,7 +352,155 @@ export default class DeploymentViewer extends Component<Props, State> {
         fs.latestValidation
       )
       : []
-    const na = (<span style={{ color: 'lightGray' }}>N/A</span>)
+    const earliestDate = formatTimestamp(`${Math.min(...versions.map(v => +v.validationResult.startDate))}`, false)
+    const latestDate = formatTimestamp(`${Math.max(...versions.map(v => +v.validationResult.endDate))}`, false)
+
+    return (
+      <Row>
+        <Col xs={6}>
+          <h4>
+            <Glyphicon glyph='list' /> {this.messages('versions')}{' '}
+            <Badge>{versions.length}</Badge>
+            <br />
+            <small>
+              <Glyphicon glyph='calendar' />{' '}
+              {earliestDate} {this.messages('to')} {latestDate}
+            </small>
+          </h4>
+        </Col>
+        <Col xs={6}>
+          <FormGroup className='pull-right'>
+            <InputGroup>
+              <FormControl
+                type='text'
+                className='pull-right'
+                style={{width: '160px'}}
+                placeholder={this.messages('search')}
+                onChange={this._onChangeSearch} />
+              <DropdownButton
+                id='add-feedsource-button'
+                componentClass={InputGroup.Button}
+                disabled={!deployableFeeds.length}
+                title={deployableFeeds.length
+                  ? <span>
+                    <Glyphicon glyph='plus' />{' '}
+                    {this.messages('addFeedSource')}
+                  </span>
+                  : <span>{this.messages('allFeedsAdded')}</span>
+                }
+                onSelect={this._onAddFeedSource}>
+                {deployableFeeds.map((fs, i) => (
+                  <MenuItem MenuItem key={i} eventKey={fs.id}>{fs.name}</MenuItem>
+                ))}
+              </DropdownButton>
+            </InputGroup>
+          </FormGroup>
+        </Col>
+      </Row>
+    )
+  }
+
+  renderConfigurationsPanel () {
+    const { deployment, updateDeployment } = this.props
+    const options = deployment.r5 ? this.state.r5 : this.state.otp
+
+    return (
+      <Panel header={<h3><Icon type='cog' /> OTP Configuration</h3>}>
+        <ListGroup fill>
+          <ListGroupItem>
+            <Checkbox
+              checked={deployment.r5}
+              onChange={this._onChangeR5}>Use R5</Checkbox>
+            <Checkbox
+              checked={deployment.buildGraphOnly}
+              onChange={this._onChangeBuildGraphOnly}>Build graph only</Checkbox>
+            {deployment.r5 ? 'R5' : 'OTP'} version
+            <Select
+              value={deployment.r5 ? deployment.r5Version : deployment.otpVersion}
+              onChange={this._onUpdateVersion}
+              options={options ? options.map(v => ({value: v, label: v})) : []} />
+          </ListGroupItem>
+          <ListGroupItem>
+            Deploying to the{' '}
+            <small><em>{deployment.routerId || 'default'}</em></small>{' '}
+            OpenTripPlanner router.
+          </ListGroupItem>
+          <ListGroupItem>
+            OpenStreetMap Settings
+            <Checkbox
+              checked={!deployment.skipOsmExtract}
+              onChange={this._onChangeSkipOsmExtract}>
+              Build graph with OSM extract
+            </Checkbox>
+            {/* Hide URL/auto-extract if skipping OSM extract. */}
+            {deployment.skipOsmExtract
+              ? null
+              : deployment.osmExtractUrl
+                ? <div>
+                  <ControlLabel className='unselectable buffer-right'>
+                    URL:
+                  </ControlLabel>
+                  <span
+                    className='overflow'
+                    style={{
+                      marginBottom: '5px',
+                      width: '240px',
+                      verticalAlign: 'middle'
+                    }}
+                    title={deployment.osmExtractUrl}>
+                    {deployment.osmExtractUrl}
+                  </span>
+                  <Button
+                    bsSize='xsmall'
+                    style={{marginLeft: '5px'}}
+                    onClick={this._setOsmUrl}>Change</Button>
+                  <Button
+                    bsSize='xsmall'
+                    style={{marginLeft: '5px'}}
+                    onClick={this._clearOsmUrl}>Clear</Button>
+                </div>
+                : <div>
+                  Auto-extract OSM (N. America only)
+                  <Button
+                    bsSize='xsmall'
+                    style={{marginLeft: '5px'}}
+                    onClick={this._setOsmUrl}>Override</Button>
+                </div>
+            }
+          </ListGroupItem>
+          <ListGroupItem>
+            <CustomConfig
+              name='customBuildConfig'
+              label='Build'
+              updateDeployment={updateDeployment}
+              deployment={deployment} />
+          </ListGroupItem>
+          <ListGroupItem>
+            <CustomConfig
+              name='customRouterConfig'
+              label='Router'
+              updateDeployment={updateDeployment}
+              deployment={deployment} />
+          </ListGroupItem>
+        </ListGroup>
+      </Panel>
+    )
+  }
+
+  render () {
+    const {
+      deleteFeedVersion,
+      deployJobs,
+      deployment,
+      deployToTarget,
+      feedSources,
+      project,
+      updateVersionForFeedSource,
+      user
+    } = this.props
+    const {target} = this.state
+    const {feedVersions} = deployment
+    if (!deployment || !project || !feedSources) return <Loading />
     const versions = feedVersions
       ? feedVersions
         .filter(
@@ -249,25 +510,11 @@ export default class DeploymentViewer extends Component<Props, State> {
               .indexOf((this.state.searchText || '').toLowerCase()) !== -1
         )
         .sort(versionsSorter)
-
       : []
-    const isMissingBounds = !deployment.projectBounds
-    const {east, north, south, west} = deployment.projectBounds ||
-      {east: 10, north: 10, west: -10, south: -10}
-    const boundsTooLarge = east - west > BOUNDS_LIMIT || north - south > BOUNDS_LIMIT
-    const bounds = this._getBounds()
     const serverDeployedTo = getServerDeployedTo(deployment, project)
-    const isWatchingDeployment = user.subscriptions && user.subscriptions.hasFeedSubscription(
-      project.id,
-      deployment.id,
-      'deployment-updated'
-    )
-    const earliestDate = formatTimestamp(`${Math.min(...versions.map(v => +v.validationResult.startDate))}`, false)
-    const latestDate = formatTimestamp(`${Math.max(...versions.map(v => +v.validationResult.endDate))}`, false)
     const oldDeployment = (target && project.deployments)
       ? project.deployments.find(d => d.deployedTo === target && deployment.routerId === d.routerId)
       : null
-    const options = deployment.r5 ? this.state.r5 : this.state.otp
     const appName = getConfigProperty('application.title')
     const title = `${appName ? appName + ' - ' : ''}${deployment.name}`
     return (
@@ -284,142 +531,13 @@ export default class DeploymentViewer extends Component<Props, State> {
         }
         <Row>
           <Col sm={9}>
-            <Panel
-              header={
-                <div>
-                  <h4>
-                    <ButtonGroup className='pull-right'>
-                      <WatchButton
-                        isWatching={isWatchingDeployment}
-                        user={user}
-                        target={deployment.id}
-                        subscriptionType='deployment-updated' />
-                      <Button
-                        bsStyle='default'
-                        onClick={this._onClickDownload}>
-                        <span><Glyphicon glyph='download' /> {this.messages('download')}</span>
-                      </Button>
-                      <DropdownButton
-                        bsStyle='primary'
-                        id='deploy-server-dropdown'
-                        pullRight
-                        disabled={!project.otpServers || !project.otpServers.length}
-                        title={project.otpServers && project.otpServers.length
-                          ? <span>
-                            <Glyphicon glyph='globe' />{' '}
-                            {this.messages('deploy')}
-                          </span>
-                          : <span>{this.messages('noServers')}</span>
-                        }
-                        onSelect={this._onSelectTarget}>
-                        {project.otpServers
-                          ? project.otpServers.map((server, i) => (
-                            <MenuItem
-                              data-test-id={`deploy-server-${i}-button`}
-                              // Disable server if the server is missing a name,
-                              // has neither an internal URL or s3 bucket name,
-                              // or has a load balancer target group set, but is
-                              // set for a test feed source (with a non-default router).
-                              disabled={
-                                deployJobs.length > 0 ||
-                                !server.name ||
-                                (
-                                  (!server.internalUrl || server.internalUrl.length === 0) &&
-                                  !server.s3Bucket
-                                ) ||
-                                (server.ec2Info && server.ec2Info.targetGroupArn && deployment.feedSourceId)
-                              }
-                              eventKey={server.id}
-                              key={server.id}
-                            >
-                              {server.name || '[Unnamed]'}
-                            </MenuItem>
-                          ))
-                          : null
-                        }
-                        {project.otpServers && <MenuItem divider />}
-                        <LinkContainer
-                          to='/admin/servers'
-                          key={project.id}>
-                          <MenuItem>
-                            <Icon type='cog' /> Manage servers
-                          </MenuItem>
-                        </LinkContainer>
-                      </DropdownButton>
-                    </ButtonGroup>
-                    <EditableTextField
-                      inline
-                      style={{marginLeft: '5px'}}
-                      value={deployment.name}
-                      onChange={this._onChangeName} />
-                  </h4>
-                  <small title={deployment.lastDeployed && formatTimestamp(deployment.lastDeployed)}>
-                    <Icon type='clock-o' />
-                    {' '}
-                    Last deployed {deployment.lastDeployed ? fromNow(deployment.lastDeployed) : na}
-                  </small>
-                </div>
-              }>
+            <Panel header={this.renderHeader()}>
               <ListGroup fill>
                 <ListGroupItem style={{padding: '0px'}}>
-                  <Map
-                    ref='map'
-                    bounds={bounds}
-                    scrollWheelZoom={false}
-                    style={{width: '100%', height: '300px'}}>
-                    <TileLayer {...defaultTileLayerProps()} />
-                    {!isMissingBounds &&
-                      <Rectangle
-                        bounds={bounds}
-                        // If bounds are too large, draw rectangle in red
-                        // (otherwise use the default path color).
-                        color={boundsTooLarge ? 'red' : '#3388ff'}
-                        fillOpacity={0} />
-                    }
-                  </Map>
+                  {this.renderMap()}
                 </ListGroupItem>
                 <ListGroupItem>
-                  <Row>
-                    <Col xs={6}>
-                      <h4>
-                        <Glyphicon glyph='list' /> {this.messages('versions')}{' '}
-                        <Badge>{versions.length}</Badge>
-                        <br />
-                        <small>
-                          <Glyphicon glyph='calendar' />{' '}
-                          {earliestDate} {this.messages('to')} {latestDate}
-                        </small>
-                      </h4>
-                    </Col>
-                    <Col xs={6}>
-                      <FormGroup className='pull-right'>
-                        <InputGroup>
-                          <FormControl
-                            type='text'
-                            className='pull-right'
-                            style={{width: '160px'}}
-                            placeholder={this.messages('search')}
-                            onChange={this._onChangeSearch} />
-                          <DropdownButton
-                            id='add-feedsource-button'
-                            componentClass={InputGroup.Button}
-                            disabled={!deployableFeeds.length}
-                            title={deployableFeeds.length
-                              ? <span>
-                                <Glyphicon glyph='plus' />{' '}
-                                {this.messages('addFeedSource')}
-                              </span>
-                              : <span>{this.messages('allFeedsAdded')}</span>
-                            }
-                            onSelect={this._onAddFeedSource}>
-                            {deployableFeeds.map((fs, i) => (
-                              <MenuItem MenuItem key={i} eventKey={fs.id}>{fs.name}</MenuItem>
-                            ))}
-                          </DropdownButton>
-                        </InputGroup>
-                      </FormGroup>
-                    </Col>
-                  </Row>
+                  {this.renderDeployentVersionsTableHeader(versions)}
                 </ListGroupItem>
                 {versions.length === 0
                   ? <p className='lead text-center margin-top-15'>
@@ -447,85 +565,7 @@ export default class DeploymentViewer extends Component<Props, State> {
               server={serverDeployedTo}
               terminateEC2InstanceForDeployment={this.props.terminateEC2InstanceForDeployment} />
             {/* Configurations panel */}
-            <Panel header={<h3><Icon type='cog' /> OTP Configuration</h3>}>
-              <ListGroup fill>
-                <ListGroupItem>
-                  <Checkbox
-                    checked={deployment.r5}
-                    onChange={this._onChangeR5}>Use R5</Checkbox>
-                  <Checkbox
-                    checked={deployment.buildGraphOnly}
-                    onChange={this._onChangeBuildGraphOnly}>Build graph only</Checkbox>
-                  {deployment.r5 ? 'R5' : 'OTP'} version
-                  <Select
-                    value={deployment.r5 ? deployment.r5Version : deployment.otpVersion}
-                    onChange={this._onUpdateVersion}
-                    options={options ? options.map(v => ({value: v, label: v})) : []} />
-                </ListGroupItem>
-                <ListGroupItem>
-                  Deploying to the{' '}
-                  <small><em>{deployment.routerId || 'default'}</em></small>{' '}
-                  OpenTripPlanner router.
-                </ListGroupItem>
-                <ListGroupItem>
-                  OpenStreetMap Settings
-                  <Checkbox
-                    checked={!deployment.skipOsmExtract}
-                    onChange={this._onChangeSkipOsmExtract}>
-                    Build graph with OSM extract
-                  </Checkbox>
-                  {/* Hide URL/auto-extract if skipping OSM extract. */}
-                  {deployment.skipOsmExtract
-                    ? null
-                    : deployment.osmExtractUrl
-                      ? <div>
-                        <ControlLabel className='unselectable buffer-right'>
-                          URL:
-                        </ControlLabel>
-                        <span
-                          className='overflow'
-                          style={{
-                            marginBottom: '5px',
-                            width: '240px',
-                            verticalAlign: 'middle'
-                          }}
-                          title={deployment.osmExtractUrl}>
-                          {deployment.osmExtractUrl}
-                        </span>
-                        <Button
-                          bsSize='xsmall'
-                          style={{marginLeft: '5px'}}
-                          onClick={this._setOsmUrl}>Change</Button>
-                        <Button
-                          bsSize='xsmall'
-                          style={{marginLeft: '5px'}}
-                          onClick={this._clearOsmUrl}>Clear</Button>
-                      </div>
-                      : <div>
-                        Auto-extract OSM (N. America only)
-                        <Button
-                          bsSize='xsmall'
-                          style={{marginLeft: '5px'}}
-                          onClick={this._setOsmUrl}>Override</Button>
-                      </div>
-                  }
-                </ListGroupItem>
-                <ListGroupItem>
-                  <CustomConfig
-                    name='customBuildConfig'
-                    label='Build'
-                    updateDeployment={updateDeployment}
-                    deployment={deployment} />
-                </ListGroupItem>
-                <ListGroupItem>
-                  <CustomConfig
-                    name='customRouterConfig'
-                    label='Router'
-                    updateDeployment={updateDeployment}
-                    deployment={deployment} />
-                </ListGroupItem>
-              </ListGroup>
-            </Panel>
+            {this.renderConfigurationsPanel()}
           </Col>
         </Row>
       </div>

--- a/lib/manager/util/deployment.js
+++ b/lib/manager/util/deployment.js
@@ -235,7 +235,7 @@ export function getServerDeployedTo (deployment: Deployment, project: Project) {
 }
 
 export function getServerForId (serverId: ?string, project: Project) {
-  if (!serverId) return null
+  if (!serverId || !project.otpServers) return null
   return project.otpServers.find(server => server.id === serverId)
 }
 

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -665,7 +665,7 @@ export type Project = {
   lastUpdated: number | string,
   name: string,
   organizationId: ?string,
-  otpServers: Array<OtpServer>,
+  otpServers?: Array<OtpServer>,
   pinnedDeploymentId: ?string,
   routerConfig: RouterConfig,
   useCustomOsmBounds: boolean,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This is a companion PR to https://github.com/ibi-group/datatools-server/pull/319. It does the following:

- Some code cleanup that removes unused flow typing from AdminPage
- Refactor of DeploymentViewer so that the render function is broken up into a few smaller, more manageable sub-renderering methods.
- Changing of the flow typing of Project.otpServers to account for the possibility of it not being defined when being returned as part of a list of projects.