### PR TITLE
Otp 2 Refactor

### DIFF
--- a/lib/manager/components/ProjectSettings.js
+++ b/lib/manager/components/ProjectSettings.js
@@ -6,7 +6,7 @@ import {LinkContainer} from 'react-router-bootstrap'
 
 import {deleteProject, updateProject} from '../actions/projects'
 import {getComponentMessages, isModuleEnabled} from '../../common/util/config'
-import DeploymentSettings from './DeploymentSettings'
+import DeploymentSettings from './deployment/DeploymentSettings'
 import ProjectSettingsForm from './ProjectSettingsForm'
 
 import type {Project} from '../../types'

--- a/lib/manager/components/deployment/CurrentDeploymentPanel.js
+++ b/lib/manager/components/deployment/CurrentDeploymentPanel.js
@@ -9,11 +9,11 @@ import {
   Label as BsLabel
 } from 'react-bootstrap'
 
-import * as deploymentActions from '../actions/deployments'
-import { formatTimestamp } from '../../common/util/date-time'
-import { getActiveInstanceCount, getServerForId } from '../util/deployment'
+import * as deploymentActions from '../../actions/deployments'
+import { formatTimestamp } from '../../../common/util/date-time'
+import { getActiveInstanceCount, getServerForId } from '../../util/deployment'
 import DeploymentPreviewButton from './DeploymentPreviewButton'
-import EC2InstanceCard from '../../common/components/EC2InstanceCard'
+import EC2InstanceCard from '../../../common/components/EC2InstanceCard'
 
 import type {
   Deployment,
@@ -22,7 +22,7 @@ import type {
   OtpServer,
   Project,
   ServerJob
-} from '../../types'
+} from '../../../types'
 
 type Props = {
   deployJobs: Array<ServerJob>,

--- a/lib/manager/components/deployment/CustomConfig.js
+++ b/lib/manager/components/deployment/CustomConfig.js
@@ -1,0 +1,124 @@
+// @flow
+
+import Icon from '@conveyal/woonerf/components/icon'
+import React, {Component} from 'react'
+import {
+  Button,
+  FormControl,
+  FormGroup,
+  HelpBlock,
+  Radio
+} from 'react-bootstrap'
+import { LinkContainer } from 'react-router-bootstrap'
+
+import * as deploymentActions from '../../actions/deployments'
+import {isValidJSONC} from '../../../common/util/json'
+
+import type {
+  Deployment
+} from '../../../types'
+
+const SAMPLE_BUILD_CONFIG = `{
+  "subwayAccessTime": 2.5
+}`
+
+const SAMPLE_ROUTER_CONFIG = `{
+  "routingDefaults": {
+    "walkSpeed": 2.0,
+    "stairsReluctance": 4.0,
+    "carDropoffTime": 240
+  }
+}`
+
+export default class CustomConfig extends Component<{
+  deployment: Deployment,
+  label: string,
+  name: string,
+  updateDeployment: typeof deploymentActions.updateDeployment
+}, {[string]: any}> {
+  state = {}
+
+  _toggleCustomConfig = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    const {deployment, updateDeployment} = this.props
+    const {name} = evt.target
+    const value = deployment[name]
+      ? null
+      : name === 'customBuildConfig'
+        ? SAMPLE_BUILD_CONFIG
+        : SAMPLE_ROUTER_CONFIG
+    updateDeployment(deployment, {[name]: value})
+  }
+
+  _onChangeConfig = (evt: SyntheticInputEvent<HTMLInputElement>) =>
+    this.setState({[this.props.name]: evt.target.value})
+
+  _onSaveConfig = () => {
+    const {deployment, name, updateDeployment} = this.props
+    const value = this.state[name]
+    if (!isValidJSONC(value)) return window.alert('Must provide valid JSON string.')
+    else {
+      updateDeployment(deployment, {[name]: value})
+      this.setState({[name]: undefined})
+    }
+  }
+
+  render () {
+    const {deployment, name, label} = this.props
+    const useCustom = deployment[name] !== null
+    const value = this.state[name] || deployment[name]
+    const validJSON = isValidJSONC(value)
+    return (
+      <div>
+        <h5>{label} configuration</h5>
+        <FormGroup>
+          <Radio
+            checked={!useCustom}
+            name={name}
+            onChange={this._toggleCustomConfig}
+            inline>
+            Project default
+          </Radio>
+          <Radio
+            checked={useCustom}
+            name={name}
+            onChange={this._toggleCustomConfig}
+            inline>
+            Custom
+          </Radio>
+        </FormGroup>
+        <p>
+          {useCustom
+            ? `Use custom JSON defined below for ${label} configuration.`
+            : `Use the ${label} configuration defined in the project deployment settings.`
+          }
+          <span>{' '}
+            {useCustom
+              ? <Button
+                style={{marginLeft: '15px'}}
+                bsSize='xsmall'
+                disabled={!this.state[name] || !validJSON}
+                onClick={this._onSaveConfig}>Save</Button>
+              : <LinkContainer
+                to={`/project/${deployment.projectId}/settings/deployment`}>
+                <Button bsSize='xsmall'>
+                  <Icon type='pencil' /> Edit
+                </Button>
+              </LinkContainer>
+            }
+          </span>
+        </p>
+        {useCustom &&
+          <FormGroup validationState={validJSON ? null : 'error'}>
+            <FormControl
+              componentClass='textarea'
+              style={{height: '125px'}}
+              placeholder='{"blah": true}'
+              onChange={this._onChangeConfig}
+              value={value} />
+            {!validJSON && <HelpBlock>Must provide valid JSON string.</HelpBlock>}
+          </FormGroup>
+        }
+      </div>
+    )
+  }
+}

