### PR TITLE
Lazy-load server data with ec2 instance info

### DIFF
--- a/lib/admin/actions/admin.js
+++ b/lib/admin/actions/admin.js
@@ -173,7 +173,7 @@ export function updateServer (server: OtpServer) {
     dispatch(updatingServer(server))
     dispatch(secureFetch(url, method, server))
       .then(res => res.json())
-      .then(server => dispatch(fetchServers()))
+      .then(server => dispatch(receiveServer(server)))
   }
 }
 

--- a/lib/admin/actions/admin.js
+++ b/lib/admin/actions/admin.js
@@ -32,6 +32,10 @@ const receiveAllRequests = createAction(
 )
 const fetchingApplicationStatus = createVoidPayloadAction('FETCHING_ALL_JOBS')
 const updatingServer = createAction('UPDATING_SERVER', (payload: OtpServer) => payload)
+const receiveServer = createAction(
+  'RECEIVE_SERVER',
+  (payload: OtpServer) => payload
+)
 const receiveServers = createAction(
   'RECEIVE_SERVERS',
   (payload: Array<OtpServer>) => payload
@@ -144,6 +148,17 @@ export function fetchServers () {
     return dispatch(secureFetch(`${SERVER_URL}`))
       .then(res => res.json())
       .then(servers => dispatch(receiveServers(servers)))
+  }
+}
+
+/**
+ * Fetch an OTP/R5 server target.
+ */
+export function fetchServer (serverId: string) {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    return dispatch(secureFetch(`${SERVER_URL}/${serverId}`))
+      .then(res => res.json())
+      .then(server => dispatch(receiveServer(server)))
   }
 }
 

--- a/lib/admin/components/ServerSettings.js
+++ b/lib/admin/components/ServerSettings.js
@@ -36,6 +36,7 @@ import type { AppState, AdminServersState } from '../../types/reducers'
 type ContainerProps = {editDisabled: boolean}
 type Props = ContainerProps & {
   deleteServer: typeof adminActions.deleteServer,
+  fetchServer: typeof adminActions.fetchServer,
   fetchServers: typeof adminActions.fetchServers,
   otpServers: AdminServersState,
   projects: Array<Project>,
@@ -149,6 +150,10 @@ class ServerSettings extends Component<Props, State> {
     }
   }
 
+  _onExpandServer = (index: number) => {
+    this.props.fetchServer(this.state.otpServers[index].id)
+  }
+
   _onSaveServer = (index: number) => this.props.updateServer(this.state.otpServers[index])
 
   _onChange = (evt, stateUpdate = {}, index) => {
@@ -224,6 +229,7 @@ class ServerSettings extends Component<Props, State> {
                   index={index}
                   key={`server-${index}`}
                   onChange={this._getOnChange}
+                  onEnter={this._onExpandServer}
                   onRemove={this._onDeleteServer}
                   onSave={this._onSaveServer}
                   saveDisabled={!this.state.hasEdits}
@@ -377,6 +383,7 @@ const mapStateToProps = (state: AppState, ownProps: ContainerProps) => {
 
 const {
   deleteServer,
+  fetchServer,
   fetchServers,
   terminateEC2Instances,
   updateServer
@@ -386,6 +393,7 @@ const { terminateEC2InstanceForDeployment } = deploymentActions
 
 const mapDispatchToProps = {
   deleteServer,
+  fetchServer,
   fetchServers,
   terminateEC2InstanceForDeployment,
   terminateEC2Instances,

--- a/lib/admin/reducers/servers.js
+++ b/lib/admin/reducers/servers.js
@@ -19,6 +19,18 @@ const servers = (state: AdminServersState = defaultState, action: Action): Admin
         isFetching: { $set: false },
         data: { $set: action.payload }
       })
+    case 'RECEIVE_SERVER':
+      const serverData = action.payload
+      if (state.data) {
+        const serverIdx = state.data.findIndex(
+          server => server.id === serverData.id
+        )
+        return update(state, {
+          isFetching: { $set: false },
+          data: { [serverIdx]: { $set: action.payload } }
+        })
+      }
+      return state
     case 'CREATED_SERVER':
       if (state.data) {
         return update(state, { data: { $push: [action.payload] } })

--- a/lib/manager/components/CollapsiblePanel.js
+++ b/lib/manager/components/CollapsiblePanel.js
@@ -20,6 +20,7 @@ type Props = {
   fields: Array<FormProps>,
   index: number,
   onChange: (SyntheticInputEvent<HTMLInputElement>, number) => void,
+  onEnter?: number => void,
   onRemove?: number => void,
   onSave?: number => any,
   saveDisabled: boolean,
@@ -35,6 +36,8 @@ export default class CollapsiblePanel extends Component<Props> {
 
   _onChange = (evt: SyntheticInputEvent<HTMLInputElement>) =>
     this.props.onChange(evt, this.props.index)
+
+  _onEnter = () => this.props.onEnter && this.props.onEnter(this.props.index)
 
   _onRemove = () => this.props.onRemove && this.props.onRemove(this.props.index)
 
@@ -80,6 +83,7 @@ export default class CollapsiblePanel extends Component<Props> {
         data-test-id={testId}
         defaultExpanded={defaultExpanded}
         header={<h5 style={{width: '100%', cursor: 'pointer'}}>{title}</h5>}
+        onEnter={this._onEnter}
       >
         <Form>
           {this.renderButtonToolbar()}

--- a/lib/manager/reducers/status.js
+++ b/lib/manager/reducers/status.js
@@ -202,6 +202,7 @@ const config = (state: StatusState = defaultState, action: Action): StatusState 
     case 'RECEIVED_RTD_SIGNS':
     case 'RECEIVED_RTD_ALERTS':
     case 'RECEIVE_ORGANIZATIONS':
+    case 'RECEIVE_SERVER':
     case 'RECEIVE_SERVERS':
       return update(state, {message: {$set: null}})
     case 'SET_APP_INFO':


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR changes the way data is loaded for the ServerSettings admin component. Whenever a panel showing the details about a server is expanded, the UI will now make a call to a new endpoint in datatools-server to load the full information about the server which could include data about ec2 instances. This is done to avoid making unnecessary calls to AWS until that data is actually needed.

This PR requires using the code in https://github.com/ibi-group/datatools-server/pull/343.