### PR TITLE
Fix e2e tests again

### DIFF
--- a/__tests__/end-to-end.js
+++ b/__tests__/end-to-end.js
@@ -885,7 +885,7 @@ describe('end-to-end', () => {
       await click('[data-test-id="confirm-create-user-button"]')
 
       // wait for user to be saved
-      await wait(2000, 'for user to be created')
+      await wait(30000, 'for user to be created')
 
       // filter users
       await filterUsers(testUserSlug)

--- a/scripts/check-if-e2e-should-run-on-travis.sh
+++ b/scripts/check-if-e2e-should-run-on-travis.sh
@@ -12,6 +12,3 @@ else
     echo 'Will run E2E tests because this is a commit to master or dev'
   fi
 fi
-
-export SHOULD_RUN_E2E=true;
-echo 'Always run E2E tests because this is a PR that tries to fix e2e tests'

--- a/scripts/check-if-e2e-should-run-on-travis.sh
+++ b/scripts/check-if-e2e-should-run-on-travis.sh
@@ -12,3 +12,6 @@ else
     echo 'Will run E2E tests because this is a commit to master or dev'
   fi
 fi
+
+export SHOULD_RUN_E2E=true;
+echo 'Always run E2E tests because this is a PR that tries to fix e2e tests'


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] e2e tests are all passing See https://travis-ci.org/github/ibi-group/datatools-ui/builds/729458864

### Description

This PR extends the amount of time (from 2s to 30s) to wait after creating a new Auth0 user before checking if it now is returned from the Auth0 API. Prior runs of the e2e tests were failing because the original wait time was not long enough.