--- a/lib/manager/components/deployment/CustomFileEditor.js
+++ b/lib/manager/components/deployment/CustomFileEditor.js
@@ -1,0 +1,256 @@
+// @flow
+
+import React, {Component} from 'react'
+import {
+  Button,
+  ButtonToolbar,
+  Checkbox,
+  ControlLabel,
+  FormControl,
+  FormGroup,
+  HelpBlock
+} from 'react-bootstrap'
+
+import type {
+  CustomFile
+} from '../../../types'
+
+type Props = {
+  customFile: CustomFile,
+  customFileEditIdx: null | number,
+  idx: number,
+  onCancelEditing: () => void,
+  onDelete: (number) => void,
+  onEdit: (number) => void,
+  onSave: (number, CustomFile) => void
+}
+
+export default class CustomFileEditor extends Component<Props, {
+  fileSource: 'raw' | 'uri',
+  model: CustomFile
+}> {
+  constructor (props: Props) {
+    super(props)
+    const { customFile } = props
+    this.state = {
+      fileSource: customFile.contents ? 'raw' : 'uri',
+      model: props.customFile
+    }
+  }
+
+  _canEdit = () => this.props.customFileEditIdx === null
+
+  _isEditing= () => this.props.idx === this.props.customFileEditIdx
+
+  _isValid = () => {
+    const {model: customFile} = this.state
+    return customFile.contents || customFile.uri
+  }
+
+  _onChangeBuildUse = () => {
+    const { model } = this.state
+    this.setState({
+      model: {
+        ...model,
+        useDuringBuild: !model.useDuringBuild
+      }
+    })
+  }
+
+  _onChangeContents = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    this.setState({
+      model: {
+        ...this.state.model,
+        contents: evt.target.value
+      }
+    })
+  }
+
+  _onChangeFilename = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    this.setState({
+      model: {
+        ...this.state.model,
+        filename: evt.target.value
+      }
+    })
+  }
+
+  _onChangeServeUse = () => {
+    const { model } = this.state
+    this.setState({
+      model: {
+        ...model,
+        useDuringServe: !model.useDuringServe
+      }
+    })
+  }
+
+  _onChangeSource = (evt: SyntheticInputEvent<HTMLSelectElement>) => {
+    const model = {...this.state.model}
+    // set variable to make flow happy
+    let newSource
+    if (evt.target.value === 'raw') {
+      model.uri = null
+      newSource = 'raw'
+    } else {
+      model.contents = null
+      newSource = 'uri'
+    }
+    this.setState({
+      fileSource: newSource,
+      model
+    })
+  }
+
+  _onChangeUri = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    this.setState({
+      model: {
+        ...this.state.model,
+        uri: evt.target.value
+      }
+    })
+  }
+
+  _onCancelEditing = () => {
+    const { customFile, onCancelEditing } = this.props
+    this.setState({
+      fileSource: customFile.contents ? 'raw' : 'uri',
+      model: customFile
+    })
+    onCancelEditing()
+  }
+
+  _onDelete = () => {
+    const { idx, onDelete } = this.props
+    onDelete(idx)
+  }
+
+  _onEdit = () => {
+    const { idx, onEdit } = this.props
+    onEdit(idx)
+  }
+
+  _onSave = () => {
+    const { idx, onSave } = this.props
+    onSave(idx, this.state.model)
+  }
+
+  _renderToolbar = () => {
+    const isEditing = this._isEditing()
+    const canEdit = this._canEdit()
+    const either = !isEditing && !canEdit
+    return (
+      <ButtonToolbar>
+        <Button
+          bsSize='xsmall'
+          disabled={either}
+          onClick={canEdit ? this._onEdit : this._onCancelEditing}
+        >
+          {isEditing ? 'Cancel' : 'Edit'}
+        </Button>
+        {isEditing &&
+          <Button
+            bsSize='xsmall'
+            disabled={!this._isValid()}
+            onClick={this._onSave}
+          >
+            Save
+          </Button>
+        }
+        <Button
+          bsSize='xsmall'
+          bsStyle='danger'
+          className='pull-right'
+          disabled={either}
+          onClick={this._onDelete}
+        >
+          Delete
+        </Button>
+      </ButtonToolbar>
+    )
+  }
+
+  render () {
+    const {
+      fileSource,
+      model: customFile
+    } = this.state
+    const isValid = this._isValid()
+    const isEditing = this._isEditing()
+    return (
+      <div className='custom-file'>
+        {this._renderToolbar()}
+        <div className='margin-top-15'>
+          {isEditing
+            ? <FormControl
+              onChange={this._onChangeFilename}
+              placeholder='Enter filename'
+              type='text'
+              value={customFile.filename}
+            />
+            : <span>
+              Filename:{' '}
+              <span style={{fontFamily: 'monospace'}}>
+                {/* FIXME: what should the behavior be here if missing */}
+                {customFile.filename || '[defaults to URI]'}
+              </span>
+            </span>
+          }
+        </div>
+        <Checkbox
+          checked={customFile.useDuringBuild}
+          disabled={!isEditing}
+          onChange={this._onChangeBuildUse}
+        >
+          Use during graph build
+        </Checkbox>
+        <Checkbox
+          checked={customFile.useDuringServe}
+          disabled={!isEditing}
+          onChange={this._onChangeServeUse}
+        >
+          Use while running server
+        </Checkbox>
+        <FormGroup validationState={isValid ? null : 'error'}>
+          <ControlLabel>File source</ControlLabel>
+          <FormControl
+            componentClass='select'
+            disabled={!isEditing}
+            onChange={this._onChangeSource}
+            placeholder='select type'
+            style={{ marginBottom: 5 }}
+            value={fileSource}
+          >
+            <option value='raw'>From raw input</option>
+            <option value='uri'>Download from URI</option>
+          </FormControl>
+          {!isValid && <HelpBlock>Please set contents or uri!</HelpBlock>}
+          {fileSource === 'raw' && (
+            <FormControl
+              componentClass='textarea'
+              disabled={!isEditing}
+              style={{height: '125px'}}
+              placeholder='{"blah": true}'
+              onChange={this._onChangeContents}
+              value={customFile.contents}
+            />
+          )}
+          {fileSource === 'uri' && (
+            <span>
+              <FormControl
+                disabled={!isEditing}
+                placeholder='https://www.examle.com/file.json'
+                onChange={this._onChangeUri}
+                type='text'
+                value={customFile.uri}
+              />
+              {!customFile.uri && (
+                <HelpBlock>Enter either a HTTP(S) URL or AWS S3 URI</HelpBlock>
+              )}
+            </span>
+          )}
+        </FormGroup>
+      </div>
+    )
+  }
+}

