### PR TITLE
Remove show routes on map

### DIFF
--- a/lib/editor/components/map/EditorMapLayersControl.js
+++ b/lib/editor/components/map/EditorMapLayersControl.js
@@ -3,11 +3,8 @@
 import React, {Component} from 'react'
 import {Browser} from 'leaflet'
 import {
-  TileLayer,
-  FeatureGroup,
   LayersControl,
-  Polyline,
-  Tooltip
+  TileLayer
 } from 'react-leaflet'
 
 import {getUserMetadataProperty} from '../../../common/util/user'

--- a/lib/editor/components/map/EditorMapLayersControl.js
+++ b/lib/editor/components/map/EditorMapLayersControl.js
@@ -28,33 +28,35 @@ type OverlayItem = {component: any, name: string}
 
 export default class EditorMapLayersControl extends Component<Props> {
   render () {
-    const { tripPatterns, stops, user } = this.props
+    const { stops, user } = this.props
     const { BaseLayer, Overlay } = LayersControl
     const OVERLAYS: Array<OverlayItem> = [
-      {
-        name: 'Route alignments',
-        component: (
-          <FeatureGroup>
-            {tripPatterns
-              ? tripPatterns.map((tp) => {
-                if (!tp.latLngs) return null
-                return (
-                  <Polyline
-                    key={tp.id}
-                    positions={tp.latLngs}
-                    weight={2}
-                    color='#888'>
-                    <Tooltip sticky>
-                      <span>{tp.name} ({tp.route_id})</span>
-                    </Tooltip>
-                  </Polyline>
-                )
-              })
-              : null
-            }
-          </FeatureGroup>
-        )
-      },
+      // FIXME: Do not show trip pattern overlay because it can cause out of
+      // memory issues for very large GTFS feeds.
+      // {
+      //   name: 'Route alignments',
+      //   component: (
+      //     <FeatureGroup>
+      //       {tripPatterns
+      //         ? tripPatterns.map((tp) => {
+      //           if (!tp.latLngs) return null
+      //           return (
+      //             <Polyline
+      //               key={tp.id}
+      //               positions={tp.latLngs}
+      //               weight={2}
+      //               color='#888'>
+      //               <Tooltip sticky>
+      //                 <span>{tp.name} ({tp.route_id})</span>
+      //               </Tooltip>
+      //             </Polyline>
+      //           )
+      //         })
+      //         : null
+      //       }
+      //     </FeatureGroup>
+      //   )
+      // },
       {
         name: 'Stop locations',
         component: <StopLayer key='stop-layer' stops={stops} />


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Removes the editor map layer control to show routes on the map. Fixes ibi-group/datatools-ui#627. Commented out because there is client interest in this feature coming back, but at the moment it's too risky.
