### PR TITLE
add config graphopper url

### DIFF
--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -7,6 +7,6 @@ MAPBOX_ATTRIBUTION: <a href="https://www.mapbox.com/about/maps/" target="_blank"
 SLACK_CHANNEL: optional-slack-channel
 SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key
-GRAPH_HOPPER_URL: https://graphhopper.com/api/1/
+# GRAPH_HOPPER_URL: http://localhost:8989/api/
 GOOGLE_ANALYTICS_TRACKING_ID: optional-ga-key
 # GRAPH_HOPPER_POINT_LIMIT: 10 # Defaults to 30

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -7,6 +7,7 @@ MAPBOX_ATTRIBUTION: <a href="https://www.mapbox.com/about/maps/" target="_blank"
 SLACK_CHANNEL: optional-slack-channel
 SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key
+# Optional override to use a custom service instead of the graphhopper.com hosted service.
 # GRAPH_HOPPER_URL: http://localhost:8989/
 GOOGLE_ANALYTICS_TRACKING_ID: optional-ga-key
 # GRAPH_HOPPER_POINT_LIMIT: 10 # Defaults to 30

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -7,5 +7,6 @@ MAPBOX_ATTRIBUTION: <a href="https://www.mapbox.com/about/maps/" target="_blank"
 SLACK_CHANNEL: optional-slack-channel
 SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key
+GRAPH_HOPPER_URL: https://graphhopper.com/api/1/
 GOOGLE_ANALYTICS_TRACKING_ID: optional-ga-key
 # GRAPH_HOPPER_POINT_LIMIT: 10 # Defaults to 30

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -7,6 +7,6 @@ MAPBOX_ATTRIBUTION: <a href="https://www.mapbox.com/about/maps/" target="_blank"
 SLACK_CHANNEL: optional-slack-channel
 SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key
-# GRAPH_HOPPER_URL: http://localhost:8989/api/
+# GRAPH_HOPPER_URL: http://localhost:8989/
 GOOGLE_ANALYTICS_TRACKING_ID: optional-ga-key
 # GRAPH_HOPPER_POINT_LIMIT: 10 # Defaults to 30

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -203,13 +203,7 @@ export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopp
   if (!process.env.GRAPH_HOPPER_KEY) {
     throw new Error('GRAPH_HOPPER_KEY not set')
   }
-  if (process.env.GRAPH_HOPPER_URL) {
-    // If there is a graph_hopper custom url defined then use it
-    graphhopper_url = process.env.GRAPH_HOPPER_URL
-  } else {
-    // The variable is not set the use the external default url
-    graphhopper_url = 'https://graphhopper.com/api/1/' 
-  }
+  const GRAPH_HOPPER_URL = process.env.GRAPH_HOPPER_URL || 'https://graphhopper.com/api/1/'
   const params = {
     key: process.env.GRAPH_HOPPER_KEY,
     vehicle: 'car',
@@ -218,6 +212,6 @@ export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopp
   }
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   return fetch(
-    `${graphhopper_url}route?${locations}&${qs.stringify(params)}`
+    `${GRAPH_HOPPER_URL}route?${locations}&${qs.stringify(params)}`
   ).then(res => res.json())
 }

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -194,7 +194,7 @@ export async function getSegment (
  *
  * Example URL: https://graphhopper.com/api/1/route?point=49.932707,11.588051&point=50.3404,11.64705&vehicle=car&debug=true&&type=json
  */
-export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopperResponse> {  
+export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopperResponse> {
   if (points.length < 2) {
     console.warn('need at least two points to route with graphhopper', points)
     return null

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -203,6 +203,7 @@ export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopp
   if (!process.env.GRAPH_HOPPER_KEY) {
     throw new Error('GRAPH_HOPPER_KEY not set')
   }
+  // Use custom url if it exists, otherwise default to the hosted service.
   const GRAPH_HOPPER_URL = process.env.GRAPH_HOPPER_URL || 'https://graphhopper.com/api/1/'
   const params = {
     key: process.env.GRAPH_HOPPER_KEY,

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -194,8 +194,7 @@ export async function getSegment (
  *
  * Example URL: https://graphhopper.com/api/1/route?point=49.932707,11.588051&point=50.3404,11.64705&vehicle=car&debug=true&&type=json
  */
-export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopperResponse> {
-  var graphhopper_url
+export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopperResponse> {  
   if (points.length < 2) {
     console.warn('need at least two points to route with graphhopper', points)
     return null

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -195,12 +195,20 @@ export async function getSegment (
  * Example URL: https://graphhopper.com/api/1/route?point=49.932707,11.588051&point=50.3404,11.64705&vehicle=car&debug=true&&type=json
  */
 export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopperResponse> {
+  var graphhopper_url
   if (points.length < 2) {
     console.warn('need at least two points to route with graphhopper', points)
     return null
   }
   if (!process.env.GRAPH_HOPPER_KEY) {
     throw new Error('GRAPH_HOPPER_KEY not set')
+  }
+  if (process.env.GRAPH_HOPPER_URL) {
+    // If there is a graph_hopper custom url defined then use it
+    graphhopper_url = process.env.GRAPH_HOPPER_URL
+  } else {
+    // The variable is not set the use the external default url
+    graphhopper_url = 'https://graphhopper.com/api/1/' 
   }
   const params = {
     key: process.env.GRAPH_HOPPER_KEY,
@@ -210,6 +218,6 @@ export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopp
   }
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   return fetch(
-    `https://graphhopper.com/api/1/route?${locations}&${qs.stringify(params)}`
+    `${graphhopper_url}route?${locations}&${qs.stringify(params)}`
   ).then(res => res.json())
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

fixes #633

The pull request add a config variable GRAPH_HOPPER_URL that you are able to config your'e own server, default value is the graphhopper hosted url. It's has a fall back that if it is not configured that it will the hardcoded hosted grapphopper url. 