--- a/lib/manager/components/deployment/DeploymentConfigurationsPanel.js
+++ b/lib/manager/components/deployment/DeploymentConfigurationsPanel.js
@@ -1,0 +1,280 @@
+// @flow
+
+import Icon from '@conveyal/woonerf/components/icon'
+import fetch from 'isomorphic-fetch'
+import React, {Component} from 'react'
+import {
+  Checkbox,
+  ControlLabel,
+  ListGroup,
+  ListGroupItem,
+  Button,
+  Panel,
+  Glyphicon
+} from 'react-bootstrap'
+import Select from 'react-select'
+import validator from 'validator'
+
+import * as deploymentActions from '../../actions/deployments'
+import {getConfigProperty} from '../../../common/util/config'
+import CustomConfig from './CustomConfig'
+import CustomFileEditor from './CustomFileEditor'
+
+import type {
+  CustomFile,
+  Deployment,
+  ReactSelectOption
+} from '../../../types'
+
+const TRIP_PLANNER_VERSIONS = [
+  { label: 'OTP 1.X', value: 'OTP_1' },
+  { label: 'OTP 2.X', value: 'OTP_2' }
+]
+
+export default class DeploymentConfigurationsPanel extends Component<{
+  deployment: Deployment,
+  updateDeployment: typeof deploymentActions.updateDeployment
+}, {
+  customFileEditIdx: null | number,
+  otp: Array<ReactSelectOption>,
+}> {
+  state = {
+    customFileEditIdx: null,
+    otp: []
+  }
+  componentDidMount () {
+    // Fetch the available OTP versions from S3.
+    this._loadOptions()
+  }
+
+  /**
+   * Parse .jar options from an S3 text XML response.
+   * @param  {string} text text response from s3
+   * @param  {string} key  state key under which to store options
+   */
+  _parseOptionsFromXml = (text: string) => {
+    const parser = new window.DOMParser()
+    const doc = parser.parseFromString(text, 'application/xml')
+
+    const all = Array.from(doc.querySelectorAll('Contents'))
+      .map(item => item.querySelector('Key').childNodes[0].nodeValue) // get just key
+      .filter(item => item !== 'index.html') // don't include the main page
+      .map(item => item.replace(/.jar$/, '')) // and remove .jar
+    this.setState({otp: all})
+  }
+
+  _loadAndParseOptionsFromXml = (url: string) => {
+    fetch(url)
+      .then(res => res.text())
+      .then(text => this._parseOptionsFromXml(text))
+  }
+
+  /**
+   * Load .jar options from OTP and R5 S3 buckets.
+   */
+  _loadOptions = () => {
+    const otpUrl = getConfigProperty('modules.deployment.otp_download_url') || 'https://opentripplanner-builds.s3.amazonaws.com'
+    this._loadAndParseOptionsFromXml(otpUrl)
+  }
+
+  _onAddCustomFile = () => {
+    const { deployment } = this.props
+    const customFiles = deployment.customFiles
+      ? [...deployment.customFiles, {}]
+      : [{}]
+    this._updateDeployment({ customFiles })
+    this.setState({ customFileEditIdx: customFiles.length - 1 })
+  }
+
+  _onChangeBuildGraphOnly = () => this._updateDeployment({buildGraphOnly: !this.props.deployment.buildGraphOnly})
+
+  _onChangeSkipOsmExtract = () => {
+    const {skipOsmExtract} = this.props.deployment
+    if (!skipOsmExtract) {
+      // If changing from including OSM to skipping OSM, verify that this is
+      // intentional.
+      if (!window.confirm('Are you sure you want to exclude an OSM extract from the graph build? This will prevent the use of the OSM street network in routing results.')) {
+        return
+      }
+    }
+    this._updateDeployment({skipOsmExtract: !skipOsmExtract})
+  }
+
+  _onCancelEditingCustomFile = () => {
+    this.setState({ customFileEditIdx: null })
+  }
+
+  _onEditCustomFile = (idx: number) => {
+    this.setState({ customFileEditIdx: idx })
+  }
+
+  _onDeleteCustomFile = (idx: number) => {
+    const { deployment } = this.props
+    const customFiles = [...deployment.customFiles || []]
+    customFiles.splice(idx, 1)
+    this._updateDeployment({ customFiles })
+    this.setState({ customFileEditIdx: null })
+  }
+
+  _onSaveCustomFile = (idx: number, data: CustomFile) => {
+    const { deployment } = this.props
+    const customFiles = [...deployment.customFiles || []]
+    customFiles[idx] = data
+    this._updateDeployment({ customFiles })
+    this.setState({ customFileEditIdx: null })
+  }
+
+  _setOsmUrl = () => {
+    const currentUrl = this.props.deployment.osmExtractUrl || ''
+    const osmExtractUrl = window.prompt(
+      'Please provide a public URL from which to download an OSM extract (.pbf).',
+      currentUrl
+    )
+    if (osmExtractUrl) {
+      if (!validator.isURL(osmExtractUrl)) {
+        window.alert(`URL ${osmExtractUrl} is invalid!`)
+        return
+      }
+      this._updateDeployment({osmExtractUrl})
+    }
+  }
+
+  _clearOsmUrl = () => this._updateDeployment({osmExtractUrl: null})
+
+  _onUpdateTripPlannerVersion = (option: ReactSelectOption) => {
+    const {deployment, updateDeployment} = this.props
+    updateDeployment(deployment, { tripPlannerVersion: option.value })
+  }
+
+  _onUpdateVersion = (option: ReactSelectOption) => {
+    this._updateDeployment({otpVersion: option.value})
+  }
+
+  _updateDeployment = (props: {[string]: any}) => {
+    const {deployment, updateDeployment} = this.props
+    updateDeployment(deployment, props)
+  }
+
+  render () {
+    const { deployment, updateDeployment } = this.props
+    const { customFileEditIdx, otp: options } = this.state
+    const isOtp = deployment.tripPlannerVersion.startsWith('OTP_')
+
+    return (
+      <Panel header={<h3><Icon type='cog' /> OTP Configuration</h3>}>
+        <ListGroup fill>
+          <ListGroupItem>
+            <Checkbox
+              checked={deployment.buildGraphOnly}
+              onChange={this._onChangeBuildGraphOnly}
+            >
+              Build graph only
+            </Checkbox>
+            Trip Planner Version:
+            <Select
+              value={deployment.tripPlannerVersion}
+              onChange={this._onUpdateTripPlannerVersion}
+              options={TRIP_PLANNER_VERSIONS}
+            />
+            {isOtp && (
+              <div>
+                OTP jar file
+                <Select
+                  value={deployment.otpVersion}
+                  onChange={this._onUpdateVersion}
+                  options={options ? options.map(v => ({value: v, label: v})) : []}
+                />
+              </div>
+            )}
+          </ListGroupItem>
+          <ListGroupItem>
+            Deploying to the{' '}
+            <small><em>{deployment.routerId || 'default'}</em></small>{' '}
+            OpenTripPlanner router.
+          </ListGroupItem>
+          <ListGroupItem>
+            OpenStreetMap Settings
+            <Checkbox
+              checked={!deployment.skipOsmExtract}
+              onChange={this._onChangeSkipOsmExtract}>
+              Build graph with OSM extract
+            </Checkbox>
+            {/* Hide URL/auto-extract if skipping OSM extract. */}
+            {deployment.skipOsmExtract
+              ? null
+              : deployment.osmExtractUrl
+                ? <div>
+                  <ControlLabel className='unselectable buffer-right'>
+                    URL:
+                  </ControlLabel>
+                  <span
+                    className='overflow'
+                    style={{
+                      marginBottom: '5px',
+                      width: '240px',
+                      verticalAlign: 'middle'
+                    }}
+                    title={deployment.osmExtractUrl}>
+                    {deployment.osmExtractUrl}
+                  </span>
+                  <Button
+                    bsSize='xsmall'
+                    style={{marginLeft: '5px'}}
+                    onClick={this._setOsmUrl}>Change</Button>
+                  <Button
+                    bsSize='xsmall'
+                    style={{marginLeft: '5px'}}
+                    onClick={this._clearOsmUrl}>Clear</Button>
+                </div>
+                : <div>
+                  Auto-extract OSM (N. America only)
+                  <Button
+                    bsSize='xsmall'
+                    style={{marginLeft: '5px'}}
+                    onClick={this._setOsmUrl}>Override</Button>
+                </div>
+            }
+          </ListGroupItem>
+          <ListGroupItem>
+            <CustomConfig
+              name='customBuildConfig'
+              label='Build'
+              updateDeployment={updateDeployment}
+              deployment={deployment} />
+          </ListGroupItem>
+          <ListGroupItem>
+            <CustomConfig
+              name='customRouterConfig'
+              label='Router'
+              updateDeployment={updateDeployment}
+              deployment={deployment} />
+          </ListGroupItem>
+          <ListGroupItem>
+            <h5>Custom Files</h5>
+            {deployment.customFiles && deployment.customFiles.map(
+              (customFile, idx) => (
+                <CustomFileEditor
+                  customFile={customFile}
+                  customFileEditIdx={customFileEditIdx}
+                  deployment={deployment}
+                  idx={idx}
+                  onCancelEditing={this._onCancelEditingCustomFile}
+                  onDelete={this._onDeleteCustomFile}
+                  onEdit={this._onEditCustomFile}
+                  onSave={this._onSaveCustomFile}
+                />
+              )
+            )}
+            <Button
+              disabled={customFileEditIdx !== null}
+              onClick={this._onAddCustomFile}
+            >
+              <Glyphicon glyph='plus' />{' '}
+              Add custom file
+            </Button>
+          </ListGroupItem>
+        </ListGroup>
+      </Panel>
+    )
+  }
+}

