### PR TITLE
Handle uncaught error and improve add stop by name

### DIFF
--- a/lib/common/components/Loading.js
+++ b/lib/common/components/Loading.js
@@ -4,10 +4,12 @@ import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
 import { Row, Col } from 'react-bootstrap'
 
+import type {Style} from '../../types'
+
 type Props = {
   inline?: boolean,
   small?: boolean,
-  style?: {[string]: string | number}
+  style?: Style
 }
 
 export default class Loading extends Component<Props> {

--- a/lib/editor/components/MinuteSecondInput.js
+++ b/lib/editor/components/MinuteSecondInput.js
@@ -8,11 +8,13 @@ import {
   convertMMSSStringToSeconds
 } from '../../common/util/date-time'
 
+import type {Style} from '../../types'
+
 type Props = {
   disabled?: boolean,
   onChange: number => void,
   seconds: number,
-  style?: {[string]: string | number}
+  style?: Style
 }
 
 type State = {

--- a/lib/editor/components/VirtualizedEntitySelect.js
+++ b/lib/editor/components/VirtualizedEntitySelect.js
@@ -5,7 +5,7 @@ import VirtualizedSelect from 'react-virtualized-select'
 
 import {getEntityName} from '../util/gtfs'
 
-import type {Entity} from '../../types'
+import type {Entity, Style} from '../../types'
 
 export type EntityOption = {
   entity: Entity,
@@ -20,7 +20,7 @@ type Props = {
   entityKey: string,
   onChange: any => void,
   optionRenderer?: Function,
-  style?: {[string]: number | string},
+  style?: Style,
   value?: any
 }
 

--- a/lib/editor/components/map/AddableStop.js
+++ b/lib/editor/components/map/AddableStop.js
@@ -1,12 +1,11 @@
 // @flow
 
-import Icon from '@conveyal/woonerf/components/icon'
 import { divIcon } from 'leaflet'
 import React, {Component} from 'react'
-import {Button, Dropdown, MenuItem} from 'react-bootstrap'
 import {Marker, Popup} from 'react-leaflet'
 
 import * as stopStrategiesActions from '../../actions/map/stopStrategies'
+import AddPatternStopDropdown from '../pattern/AddPatternStopDropdown'
 
 import type {GtfsStop, Pattern} from '../../../types'
 
@@ -28,6 +27,7 @@ export default class AddableStop extends Component<Props> {
   render () {
     const {
       activePattern,
+      addStopToPattern,
       stop
     } = this.props
     const color = 'blue'
@@ -40,7 +40,6 @@ export default class AddableStop extends Component<Props> {
       className: '',
       iconSize: [24, 24]
     })
-    // TODO: Refactor to share code with PatternStopButtons
     return (
       <Marker
         position={[stop.stop_lat, stop.stop_lon]}
@@ -48,36 +47,12 @@ export default class AddableStop extends Component<Props> {
         <Popup>
           <div style={{minWidth: '180px'}}>
             <h5>{stopName}</h5>
-            <Dropdown
-              id={`add-stop-dropdown`}
-              pullRight
-              onSelect={this._onSelectStop}>
-              <Button
-                bsStyle='success'
-                onClick={this._onClickAddStopToEnd}>
-                <Icon type='plus' /> Add stop
-              </Button>
-              <Dropdown.Toggle
-                bsStyle='success' />
-              <Dropdown.Menu style={{maxHeight: '200px', overflowY: 'scroll'}}>
-                <MenuItem
-                  value={activePattern.patternStops.length}
-                  eventKey={activePattern.patternStops.length}>
-                  Add to end (default)
-                </MenuItem>
-                {activePattern.patternStops && activePattern.patternStops.map((stop, i) => {
-                  const index = activePattern.patternStops.length - i
-                  return (
-                    <MenuItem
-                      value={index - 1}
-                      eventKey={index - 1}
-                      key={i}>
-                      {index === 1 ? 'Add to beginning' : `Insert as stop #${index}`}
-                    </MenuItem>
-                  )
-                })}
-              </Dropdown.Menu>
-            </Dropdown>
+            <AddPatternStopDropdown
+              activePattern={activePattern}
+              addStopToPattern={addStopToPattern}
+              label='Add stop'
+              stop={stop}
+            />
           </div>
         </Popup>
       </Marker>

--- a/lib/editor/components/map/pattern-debug-lines.js
+++ b/lib/editor/components/map/pattern-debug-lines.js
@@ -5,8 +5,8 @@ import {Polyline} from 'react-leaflet'
 import lineDistance from 'turf-line-distance'
 import lineString from 'turf-linestring'
 
-import {POINT_TYPE} from '../../constants'
-import {isValidPoint} from '../../util/map'
+import {PATTERN_TO_STOP_DISTANCE_THRESHOLD_METERS} from '../../constants'
+import {getStopControlPoints} from '../../util/map'
 
 import type {ControlPoint, GtfsStop, Pattern} from '../../../types'
 import type {EditSettingsState} from '../../../types/reducers'
@@ -19,8 +19,6 @@ type Props = {
   patternStop: {id: string, index: number},
   stops: Array<GtfsStop>
 }
-
-const DISTANCE_THRESHOLD = 50
 
 /**
  * This react-leaflet component draws connecting lines between a pattern
@@ -44,33 +42,33 @@ export default class PatternDebugLines extends PureComponent<Props> {
           // i.e., whether the line should be rendered.
           .map((cp, index) => ({...cp, cpIndex: index}))
           // Filter out the user-added anchors
-          .filter(cp => cp.pointType === POINT_TYPE.STOP)
+          .filter(getStopControlPoints)
           // The remaining number should match the number of stops
           .map((cp, index) => {
             const {cpIndex, point, stopId} = cp
-            if (!isValidPoint(point)) {
-              return null
-            }
+            // If hiding inactive segments (and this control point is not along
+            // a visible segment), do not show debug line.
             if (editSettings.hideInactiveSegments && (cpIndex > patternSegment + 1 || cpIndex < patternSegment - 1)) {
               return null
             }
             const patternStopIsActive = patternStop.index === index
             // Do not render if some other pattern stop is active
-            // $FlowFixMe
-            if ((patternStop.index || patternStop.index === 0) && !patternStopIsActive) {
+            if (typeof patternStop.index === 'number' && !patternStopIsActive) {
               return null
             }
             const {coordinates: cpCoord} = point.geometry
+            // Find stop entity for control point.
             const stop = stops.find(s => s.stop_id === stopId)
             if (!stop) {
-              // console.warn(`Could not find stop for pattern stop index=${index} patternStop#stopId=${stopId}`)
+              // If no stop entity found, do not attempt to draw a line to the
+              // missing stop.
               return null
             }
             const coordinates = [[cpCoord[1], cpCoord[0]], [stop.stop_lat, stop.stop_lon]]
             const distance: number = lineDistance(lineString(coordinates), 'meters')
-            const distanceGreaterThanThreshold = distance > DISTANCE_THRESHOLD
+            const distanceGreaterThanThreshold = distance > PATTERN_TO_STOP_DISTANCE_THRESHOLD_METERS
             if (distanceGreaterThanThreshold) {
-              console.warn(`Distance from pattern stop index=${index} to projected point is greater than ${DISTANCE_THRESHOLD} (${distance}).`)
+              console.warn(`Distance from pattern stop index=${index} to projected point is greater than ${PATTERN_TO_STOP_DISTANCE_THRESHOLD_METERS} (${distance}).`)
             }
             return (
               <Polyline

--- a/lib/editor/components/map/pattern-debug-lines.js
+++ b/lib/editor/components/map/pattern-debug-lines.js
@@ -6,7 +6,7 @@ import lineDistance from 'turf-line-distance'
 import lineString from 'turf-linestring'
 
 import {PATTERN_TO_STOP_DISTANCE_THRESHOLD_METERS} from '../../constants'
-import {getStopControlPoints} from '../../util/map'
+import {isValidStopControlPoint} from '../../util/map'
 
 import type {ControlPoint, GtfsStop, Pattern} from '../../../types'
 import type {EditSettingsState} from '../../../types/reducers'
@@ -42,7 +42,7 @@ export default class PatternDebugLines extends PureComponent<Props> {
           // i.e., whether the line should be rendered.
           .map((cp, index) => ({...cp, cpIndex: index}))
           // Filter out the user-added anchors
-          .filter(getStopControlPoints)
+          .filter(isValidStopControlPoint)
           // The remaining number should match the number of stops
           .map((cp, index) => {
             const {cpIndex, point, stopId} = cp

--- a/lib/editor/components/pattern/AddPatternStopDropdown.js
+++ b/lib/editor/components/pattern/AddPatternStopDropdown.js
@@ -81,31 +81,44 @@ export default class AddPatternStopDropdown extends Component<Props> {
             Add to end (default)
           </MenuItem>
           {activePattern.patternStops && activePattern.patternStops.map((s, i) => {
-            // addIndex is in "reverse" order
-            const addIndex = activePattern.patternStops.length - i
+            // addIndex is in "reverse" order. For example:
+            // - 5 pattern stops
+            // - rendering MenuItem 'Insert at stop #4'
+            // - addIndex = 3 = 5 (stops) - 1 (i) - 1
+            // - nextIndex = 4
+            // - previousIndex = 2
+            const addIndex = activePattern.patternStops.length - i - 1
+            const nextIndex = addIndex + 1
+            const previousIndex = addIndex - 1
             let disableAdjacent = false
-            // If showing for current pattern stop, do not allow adding as an
-            // adjacent stop.
+            // If showing the dropdown for the currently selected pattern stop,
+            // do not allow adding as an adjacent stop (a pattern should not
+            // visit the same stop consecutively).
             if (typeof index === 'number') {
-              disableAdjacent = (index >= addIndex - 2 && index < addIndex)
+              disableAdjacent = index > previousIndex && index < nextIndex
             }
-            // Disable adding stop to current position or directly before/after
-            // current position
+            // Disable adding stop to current position or directly before
+            // current position. nextIndex is OK because inserting the stop at
+            // addIndex would move the current stop at addIndex into the
+            // nextIndex position, which would serve as a buffer (and avoid
+            // having the same stop in consecutive positions).
             const addAtIndexDisabled = disableAdjacent ||
-              this._matchesStopAtIndex(addIndex - 2) ||
-              this._matchesStopAtIndex(addIndex - 1)
-            // Skip MenuItem index is the same as the pattern stop index
-            if (index === addIndex - 1 || addIndex === 1) {
+              this._matchesStopAtIndex(previousIndex) ||
+              this._matchesStopAtIndex(addIndex)
+            // Skip MenuItem if index is the same as the currently selected
+            // pattern stop index or it's the zeroth addIndex (Add to
+            // beginning handles this case).
+            if (index === addIndex || addIndex === 0) {
               return null
             }
             return (
               <MenuItem
                 disabled={addAtIndexDisabled}
-                value={addIndex - 1}
+                value={addIndex}
                 title={addAtIndexDisabled ? DISABLED_MESSAGE : ''}
                 key={i}
-                eventKey={addIndex - 1}>
-                {`Insert as stop #${addIndex}`}
+                eventKey={addIndex}>
+                Insert as stop #{addIndex + 1}
               </MenuItem>
             )
           })}

--- a/lib/editor/components/pattern/AddPatternStopDropdown.js
+++ b/lib/editor/components/pattern/AddPatternStopDropdown.js
@@ -1,0 +1,123 @@
+// @flow
+
+import Icon from '@conveyal/woonerf/components/icon'
+import React, {Component} from 'react'
+import { Button, Dropdown, MenuItem } from 'react-bootstrap'
+
+import * as stopStrategiesActions from '../../actions/map/stopStrategies'
+
+import type {GtfsStop, Pattern, PatternStop, Style} from '../../../types'
+
+type Props = {
+  activePattern: Pattern,
+  addStopToPattern: typeof stopStrategiesActions.addStopToPattern,
+  index?: number, // current pattern stop index (if dropdown shown for current pattern stop)
+  label?: string,
+  patternStop?: PatternStop, // optional current pattern stop
+  size?: string,
+  stop: GtfsStop,
+  style?: Style
+}
+
+const DISABLED_MESSAGE = 'Cannot have the same stop appear consecutively in list'
+
+/**
+ * Dropdown button that adds a stop as a new pattern stop to the actively
+ * selected pattern.
+ */
+export default class AddPatternStopDropdown extends Component<Props> {
+  _addStop = (index?: number) => {
+    const {activePattern, addStopToPattern, stop} = this.props
+    addStopToPattern(activePattern, stop, index)
+  }
+
+  _matchesStopAtIndex = (index: number) => {
+    const {activePattern, stop} = this.props
+    const patternStopAtIndex = activePattern.patternStops[index]
+    return patternStopAtIndex && patternStopAtIndex.stopId === stop.stop_id
+  }
+
+  _onAddToEnd = () => this._addStop()
+
+  _onSelectStop = (key: number) => this._addStop(key)
+
+  render () {
+    const {activePattern, index, label, size, style} = this.props
+    const {patternStops} = activePattern
+    const lastIndex = patternStops.length - 1
+    // Check that first/last stop is not already set to this stop.
+    let addToEndDisabled = this._matchesStopAtIndex(lastIndex)
+    let addToBeginningDisabled = this._matchesStopAtIndex(0)
+    // Also, disable end/beginning if the current pattern stop being viewed
+    // occupies one of these positions.
+    if (typeof index === 'number') {
+      addToEndDisabled = addToEndDisabled || index >= lastIndex
+      addToBeginningDisabled = addToBeginningDisabled || index === 0
+    }
+    return (
+      <Dropdown
+        id={`add-stop-dropdown`}
+        pullRight
+        onSelect={this._onSelectStop}
+        style={style}
+      >
+        <Button
+          bsSize={size}
+          bsStyle='success'
+          disabled={addToEndDisabled}
+          title={addToEndDisabled ? DISABLED_MESSAGE : ''}
+          onClick={this._onAddToEnd}>
+          <Icon type='plus' /> {label}
+        </Button>
+        <Dropdown.Toggle
+          bsSize={size}
+          bsStyle='success' />
+        <Dropdown.Menu style={{maxHeight: '200px', overflowY: 'scroll'}}>
+          <MenuItem
+            disabled={addToEndDisabled}
+            title={addToEndDisabled ? DISABLED_MESSAGE : ''}
+            value={activePattern.patternStops.length}
+            eventKey={activePattern.patternStops.length}>
+            Add to end (default)
+          </MenuItem>
+          {activePattern.patternStops && activePattern.patternStops.map((s, i) => {
+            // addIndex is in "reverse" order
+            const addIndex = activePattern.patternStops.length - i
+            let disableAdjacent = false
+            // If showing for current pattern stop, do not allow adding as an
+            // adjacent stop.
+            if (typeof index === 'number') {
+              disableAdjacent = (index >= addIndex - 2 && index < addIndex)
+            }
+            // Disable adding stop to current position or directly before/after
+            // current position
+            const addAtIndexDisabled = disableAdjacent ||
+              this._matchesStopAtIndex(addIndex - 2) ||
+              this._matchesStopAtIndex(addIndex - 1)
+            // Skip MenuItem index is the same as the pattern stop index
+            if (index === addIndex - 1 || addIndex === 1) {
+              return null
+            }
+            return (
+              <MenuItem
+                disabled={addAtIndexDisabled}
+                value={addIndex - 1}
+                title={addAtIndexDisabled ? DISABLED_MESSAGE : ''}
+                key={i}
+                eventKey={addIndex - 1}>
+                {`Insert as stop #${addIndex}`}
+              </MenuItem>
+            )
+          })}
+          <MenuItem
+            disabled={addToBeginningDisabled}
+            title={addToBeginningDisabled ? DISABLED_MESSAGE : ''}
+            value={0}
+            eventKey={0}>
+            Add to beginning
+          </MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
+    )
+  }
+}

--- a/lib/editor/components/pattern/EditShapePanel.js
+++ b/lib/editor/components/pattern/EditShapePanel.js
@@ -19,8 +19,8 @@ import {polyline as getPolyline} from '../../../scenario-editor/utils/valhalla'
 import {
   controlPointsFromSegments,
   generateControlPointsFromPatternStops,
-  getStopControlPoints,
-  getPatternDistance
+  getPatternDistance,
+  isValidStopControlPoint
 } from '../../util/map'
 
 import type {ControlPoint, LatLng, Pattern, GtfsStop} from '../../../types'
@@ -150,7 +150,7 @@ export default class EditShapePanel extends Component<Props> {
   _getPatternStopsWithShapeIssues = () => {
     const {controlPoints, stops} = this.props
     return controlPoints
-      .filter(getStopControlPoints)
+      .filter(isValidStopControlPoint)
       .map((controlPoint, index) => {
         const {point, stopId} = controlPoint
         let exceedsThreshold = false

--- a/lib/editor/components/pattern/EditShapePanel.js
+++ b/lib/editor/components/pattern/EditShapePanel.js
@@ -2,13 +2,15 @@
 
 import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
-import {Button, ButtonGroup, ButtonToolbar, OverlayTrigger, Tooltip} from 'react-bootstrap'
+import {Alert, Button, ButtonGroup, ButtonToolbar, OverlayTrigger, Tooltip} from 'react-bootstrap'
 import ll from '@conveyal/lonlat'
 import numeral from 'numeral'
+import lineDistance from 'turf-line-distance'
+import lineString from 'turf-linestring'
 
 import * as activeActions from '../../actions/active'
 import * as mapActions from '../../actions/map'
-import {ARROW_MAGENTA} from '../../constants'
+import {ARROW_MAGENTA, PATTERN_TO_STOP_DISTANCE_THRESHOLD_METERS} from '../../constants'
 import * as tripPatternActions from '../../actions/tripPattern'
 import OptionButton from '../../../common/components/OptionButton'
 import EditSettings from './EditSettings'
@@ -17,6 +19,7 @@ import {polyline as getPolyline} from '../../../scenario-editor/utils/valhalla'
 import {
   controlPointsFromSegments,
   generateControlPointsFromPatternStops,
+  getStopControlPoints,
   getPatternDistance
 } from '../../util/map'
 
@@ -139,6 +142,42 @@ export default class EditShapePanel extends Component<Props> {
     })
   }
 
+  /**
+   * Checks the control points for stop control points that are located too far
+   * from the actual stop location. This is used to give instructions to the
+   * user on resolving the issue.
+   */
+  _getPatternStopsWithShapeIssues = () => {
+    const {controlPoints, stops} = this.props
+    return controlPoints
+      .filter(getStopControlPoints)
+      .map((controlPoint, index) => {
+        const {point, stopId} = controlPoint
+        let exceedsThreshold = false
+        const {coordinates: cpCoord} = point.geometry
+        // Find stop entity for control point.
+        const stop = stops.find(s => s.stop_id === stopId)
+        if (!stop) {
+          // If no stop entity found, do not attempt to draw a line to the
+          // missing stop.
+          return {controlPoint, index, stop: null, distance: 0, exceedsThreshold}
+        }
+        const coordinates = [[cpCoord[1], cpCoord[0]], [stop.stop_lat, stop.stop_lon]]
+        const distance: number = lineDistance(lineString(coordinates), 'meters')
+        exceedsThreshold = distance > PATTERN_TO_STOP_DISTANCE_THRESHOLD_METERS
+        return {
+          controlPoint,
+          distance,
+          exceedsThreshold,
+          index,
+          stop
+        }
+      })
+      // TODO: This can be removed if at some point we need to show stops where
+      // the distance threshold is not exceeded.
+      .filter(item => item.exceedsThreshold)
+  }
+
   _beginEditing = () => {
     const {togglePatternEditing} = this.props
     togglePatternEditing()
@@ -188,6 +227,7 @@ export default class EditShapePanel extends Component<Props> {
     const nextSegment = (!patternSegment && patternSegment !== 0)
       ? 0
       : patternSegment + 1
+    const patternStopsWithShapeIssues = this._getPatternStopsWithShapeIssues()
     return (
       <div>
         <h4 className='line'>
@@ -217,6 +257,54 @@ export default class EditShapePanel extends Component<Props> {
             </small>
           }
         </div>
+        {patternStopsWithShapeIssues.length > 0
+          ? <Alert bsStyle='warning' style={{fontSize: 'small'}}>
+            <h4><Icon type='exclamation-triangle' /> Pattern stop snapping issue</h4>
+            <ul className='list-unstyled' style={{marginBottom: '5px'}}>
+              {patternStopsWithShapeIssues
+                .map(item => {
+                  const {distance, index, stop} = item
+                  if (!stop) return null
+                  const roundedDist = Math.round(distance * 100) / 100
+                  return (
+                    <li key={index}>
+                      #{index + 1} {stop.stop_name}{' '}
+                      <span style={{color: 'red'}}>
+                        {roundedDist} m
+                      </span>
+                    </li>
+                  )
+                })
+              }
+            </ul>
+            <p>
+              The stop(s) listed above are located
+              too far (max = {PATTERN_TO_STOP_DISTANCE_THRESHOLD_METERS}{' '}
+              meters) from the pattern shape.
+            </p>
+            <p>
+              This can be resolved by:
+              <ol>
+                <li>
+                  moving the stop itself closer to the street's edge;
+                </li>
+                <li>
+                  changing where the stop is "snapped" to the shape: click{' '}
+                  <strong>Edit pattern geometry</strong>, uncheck{' '}
+                  <strong>Hide stop handles</strong>, and move the stop handle
+                  closer to the stop. Checking <strong>Hide inactive segments</strong>{' '}
+                  can help isolate the problematic stop handle; or
+                </li>
+                <li>
+                  regenerating the shape from existing stops: click{' '}
+                  <strong>From stops</strong>.
+                </li>
+              </ol>
+            </p>
+          </Alert>
+          : null
+        }
+
         {editSettings.editGeometry
           ? <div>
             <ButtonToolbar>

--- a/lib/editor/components/pattern/PatternStopButtons.js
+++ b/lib/editor/components/pattern/PatternStopButtons.js
@@ -2,13 +2,14 @@
 
 import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
-import { Button, Dropdown, OverlayTrigger, Tooltip, ButtonGroup, MenuItem } from 'react-bootstrap'
+import { Button, OverlayTrigger, Tooltip, ButtonGroup } from 'react-bootstrap'
 
 import * as activeActions from '../../actions/active'
 import * as stopStrategiesActions from '../../actions/map/stopStrategies'
 import * as tripPatternActions from '../../actions/tripPattern'
+import AddPatternStopDropdown from './AddPatternStopDropdown'
 
-import type {Feed, GtfsStop, Pattern, PatternStop} from '../../../types'
+import type {Feed, GtfsStop, Pattern, PatternStop, Style} from '../../../types'
 
 type Props = {
   activePattern: Pattern,
@@ -23,7 +24,7 @@ type Props = {
   setActiveStop: typeof tripPatternActions.setActiveStop,
   size: string,
   stop: GtfsStop,
-  style?: {[string]: number | string},
+  style?: Style,
   updatePatternStops: typeof tripPatternActions.updatePatternStops
 }
 
@@ -44,7 +45,13 @@ export default class PatternStopButtons extends Component<Props> {
 
   _onClickRemove = () => {
     const {activePattern, index, removeStopFromPattern, stop} = this.props
-    removeStopFromPattern(activePattern, stop, index)
+    if (
+      window.confirm(
+        `Are you sure you would like to remove ${stop.stop_name} (${stop.stop_id}) as pattern stop #${index + 1}?`
+      )
+    ) {
+      removeStopFromPattern(activePattern, stop, index)
+    }
   }
 
   _onClickSave = () => this.props.saveActiveGtfsEntity('trippattern')
@@ -55,11 +62,16 @@ export default class PatternStopButtons extends Component<Props> {
   }
 
   render () {
-    const {stop, index, activePattern, patternEdited, style, size} = this.props
-    const {patternStops} = activePattern
-    const lastIndex = patternStops.length - 1
-    const addToEndDisabled = index >= lastIndex || patternStops[lastIndex].stopId === stop.id
-    const addToBeginningDisabled = index === 0 || patternStops[0].stopId === stop.id
+    const {
+      activePattern,
+      addStopToPattern,
+      index,
+      patternEdited,
+      patternStop,
+      size,
+      stop,
+      style
+    } = this.props
     return (
       <ButtonGroup
         className='pull-right'
@@ -74,14 +86,20 @@ export default class PatternStopButtons extends Component<Props> {
           onClick={this._onClickSave}>
           <Icon type='floppy-o' />
         </Button>
-        <OverlayTrigger overlay={<Tooltip id='edit-stop-tooltip'>Edit stop</Tooltip>}>
+        <OverlayTrigger
+          overlay={<Tooltip id='edit-stop-tooltip'>Edit stop</Tooltip>}
+        >
           <Button
             bsSize={size}
             onClick={this._onClickEdit}>
             <Icon type='pencil' />
           </Button>
         </OverlayTrigger>
-        <OverlayTrigger overlay={<Tooltip id='remove-stop-tooltip'>Remove from pattern</Tooltip>}>
+        <OverlayTrigger
+          overlay={
+            <Tooltip id='remove-stop-tooltip'>Remove stop from pattern</Tooltip>
+          }
+        >
           <Button
             bsSize={size}
             bsStyle='danger'
@@ -89,58 +107,14 @@ export default class PatternStopButtons extends Component<Props> {
             <Icon type='trash' />
           </Button>
         </OverlayTrigger>
-        <Dropdown
-          id={`add-stop-dropdown`}
-          pullRight
-          onSelect={this._onSelectStop}>
-          <Button
-            bsSize={size}
-            bsStyle='success'
-            disabled={addToEndDisabled}
-            onClick={this._onAddToEnd}>
-            <Icon type='plus' />
-          </Button>
-          <Dropdown.Toggle
-            bsSize={size}
-            bsStyle='success' />
-          <Dropdown.Menu style={{maxHeight: '200px', overflowY: 'scroll'}}>
-            <MenuItem
-              disabled={addToEndDisabled}
-              value={activePattern.patternStops.length}
-              eventKey={activePattern.patternStops.length}>
-              Add to end (default)
-            </MenuItem>
-            {activePattern.patternStops && activePattern.patternStops.map((s, i) => {
-              // addIndex is in "reverse" order
-              const addIndex = activePattern.patternStops.length - i
-              const addAtIndexDisabled = (index >= addIndex - 2 && index < addIndex) ||
-                (patternStops[addIndex - 2] && patternStops[addIndex - 2].stopId === stop.id) ||
-                (patternStops[addIndex - 1] && patternStops[addIndex - 1].stopId === stop.id)
-                // (patternStops[addIndex + 1] && patternStops[addIndex + 1].stopId === stop.id)
-              // skip MenuItem index is the same as the pattern stop index
-              if (index === addIndex - 1 || addIndex === 1) {
-                return null
-              }
-              // disable adding stop to current position or directly before/after current position
-              return (
-                <MenuItem
-                  disabled={addAtIndexDisabled}
-                  value={addIndex - 1}
-                  title={addAtIndexDisabled ? `Cannot have the same stop appear consecutively in list` : ''}
-                  key={i}
-                  eventKey={addIndex - 1}>
-                  {`Insert as stop #${addIndex}`}
-                </MenuItem>
-              )
-            })}
-            <MenuItem
-              disabled={addToBeginningDisabled}
-              value={0}
-              eventKey={0}>
-              Add to beginning
-            </MenuItem>
-          </Dropdown.Menu>
-        </Dropdown>
+        <AddPatternStopDropdown
+          activePattern={activePattern}
+          addStopToPattern={addStopToPattern}
+          index={index}
+          patternStop={patternStop}
+          size={size}
+          stop={stop}
+        />
       </ButtonGroup>
     )
   }

--- a/lib/editor/components/pattern/PatternStopsPanel.js
+++ b/lib/editor/components/pattern/PatternStopsPanel.js
@@ -8,9 +8,11 @@ import * as activeActions from '../../actions/active'
 import * as mapActions from '../../actions/map'
 import * as stopStrategiesActions from '../../actions/map/stopStrategies'
 import * as tripPatternActions from '../../actions/tripPattern'
+import AddPatternStopDropdown from './AddPatternStopDropdown'
 import NormalizeStopTimesModal from './NormalizeStopTimesModal'
 import PatternStopContainer from './PatternStopContainer'
 import VirtualizedEntitySelect from '../VirtualizedEntitySelect'
+import {getEntityBounds, getEntityName} from '../../util/gtfs'
 
 import type {Pattern, GtfsStop, Feed, ControlPoint, Coordinates} from '../../../types'
 import type {EditorStatus, EditSettingsUndoState, MapState} from '../../../types/reducers'
@@ -34,19 +36,26 @@ type Props = {
   stops: Array<GtfsStop>,
   updateActiveGtfsEntity: typeof activeActions.updateActiveGtfsEntity,
   updateEditSetting: typeof activeActions.updateEditSetting,
+  updateMapSetting: typeof mapActions.updateMapSetting,
   updatePatternGeometry: typeof mapActions.updatePatternGeometry,
   updatePatternStops: typeof tripPatternActions.updatePatternStops
 }
 
-type State = { showNormalizeStopTimesModal: boolean }
+type State = {
+  patternStopCandidate: ?GtfsStop,
+  showNormalizeStopTimesModal: boolean
+ }
 
 export default class PatternStopsPanel extends Component<Props, State> {
   state = {
-    showNormalizeStopTimesModal: false
+    showNormalizeStopTimesModal: false,
+    patternStopCandidate: null
   }
 
   _toggleAddStopsMode = () => {
     const {editSettings, updateEditSetting} = this.props
+    // Clear stop candidate (if defined).
+    this.setState({patternStopCandidate: null})
     updateEditSetting({
       setting: 'addStops',
       value: !editSettings.present.addStops
@@ -58,12 +67,16 @@ export default class PatternStopsPanel extends Component<Props, State> {
 
   _onCloseModal = () => this.setState({showNormalizeStopTimesModal: false})
 
-  _addStopFromSelect = (input: any) => {
+  _selectStop = (input: any) => {
     if (!input) {
+      // Clear stop candidate if input is cleared.
+      this.setState({patternStopCandidate: null})
       return
     }
     const stop: GtfsStop = input.entity
-    return this.props.addStopToPattern(this.props.activePattern, stop)
+    // Zoom to stop candidate
+    this.props.updateMapSetting({bounds: getEntityBounds(stop), target: +stop.id})
+    this.setState({patternStopCandidate: stop})
   }
 
   render () {
@@ -88,6 +101,7 @@ export default class PatternStopsPanel extends Component<Props, State> {
       updatePatternStops
     } = this.props
     const {addStops} = editSettings.present
+    const {patternStopCandidate} = this.state
     const patternHasStops = activePattern.patternStops &&
       activePattern.patternStops.length > 0
     return (
@@ -174,8 +188,24 @@ export default class PatternStopsPanel extends Component<Props, State> {
               <VirtualizedEntitySelect
                 component={'stop'}
                 entities={stops}
-                // $FlowFixMe wrapped action type mismatch?
-                onChange={this._addStopFromSelect} />
+                onChange={this._selectStop} />
+              {patternStopCandidate
+                ? <div style={{
+                  textAlign: 'center',
+                  marginTop: '5px'
+                }}>
+                  <p>{getEntityName(patternStopCandidate)}</p>
+                  <AddPatternStopDropdown
+                    activePattern={activePattern}
+                    block
+                    addStopToPattern={addStopToPattern}
+                    label='Add stop to end'
+                    stop={patternStopCandidate}
+                    style={{marginBotton: '10px'}}
+                  />
+                </div>
+                : null
+              }
               <div style={{marginTop: '5px'}}>
                 <Button
                   bsSize='small'

--- a/lib/editor/constants/index.js
+++ b/lib/editor/constants/index.js
@@ -17,3 +17,5 @@ export const POINT_TYPE = Object.freeze({
 })
 
 export const ARROW_MAGENTA = '#d50b65'
+
+export const PATTERN_TO_STOP_DISTANCE_THRESHOLD_METERS = 50

--- a/lib/editor/selectors/index.js
+++ b/lib/editor/selectors/index.js
@@ -247,12 +247,21 @@ export const getControlPoints = createSelector(
           )
         } catch (error) {
           console.warn(`Error adding pattern stops to shapepoints`, error)
+          // FIXME: shapepoints issue?
           result = {shapePoints, patternSegments: [], error}
         }
         patternSegments = result.patternSegments
         // Get control points from shape points result, which will include any
         // projected stops and any pre-existing anchors.
-        controlPoints = getControlPointsFromShapePoints(result.shapePoints)
+        // Note: It's not entirely clear what in addPatternStopsToShapePoints
+        // causes result.shapePoints to sometimes only have one shape point item,
+        // but further investigation may be needed (if surrounding this in a
+        // try/catch is causing issues).
+        try {
+          controlPoints = getControlPointsFromShapePoints(result.shapePoints)
+        } catch (error) {
+          console.warn(error, result)
+        }
         if (controlPoints.length - 1 > patternSegments.length) {
           // There are non-stop control points that need to be added in.
           for (let i = 0; i < controlPoints.length; i++) {
@@ -405,7 +414,10 @@ function addPatternStopsToShapePoints (
     // .map(sp => ({...sp}))
     .filter(sp => sp.pointType === POINT_TYPE.STOP)
   if (patternStops.length !== stopControlPoints.length) {
-    console.warn(`Pattern stops (length=${patternStops.length}) and stop control points (length=${stopControlPoints.length}) mismatch!`, patternStops, oldShapePoints)
+    // Note: It seems to be OK (and expected), when adding a pattern stop that stop
+    // control points length is one less than pattern stops. But log a warning
+    // if the difference is something else.
+    console.warn(`Pattern stops (length=${patternStops.length}) and stop control points (length=${stopControlPoints.length}) mismatch!`, patternStops, stopControlPoints, oldShapePoints)
   }
   const patternLine: GeoJsonLinestring = lineString(coordinatesFromShapePoints(shapePointsCopy))
   const patternLengthInMeters: number = lineDistance(patternLine, 'meters')

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -103,6 +103,19 @@ export function isValidPoint (point: any) {
   return Boolean(point && point.geometry && point.geometry.coordinates)
 }
 
+/**
+ * Array filter function to filter control points for stop control points with
+ * valid locations.
+ */
+export function getStopControlPoints (controlPoint: ControlPoint, index: number) {
+  const {point, pointType} = controlPoint
+  // Filter out control points that are not for stops.
+  if (pointType !== POINT_TYPE.STOP) return false
+  // And filter out control points that don't contain valid points.
+  if (!isValidPoint(point)) return false
+  return true
+}
+
 export function newControlPoint (
   distance: ?number,
   point: GeoJsonPoint,

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -107,7 +107,7 @@ export function isValidPoint (point: any) {
  * Array filter function to filter control points for stop control points with
  * valid locations.
  */
-export function getStopControlPoints (controlPoint: ControlPoint, index: number) {
+export function isValidStopControlPoint (controlPoint: ControlPoint) {
   const {point, pointType} = controlPoint
   // Filter out control points that are not for stops.
   if (pointType !== POINT_TYPE.STOP) return false

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -71,6 +71,8 @@ export type Bounds = {
   west: number
 }
 
+export type Style = {[string]: string | number}
+
 export type Route = {
   agencyId: string,
   feedId: string,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR does a few things:
- fixes #617
- improves the process for adding stops by name to a pattern (see screenshot 1)
- DRYs out shared code for the dropdown that adds a stop to a pattern
- adds feedback to user about pattern stops that are too far from the pattern shape (see screenshot 2)
- adds a shared type for `Style` props


### Screenshot 1: Adding a stop by name
![image](https://user-images.githubusercontent.com/2370911/96310429-4f6e2000-0fd5-11eb-9b19-5d90c0ef67b9.png)


### Screenshot 2: feedback about pattern stops
![image](https://user-images.githubusercontent.com/2370911/96310353-35344200-0fd5-11eb-8b44-f87948fa4269.png)
