### PR TITLE
Update 'publicly_available' and 'status' default values. 

### DIFF
--- a/lib/editor/util/gtfs.js
+++ b/lib/editor/util/gtfs.js
@@ -135,8 +135,8 @@ export const generateProps = (component: string, editorState: any): any => {
         route_long_name: null,
         route_color: routeColor,
         route_text_color: idealTextColor(routeColor),
-        publicly_visible: 0, // not public
-        status: 0, // IN_PROGRESS
+        publicly_visible: 1, // public
+        status: 2, // APPROVED
         route_type: feedInfo && feedInfo.default_route_type !== null
           ? feedInfo.default_route_type
           : 3


### PR DESCRIPTION
### Description

Update the default values of status and publicly available feeds to be "Approved" and "Yes",
respectively. This was just a simple change to the generateProps function in editor/util/gtfs.js to assign a value of 1 to publicly_visible, and 2 to status. This should better conform to user expectations for a new route. 

resolves #589

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### New defaults: 
![image](https://user-images.githubusercontent.com/63798641/86629201-0d2a5100-bf99-11ea-9c5b-9e34b6a7e941.png)