--- a/lib/manager/components/deployment/DeploymentConfirmModal.js
+++ b/lib/manager/components/deployment/DeploymentConfirmModal.js
@@ -4,15 +4,15 @@ import React, {Component, type Node} from 'react'
 import {Alert as BootstrapAlert, Button, Glyphicon, Modal} from 'react-bootstrap'
 import {Map, TileLayer, Rectangle} from 'react-leaflet'
 
-import * as deploymentActions from '../actions/deployments'
-import {getComponentMessages} from '../../common/util/config'
-import {defaultTileLayerProps} from '../../common/util/maps'
-import {getServerForId} from '../util/deployment'
-import {getFeedNames, versionHasExpired} from '../util/version'
+import * as deploymentActions from '../../actions/deployments'
+import {getComponentMessages} from '../../../common/util/config'
+import {defaultTileLayerProps} from '../../../common/util/maps'
+import {getServerForId} from '../../util/deployment'
+import {getFeedNames, versionHasExpired} from '../../util/version'
 import polygon from 'turf-polygon'
 import area from '@turf/area'
 
-import type {Deployment, Project, SummarizedFeedVersion} from '../../types'
+import type {Deployment, Project, SummarizedFeedVersion} from '../../../types'
 
 type Props = {
   deployToTarget: typeof deploymentActions.deployToTarget,

--- a/lib/manager/components/deployment/DeploymentPreviewButton.js
+++ b/lib/manager/components/deployment/DeploymentPreviewButton.js
@@ -4,7 +4,7 @@ import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
 import {Button, Tooltip, OverlayTrigger} from 'react-bootstrap'
 
-import type {Deployment, Project} from '../../types'
+import type {Deployment, Project} from '../../../types'
 
 type Props = {
   deployment: Deployment,

--- a/lib/manager/components/deployment/DeploymentSettings.js
+++ b/lib/manager/components/deployment/DeploymentSettings.js
@@ -9,14 +9,14 @@ import {shallowEqual} from 'react-pure-render'
 import {withRouter} from 'react-router'
 import {LinkContainer} from 'react-router-bootstrap'
 
-import FormInput from '../../common/components/FormInput'
-import {getComponentMessages} from '../../common/util/config'
-import CollapsiblePanel from './CollapsiblePanel'
-import {parseBounds} from '../util'
-import {FIELDS, SERVER_FIELDS, UPDATER_FIELDS} from '../util/deployment'
+import FormInput from '../../../common/components/FormInput'
+import {getComponentMessages} from '../../../common/util/config'
+import CollapsiblePanel from '../CollapsiblePanel'
+import {parseBounds} from '../../util'
+import {FIELDS, SERVER_FIELDS, UPDATER_FIELDS} from '../../util/deployment'
 
-import {updateProject} from '../actions/projects'
-import type {Project} from '../../types'
+import {updateProject} from '../../actions/projects'
+import type {Project} from '../../../types'
 
 type Props = {
   editDisabled: boolean,

--- a/lib/manager/components/deployment/DeploymentVersionsTable.js
+++ b/lib/manager/components/deployment/DeploymentVersionsTable.js
@@ -4,13 +4,13 @@ import React, {Component} from 'react'
 import {Table, Button, Badge, Glyphicon, ButtonToolbar} from 'react-bootstrap'
 import { Link } from 'react-router'
 
-import * as deploymentActions from '../actions/deployments'
-import {getComponentMessages} from '../../common/util/config'
-import {formatTimestamp, fromNow} from '../../common/util/date-time'
-import {versionHasExpired, versionHasNotBegun} from '../util/version'
+import * as deploymentActions from '../../actions/deployments'
+import {getComponentMessages} from '../../../common/util/config'
+import {formatTimestamp, fromNow} from '../../../common/util/date-time'
+import {versionHasExpired, versionHasNotBegun} from '../../util/version'
 
-import type {Deployment, Feed, Project, SummarizedFeedVersion} from '../../types'
-import type {ManagerUserState} from '../../types/reducers'
+import type {Deployment, Feed, Project, SummarizedFeedVersion} from '../../../types'
+import type {ManagerUserState} from '../../../types/reducers'
 
 type Props = {
   deleteFeedVersion: typeof deploymentActions.deleteFeedVersion,

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -4,12 +4,8 @@ import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
 import { LinkContainer } from 'react-router-bootstrap'
 import {
-  Checkbox,
-  ControlLabel,
-  Radio,
   FormGroup,
   InputGroup,
-  HelpBlock,
   ListGroup,
   ListGroupItem,
   Row,
@@ -24,9 +20,6 @@ import {
   MenuItem
 } from 'react-bootstrap'
 import {Map, TileLayer, Rectangle} from 'react-leaflet'
-import Select from 'react-select'
-import fetch from 'isomorphic-fetch'
-import validator from 'validator'
 
 import * as deploymentActions from '../../actions/deployments'
 import Loading from '../../../common/components/Loading'
@@ -35,19 +28,16 @@ import Title from '../../../common/components/Title'
 import WatchButton from '../../../common/containers/WatchButton'
 import {getComponentMessages, getConfigProperty} from '../../../common/util/config'
 import {formatTimestamp, fromNow} from '../../../common/util/date-time'
-import {isValidJSONC} from '../../../common/util/json'
 import {defaultTileLayerProps} from '../../../common/util/maps'
 import { versionsSorter } from '../../../common/util/util'
 import {getServerDeployedTo} from '../../util/deployment'
 import CurrentDeploymentPanel from './CurrentDeploymentPanel'
+import DeploymentConfigurationsPanel from './DeploymentConfigurationsPanel'
 import DeploymentConfirmModal from './DeploymentConfirmModal'
 import DeploymentVersionsTable from './DeploymentVersionsTable'
 
 import type {Props as ContainerProps} from '../../containers/ActiveDeploymentViewer'
 import type {
-  CustomFile,
-  Deployment,
-  ReactSelectOption,
   ServerJob,
   SummarizedFeedVersion
 } from '../../../types'
@@ -68,35 +58,15 @@ type Props = ContainerProps & {
 }
 
 type State = {
-  customFileEditIdx: null | number,
-  otp: Array<ReactSelectOption>,
   searchText: ?string,
   target: ?string
 }
 
 const BOUNDS_LIMIT = 10 // Limit for the decimal degrees span
 
-const SAMPLE_BUILD_CONFIG = `{
-  "subwayAccessTime": 2.5
-}`
-
-const SAMPLE_ROUTER_CONFIG = `{
-  "routingDefaults": {
-    "walkSpeed": 2.0,
-    "stairsReluctance": 4.0,
-    "carDropoffTime": 240
-  }
-}`
-
-const TRIP_PLANNER_VERSIONS = [
-  { label: 'OTP 1.X', value: 'OTP_1' },
-  { label: 'OTP 2.X', value: 'OTP_2' }
-]
-
 export default class DeploymentViewer extends Component<Props, State> {
   messages = getComponentMessages('DeploymentViewer')
   state = {
-    customFileEditIdx: null,
     otp: [],
     searchText: null,
     target: null
@@ -104,8 +74,6 @@ export default class DeploymentViewer extends Component<Props, State> {
 
   componentDidMount () {
     this.resetMap()
-    // Fetch the available OTP and R5 build versions from S3.
-    this._loadOptions()
   }
 
   /**
@@ -129,45 +97,6 @@ export default class DeploymentViewer extends Component<Props, State> {
     return [[north, east], [south, west]]
   }
 
-  /**
-   * Parse .jar options from an S3 text XML response.
-   * @param  {string} text text response from s3
-   * @param  {string} key  state key under which to store options
-   */
-  _parseOptionsFromXml = (text: string) => {
-    const parser = new window.DOMParser()
-    const doc = parser.parseFromString(text, 'application/xml')
-
-    const all = Array.from(doc.querySelectorAll('Contents'))
-      .map(item => item.querySelector('Key').childNodes[0].nodeValue) // get just key
-      .filter(item => item !== 'index.html') // don't include the main page
-      .map(item => item.replace(/.jar$/, '')) // and remove .jar
-    this.setState({otp: all})
-  }
-
-  _loadAndParseOptionsFromXml = (url: string) => {
-    fetch(url)
-      .then(res => res.text())
-      .then(text => this._parseOptionsFromXml(text))
-  }
-
-  /**
-   * Load .jar options from OTP and R5 S3 buckets.
-   */
-  _loadOptions = () => {
-    const otpUrl = getConfigProperty('modules.deployment.otp_download_url') || 'https://opentripplanner-builds.s3.amazonaws.com'
-    this._loadAndParseOptionsFromXml(otpUrl)
-  }
-
-  _onAddCustomFile = () => {
-    const { deployment } = this.props
-    const customFiles = deployment.customFiles
-      ? [...deployment.customFiles, {}]
-      : [{}]
-    this._updateDeployment({ customFiles })
-    this.setState({ customFileEditIdx: customFiles.length - 1 })
-  }
-
   _onAddFeedSource = (feedSourceId: string) => {
     const feed = this.props.feedSources.find(fs => fs.id === feedSourceId)
     const id = feed && feed.latestVersionId
@@ -183,74 +112,11 @@ export default class DeploymentViewer extends Component<Props, State> {
 
   _onChangeName = (name: string) => this._updateDeployment({name})
 
-  _onChangeBuildGraphOnly = () => this._updateDeployment({buildGraphOnly: !this.props.deployment.buildGraphOnly})
-
-  _onChangeSkipOsmExtract = () => {
-    const {skipOsmExtract} = this.props.deployment
-    if (!skipOsmExtract) {
-      // If changing from including OSM to skipping OSM, verify that this is
-      // intentional.
-      if (!window.confirm('Are you sure you want to exclude an OSM extract from the graph build? This will prevent the use of the OSM street network in routing results.')) {
-        return
-      }
-    }
-    this._updateDeployment({skipOsmExtract: !skipOsmExtract})
-  }
-
   _onClickDownload = () => this.props.downloadDeployment(this.props.deployment)
 
   _onCloseModal = () => this.setState({target: null})
 
-  _onCancelEditingCustomFile = () => {
-    this.setState({ customFileEditIdx: null })
-  }
-
-  _onEditCustomFile = (idx: number) => {
-    this.setState({ customFileEditIdx: idx })
-  }
-
-  _onDeleteCustomFile = (idx: number) => {
-    const { deployment } = this.props
-    const customFiles = [...deployment.customFiles || []]
-    customFiles.splice(idx, 1)
-    this._updateDeployment({ customFiles })
-  }
-
-  _onSaveCustomFile = (idx: number, data: CustomFile) => {
-    const { deployment } = this.props
-    const customFiles = [...deployment.customFiles || []]
-    customFiles[idx] = data
-    this._updateDeployment({ customFiles })
-    this.setState({ customFileEditIdx: null })
-  }
-
-  _setOsmUrl = () => {
-    const currentUrl = this.props.deployment.osmExtractUrl || ''
-    const osmExtractUrl = window.prompt(
-      'Please provide a public URL from which to download an OSM extract (.pbf).',
-      currentUrl
-    )
-    if (osmExtractUrl) {
-      if (!validator.isURL(osmExtractUrl)) {
-        window.alert(`URL ${osmExtractUrl} is invalid!`)
-        return
-      }
-      this._updateDeployment({osmExtractUrl})
-    }
-  }
-
-  _clearOsmUrl = () => this._updateDeployment({osmExtractUrl: null})
-
   _onSelectTarget = (target: string) => this.setState({target})
-
-  _onUpdateTripPlannerVersion = (option: ReactSelectOption) => {
-    const {deployment, updateDeployment} = this.props
-    updateDeployment(deployment, { tripPlannerVersion: option.value })
-  }
-
-  _onUpdateVersion = (option: ReactSelectOption) => {
-    this._updateDeployment({otpVersion: option.value})
-  }
 
   _updateDeployment = (props: {[string]: any}) => {
     const {deployment, updateDeployment} = this.props
@@ -438,138 +304,6 @@ export default class DeploymentViewer extends Component<Props, State> {
     )
   }
 
-  renderConfigurationsPanel () {
-    const { deployment, updateDeployment } = this.props
-    const options = this.state.otp
-    const isOtp = deployment.tripPlannerVersion.startsWith('OTP_')
-
-    return (
-      <Panel header={<h3><Icon type='cog' /> OTP Configuration</h3>}>
-        <ListGroup fill>
-          <ListGroupItem>
-            <Checkbox
-              checked={deployment.buildGraphOnly}
-              onChange={this._onChangeBuildGraphOnly}
-            >
-              Build graph only
-            </Checkbox>
-            Trip Planner Version:
-            <Select
-              value={deployment.tripPlannerVersion}
-              onChange={this._onUpdateTripPlannerVersion}
-              options={TRIP_PLANNER_VERSIONS}
-            />
-            {isOtp && (
-              <div>
-                OTP jar file
-                <Select
-                  value={deployment.otpVersion}
-                  onChange={this._onUpdateVersion}
-                  options={options ? options.map(v => ({value: v, label: v})) : []}
-                />
-              </div>
-            )}
-          </ListGroupItem>
-          <ListGroupItem>
-            Deploying to the{' '}
-            <small><em>{deployment.routerId || 'default'}</em></small>{' '}
-            OpenTripPlanner router.
-          </ListGroupItem>
-          <ListGroupItem>
-            OpenStreetMap Settings
-            <Checkbox
-              checked={!deployment.skipOsmExtract}
-              onChange={this._onChangeSkipOsmExtract}>
-              Build graph with OSM extract
-            </Checkbox>
-            {/* Hide URL/auto-extract if skipping OSM extract. */}
-            {deployment.skipOsmExtract
-              ? null
-              : deployment.osmExtractUrl
-                ? <div>
-                  <ControlLabel className='unselectable buffer-right'>
-                    URL:
-                  </ControlLabel>
-                  <span
-                    className='overflow'
-                    style={{
-                      marginBottom: '5px',
-                      width: '240px',
-                      verticalAlign: 'middle'
-                    }}
-                    title={deployment.osmExtractUrl}>
-                    {deployment.osmExtractUrl}
-                  </span>
-                  <Button
-                    bsSize='xsmall'
-                    style={{marginLeft: '5px'}}
-                    onClick={this._setOsmUrl}>Change</Button>
-                  <Button
-                    bsSize='xsmall'
-                    style={{marginLeft: '5px'}}
-                    onClick={this._clearOsmUrl}>Clear</Button>
-                </div>
-                : <div>
-                  Auto-extract OSM (N. America only)
-                  <Button
-                    bsSize='xsmall'
-                    style={{marginLeft: '5px'}}
-                    onClick={this._setOsmUrl}>Override</Button>
-                </div>
-            }
-          </ListGroupItem>
-          <ListGroupItem>
-            <CustomConfig
-              name='customBuildConfig'
-              label='Build'
-              updateDeployment={updateDeployment}
-              deployment={deployment} />
-          </ListGroupItem>
-          <ListGroupItem>
-            <CustomConfig
-              name='customRouterConfig'
-              label='Router'
-              updateDeployment={updateDeployment}
-              deployment={deployment} />
-          </ListGroupItem>
-          {this.renderCustomFiles()}
-        </ListGroup>
-      </Panel>
-    )
-  }
-
-  renderCustomFiles = () => {
-    const { deployment } = this.props
-    const { customFileEditIdx } = this.state
-
-    return (
-      <ListGroupItem>
-        <h5>Custom Files</h5>
-        {deployment.customFiles && deployment.customFiles.map(
-          (customFile, idx) => (
-            <CustomFileEditor
-              customFile={customFile}
-              customFileEditIdx={customFileEditIdx}
-              deployment={deployment}
-              idx={idx}
-              onCancelEditing={this._onCancelEditingCustomFile}
-              onDelete={this._onDeleteCustomFile}
-              onEdit={this._onEditCustomFile}
-              onSave={this._onSaveCustomFile}
-            />
-          )
-        )}
-        <Button
-          disabled={customFileEditIdx !== null}
-          onClick={this._onAddCustomFile}
-        >
-          <Glyphicon glyph='plus' />{' '}
-          Add custom file
-        </Button>
-      </ListGroupItem>
-    )
-  }
-
   render () {
     const {
       deleteFeedVersion,
@@ -578,6 +312,7 @@ export default class DeploymentViewer extends Component<Props, State> {
       deployToTarget,
       feedSources,
       project,
+      updateDeployment,
       updateVersionForFeedSource,
       user
     } = this.props
@@ -648,304 +383,12 @@ export default class DeploymentViewer extends Component<Props, State> {
               server={serverDeployedTo}
               terminateEC2InstanceForDeployment={this.props.terminateEC2InstanceForDeployment} />
             {/* Configurations panel */}
-            {this.renderConfigurationsPanel()}
+            <DeploymentConfigurationsPanel
+              deployment={deployment}
+              updateDeployment={updateDeployment}
+            />
           </Col>
         </Row>
-      </div>
-    )
-  }
-}
-
-class CustomConfig extends Component<{
-  deployment: Deployment,
-  label: string,
-  name: string,
-  updateDeployment: typeof deploymentActions.updateDeployment
-}, {[string]: any}> {
-  state = {}
-
-  _toggleCustomConfig = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    const {deployment, updateDeployment} = this.props
-    const {name} = evt.target
-    const value = deployment[name]
-      ? null
-      : name === 'customBuildConfig'
-        ? SAMPLE_BUILD_CONFIG
-        : SAMPLE_ROUTER_CONFIG
-    updateDeployment(deployment, {[name]: value})
-  }
-
-  _onChangeConfig = (evt: SyntheticInputEvent<HTMLInputElement>) =>
-    this.setState({[this.props.name]: evt.target.value})
-
-  _onSaveConfig = () => {
-    const {deployment, name, updateDeployment} = this.props
-    const value = this.state[name]
-    if (!isValidJSONC(value)) return window.alert('Must provide valid JSON string.')
-    else {
-      updateDeployment(deployment, {[name]: value})
-      this.setState({[name]: undefined})
-    }
-  }
-
-  render () {
-    const {deployment, name, label} = this.props
-    const useCustom = deployment[name] !== null
-    const value = this.state[name] || deployment[name]
-    const validJSON = isValidJSONC(value)
-    return (
-      <div>
-        <h5>{label} configuration</h5>
-        <FormGroup>
-          <Radio
-            checked={!useCustom}
-            name={name}
-            onChange={this._toggleCustomConfig}
-            inline>
-            Project default
-          </Radio>
-          <Radio
-            checked={useCustom}
-            name={name}
-            onChange={this._toggleCustomConfig}
-            inline>
-            Custom
-          </Radio>
-        </FormGroup>
-        <p>
-          {useCustom
-            ? `Use custom JSON defined below for ${label} configuration.`
-            : `Use the ${label} configuration defined in the project deployment settings.`
-          }
-          <span>{' '}
-            {useCustom
-              ? <Button
-                style={{marginLeft: '15px'}}
-                bsSize='xsmall'
-                disabled={!this.state[name] || !validJSON}
-                onClick={this._onSaveConfig}>Save</Button>
-              : <LinkContainer
-                to={`/project/${deployment.projectId}/settings/deployment`}>
-                <Button bsSize='xsmall'>
-                  <Icon type='pencil' /> Edit
-                </Button>
-              </LinkContainer>
-            }
-          </span>
-        </p>
-        {useCustom &&
-          <FormGroup validationState={validJSON ? null : 'error'}>
-            <FormControl
-              componentClass='textarea'
-              style={{height: '125px'}}
-              placeholder='{"blah": true}'
-              onChange={this._onChangeConfig}
-              value={value} />
-            {!validJSON && <HelpBlock>Must provide valid JSON string.</HelpBlock>}
-          </FormGroup>
-        }
-      </div>
-    )
-  }
-}
-
-class CustomFileEditor extends Component<{
-  customFile: CustomFile,
-  customFileEditIdx: null | number,
-  idx: number,
-  onCancelEditing: () => void,
-  onDelete: (number) => void,
-  onEdit: (number) => void,
-  onSave: (number, CustomFile) => void
-}, {
-  fileSource: 'raw' | 'uri',
-  model: CustomFile
-}> {
-  constructor (props) {
-    super(props)
-    const { customFile } = props
-    this.state = {
-      fileSource: customFile.contents ? 'raw' : 'uri',
-      model: props.customFile
-    }
-  }
-
-  _onChangeBuildUse = () => {
-    const { model } = this.state
-    this.setState({
-      model: {
-        ...model,
-        useDuringBuild: !model.useDuringBuild
-      }
-    })
-  }
-
-  _onChangeContents = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    this.setState({
-      model: {
-        ...this.state.model,
-        contents: evt.target.value
-      }
-    })
-  }
-
-  _onChangeFilename = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    this.setState({
-      model: {
-        ...this.state.model,
-        filename: evt.target.value
-      }
-    })
-  }
-
-  _onChangeServeUse = () => {
-    const { model } = this.state
-    this.setState({
-      model: {
-        ...model,
-        useDuringServe: !model.useDuringServe
-      }
-    })
-  }
-
-  _onChangeSource = (evt: SyntheticInputEvent<HTMLSelectElement>) => {
-    const model = {...this.state.model}
-    // set variable to make flow happy
-    let newSource
-    if (evt.target.value === 'raw') {
-      model.uri = null
-      newSource = 'raw'
-    } else {
-      model.contents = null
-      newSource = 'uri'
-    }
-    this.setState({
-      fileSource: newSource,
-      model
-    })
-  }
-
-  _onChangeUri = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    this.setState({
-      model: {
-        ...this.state.model,
-        uri: evt.target.value
-      }
-    })
-  }
-
-  _onCancelEditing = () => {
-    const { customFile, onCancelEditing } = this.props
-    this.setState({
-      fileSource: customFile.contents ? 'raw' : 'uri',
-      model: customFile
-    })
-    onCancelEditing()
-  }
-
-  _onDelete = () => {
-    const { idx, onDelete } = this.props
-    onDelete(idx)
-  }
-
-  _onEdit = () => {
-    const { idx, onEdit } = this.props
-    onEdit(idx)
-  }
-
-  _onSave = () => {
-    const { idx, onSave } = this.props
-    onSave(idx, this.state.model)
-  }
-
-  render () {
-    const {
-      customFileEditIdx,
-      idx
-    } = this.props
-    const {
-      fileSource,
-      model: customFile
-    } = this.state
-    const isValid = customFile.contents || customFile.uri
-    const isEditing = idx === customFileEditIdx
-    const canEdit = customFileEditIdx === null
-
-    return (
-      <div className='custom-file'>
-        <ButtonGroup>
-          {isEditing && (
-            <Button
-              disabled={!isValid}
-              onClick={this._onSave}
-            >
-              Save
-            </Button>
-          )}
-          {isEditing && <Button onClick={this._onCancelEditing}>Cancel</Button>}
-          {canEdit && <Button onClick={this._onEdit}>Edit</Button>}
-          {canEdit && <Button onClick={this._onDelete}>Delete</Button>}
-        </ButtonGroup>
-        <FormControl
-          disabled={!isEditing}
-          onChange={this._onChangeFilename}
-          placeholder='Enter filename'
-          type='text'
-          value={customFile.filename}
-        />
-        <Checkbox
-          checked={customFile.useDuringBuild}
-          disabled={!isEditing}
-          onChange={this._onChangeBuildUse}
-        >
-          Use during graph build
-        </Checkbox>
-        <Checkbox
-          checked={customFile.useDuringServe}
-          disabled={!isEditing}
-          onChange={this._onChangeServeUse}
-        >
-          Use while running server
-        </Checkbox>
-        <FormGroup validationState={isValid ? null : 'error'}>
-          <ControlLabel>File source</ControlLabel>
-          <FormControl
-            componentClass='select'
-            disabled={!isEditing}
-            onChange={this._onChangeSource}
-            placeholder='select type'
-            style={{ marginBottom: 5 }}
-            value={fileSource}
-          >
-            <option value='raw'>From raw input</option>
-            <option value='uri'>Download from URI</option>
-          </FormControl>
-          {!isValid && <HelpBlock>Please set contents or uri!</HelpBlock>}
-          {fileSource === 'raw' && (
-            <FormControl
-              componentClass='textarea'
-              disabled={!isEditing}
-              style={{height: '125px'}}
-              placeholder='{"blah": true}'
-              onChange={this._onChangeContents}
-              value={customFile.contents}
-            />
-          )}
-          {fileSource === 'uri' && (
-            <span>
-              <FormControl
-                disabled={!isEditing}
-                placeholder='https://www.examle.com/file.json'
-                onChange={this._onChangeUri}
-                type='text'
-                value={customFile.uri}
-              />
-              {!customFile.uri && (
-                <HelpBlock>Enter either a HTTP(S) URL or AWS S3 URI</HelpBlock>
-              )}
-            </span>
-          )}
-        </FormGroup>
       </div>
     )
   }

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -28,30 +28,30 @@ import Select from 'react-select'
 import fetch from 'isomorphic-fetch'
 import validator from 'validator'
 
-import * as deploymentActions from '../actions/deployments'
-import Loading from '../../common/components/Loading'
-import EditableTextField from '../../common/components/EditableTextField'
-import Title from '../../common/components/Title'
-import WatchButton from '../../common/containers/WatchButton'
-import {getComponentMessages, getConfigProperty} from '../../common/util/config'
-import {formatTimestamp, fromNow} from '../../common/util/date-time'
-import {isValidJSONC} from '../../common/util/json'
-import {defaultTileLayerProps} from '../../common/util/maps'
-import { versionsSorter } from '../../common/util/util'
-import {getServerDeployedTo} from '../util/deployment'
+import * as deploymentActions from '../../actions/deployments'
+import Loading from '../../../common/components/Loading'
+import EditableTextField from '../../../common/components/EditableTextField'
+import Title from '../../../common/components/Title'
+import WatchButton from '../../../common/containers/WatchButton'
+import {getComponentMessages, getConfigProperty} from '../../../common/util/config'
+import {formatTimestamp, fromNow} from '../../../common/util/date-time'
+import {isValidJSONC} from '../../../common/util/json'
+import {defaultTileLayerProps} from '../../../common/util/maps'
+import { versionsSorter } from '../../../common/util/util'
+import {getServerDeployedTo} from '../../util/deployment'
 import CurrentDeploymentPanel from './CurrentDeploymentPanel'
 import DeploymentConfirmModal from './DeploymentConfirmModal'
 import DeploymentVersionsTable from './DeploymentVersionsTable'
 
-import type {Props as ContainerProps} from '../containers/ActiveDeploymentViewer'
+import type {Props as ContainerProps} from '../../containers/ActiveDeploymentViewer'
 import type {
   CustomFile,
   Deployment,
   ReactSelectOption,
   ServerJob,
   SummarizedFeedVersion
-} from '../../types'
-import type {ManagerUserState} from '../../types/reducers'
+} from '../../../types'
+import type {ManagerUserState} from '../../../types/reducers'
 
 type Props = ContainerProps & {
   addFeedVersion: typeof deploymentActions.addFeedVersion,

--- a/lib/manager/components/deployment/DeploymentsPanel.js
+++ b/lib/manager/components/deployment/DeploymentsPanel.js
@@ -15,19 +15,19 @@ import {
   Panel
 } from 'react-bootstrap'
 
-import * as deploymentActions from '../actions/deployments'
-import * as feedsActions from '../actions/feeds'
-import * as projectsActions from '../actions/projects'
-import ActiveDeploymentViewer from '../containers/ActiveDeploymentViewer'
-import ConfirmModal from '../../common/components/ConfirmModal'
-import EditableTextField from '../../common/components/EditableTextField'
-import Loading from '../../common/components/Loading'
-import {getComponentMessages} from '../../common/util/config'
-import {formatTimestamp, fromNow} from '../../common/util/date-time'
-import {getServerDeployedTo} from '../util/deployment'
+import * as deploymentActions from '../../actions/deployments'
+import * as feedsActions from '../../actions/feeds'
+import * as projectsActions from '../../actions/projects'
+import ActiveDeploymentViewer from '../../containers/ActiveDeploymentViewer'
+import ConfirmModal from '../../../common/components/ConfirmModal'
+import EditableTextField from '../../../common/components/EditableTextField'
+import Loading from '../../../common/components/Loading'
+import {getComponentMessages} from '../../../common/util/config'
+import {formatTimestamp, fromNow} from '../../../common/util/date-time'
+import {getServerDeployedTo} from '../../util/deployment'
 
-import type {Props as ContainerProps} from '../containers/DeploymentsPanel'
-import type {Deployment, Project} from '../../types'
+import type {Props as ContainerProps} from '../../containers/DeploymentsPanel'
+import type {Deployment, Project} from '../../../types'
 
 type Props = ContainerProps & {
   createDeployment: typeof deploymentActions.createDeployment,

--- a/lib/manager/components/version/FeedVersionNavigator.js
+++ b/lib/manager/components/version/FeedVersionNavigator.js
@@ -16,7 +16,7 @@ import {isValidZipFile} from '../../../common/util/util'
 import * as snapshotActions from '../../../editor/actions/snapshots'
 import * as gtfsPlusActions from '../../../gtfsplus/actions/gtfsplus'
 import * as deploymentActions from '../../../manager/actions/deployments'
-import DeploymentPreviewButton from '../DeploymentPreviewButton'
+import DeploymentPreviewButton from '../deployment/DeploymentPreviewButton'
 import FeedVersionViewer from './FeedVersionViewer'
 import VersionSelectorDropdown from './VersionSelectorDropdown'
 

--- a/lib/manager/containers/ActiveDeploymentViewer.js
+++ b/lib/manager/containers/ActiveDeploymentViewer.js
@@ -13,7 +13,7 @@ import {
   updateDeployment,
   updateVersionForFeedSource
 } from '../actions/deployments'
-import DeploymentViewer from '../components/DeploymentViewer'
+import DeploymentViewer from '../components/deployment/DeploymentViewer'
 
 import type {Deployment, Feed, Project} from '../../types'
 import type {AppState} from '../../types/reducers'

--- a/lib/manager/containers/DeploymentsPanel.js
+++ b/lib/manager/containers/DeploymentsPanel.js
@@ -11,7 +11,7 @@ import {
   deleteDeployment,
   updateDeployment
 } from '../actions/deployments'
-import DeploymentsPanel from '../components/DeploymentsPanel'
+import DeploymentsPanel from '../components/deployment/DeploymentsPanel'
 
 import type {Project} from '../../types'
 import type {AppState} from '../../types/reducers'


### PR DESCRIPTION
This PR contains changes for #638. Primarily, it just breaks out the massive DeploymentViewer file into single component files. It also tweaks the styling/layout for custom file button toolbar.

I had considered possibly consolidating code that handles custom router/build config with the custom files, but there didn't seem to be a good way.