### PR TITLE
Navigate to latest feed version after processing complete

### DIFF
--- a/lib/manager/actions/feeds.js
+++ b/lib/manager/actions/feeds.js
@@ -141,14 +141,6 @@ export function fetchFeedSource (feedSourceId: string) {
         dispatch(fetchRelatedTables(feedSource))
         return feedSource
       })
-      .then(() => {
-        // If viewing a particular feed, navigate to a new feed version as soon as it becomes available.
-        // (If user is not looking at this feed, don't navigate away from their current page.)
-        const newVersionPath = `/feed/${feedSourceId}`
-        if (browserHistory.getCurrentLocation().pathname.startsWith(`${newVersionPath}/version/`)) {
-          browserHistory.push(newVersionPath)
-        }
-      })
   }
 }
 

--- a/lib/manager/actions/feeds.js
+++ b/lib/manager/actions/feeds.js
@@ -141,6 +141,14 @@ export function fetchFeedSource (feedSourceId: string) {
         dispatch(fetchRelatedTables(feedSource))
         return feedSource
       })
+      .then(() => {
+        // If viewing a particular feed, navigate to a new feed version as soon as it becomes available.
+        // (If user is not looking at this feed, don't navigate away from their current page.)
+        const newVersionPath = `/feed/${feedSourceId}`
+        if (browserHistory.getCurrentLocation().pathname.startsWith(`${newVersionPath}/version/`)) {
+          browserHistory.push(newVersionPath)
+        }
+      })
   }
 }
 

--- a/lib/manager/actions/status.js
+++ b/lib/manager/actions/status.js
@@ -1,6 +1,7 @@
 // @flow
 
 import moment from 'moment'
+import { browserHistory } from 'react-router'
 import { createAction, type ActionType } from 'redux-actions'
 
 import { createVoidPayloadAction, secureFetch } from '../../common/actions'
@@ -256,6 +257,17 @@ export function handleFinishedJob (job: ServerJob) {
           if (result) {
             const modalContent = getMergeFeedModalContent(result)
             dispatch(setStatusModal(modalContent))
+          }
+        }
+        break
+      case 'PROCESS_FEED':
+        // If viewing a particular feed, navigate to a new feed version as soon as it becomes available.
+        // It is the same path (without version number) as the link shown for this job status.
+        // (If user is not looking at this feed, don't navigate away from their current page.)
+        if (job.feedSourceId) {
+          const newVersionPath = `/feed/${job.feedSourceId}`
+          if (browserHistory.getCurrentLocation().pathname.startsWith(newVersionPath)) {
+            browserHistory.push(newVersionPath)
           }
         }
         break

--- a/lib/manager/actions/status.js
+++ b/lib/manager/actions/status.js
@@ -260,17 +260,6 @@ export function handleFinishedJob (job: ServerJob) {
           }
         }
         break
-      case 'PROCESS_FEED':
-        // If viewing a particular feed, navigate to a new feed version as soon as it becomes available.
-        // It is the same path (without version number) as the link shown for this job status.
-        // (If user is not looking at this feed, don't navigate away from their current page.)
-        if (job.feedSourceId) {
-          const newVersionPath = `/feed/${job.feedSourceId}`
-          if (browserHistory.getCurrentLocation().pathname.startsWith(newVersionPath)) {
-            browserHistory.push(newVersionPath)
-          }
-        }
-        break
       default:
         console.warn(`No completion step defined for job type ${job.type}`)
         break

--- a/lib/manager/actions/status.js
+++ b/lib/manager/actions/status.js
@@ -260,6 +260,17 @@ export function handleFinishedJob (job: ServerJob) {
           }
         }
         break
+      case 'PROCESS_FEED':
+        // If viewing a particular feed, navigate to a new feed version as soon as it becomes available.
+        // It is the same path (without version number) as the link shown for this job status.
+        // (If user is not looking at this feed, don't navigate away from their current page.)
+        if (job.feedSourceId) {
+          const newVersionPath = `/feed/${job.feedSourceId}`
+          if (browserHistory.getCurrentLocation().pathname.startsWith(newVersionPath)) {
+            browserHistory.push(newVersionPath)
+          }
+        }
+        break
       default:
         console.warn(`No completion step defined for job type ${job.type}`)
         break

--- a/lib/manager/actions/status.js
+++ b/lib/manager/actions/status.js
@@ -12,7 +12,7 @@ import { fetchFeedSource } from './feeds'
 import { fetchProjectWithFeeds } from './projects'
 import { downloadSnapshotViaCredentials } from '../../editor/actions/snapshots'
 
-import type {DataToolsConfig, MergeFeedsResult, ServerJob} from '../../types'
+import type {DataToolsConfig, Feed, MergeFeedsResult, ServerJob} from '../../types'
 import type {dispatchFn, getStateFn} from '../../types/reducers'
 
 type ErrorMessage = {
@@ -191,6 +191,15 @@ export function handleFinishedJob (job: ServerJob) {
           return
         }
         dispatch(fetchFeedSource(job.feedSourceId))
+          .then((feedSource: Feed) => {
+            // If viewing a particular feed, navigate to a new feed version as soon as it becomes available.
+            // (If user is not looking at this feed, don't navigate away from their current page.)
+            const newVersionPath = `/feed/${feedSource.id}`
+            if (browserHistory.getCurrentLocation().pathname.startsWith(`${newVersionPath}/version/`)) {
+              browserHistory.push(newVersionPath)
+            }
+          })
+
         if (isExtensionEnabled('mtc')) {
           const firstDate = job.validationResult && job.validationResult.firstCalendarDate
           const now = moment().startOf('day')
@@ -257,17 +266,6 @@ export function handleFinishedJob (job: ServerJob) {
           if (result) {
             const modalContent = getMergeFeedModalContent(result)
             dispatch(setStatusModal(modalContent))
-          }
-        }
-        break
-      case 'PROCESS_FEED':
-        // If viewing a particular feed, navigate to a new feed version as soon as it becomes available.
-        // It is the same path (without version number) as the link shown for this job status.
-        // (If user is not looking at this feed, don't navigate away from their current page.)
-        if (job.feedSourceId) {
-          const newVersionPath = `/feed/${job.feedSourceId}`
-          if (browserHistory.getCurrentLocation().pathname.startsWith(newVersionPath)) {
-            browserHistory.push(newVersionPath)
           }
         }
         break

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -162,7 +162,7 @@ export function publishFeedVersion (feedVersion: FeedVersion) {
 }
 
 /**
- * Merges two feed versions according to the strategy defined within the
+ * Merges two feed versions according to the strategy defined by the mergeType parameter.
  */
 export function mergeVersions (targetVersionId: string, versionId: string, mergeType: 'SERVICE_PERIOD' | 'REGIONAL') {
   return function (dispatch: dispatchFn, getState: getStateFn) {


### PR DESCRIPTION
### Checklist

- [X] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [X] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [X] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

This PR fixes #643.

Under the hood, the PR changes job handling so that if viewing a particular feed, datatools navigates to a new feed version when that version's processing is complete. Hopefully that does not create undesired side effects.


