### PR TITLE
fix mkdocs on GitHub Actions

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install mkdocs
-        run: pip install mkdocs
+        run: |
+          pip install mkdocs
+          mkdocs --version
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install mkdocs
         run: |
+          python -m pip install --upgrade pip
           pip install mkdocs
           mkdocs --version
       - name: Use Node.js 12.x

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -25,6 +25,7 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v2
+      # install python 3.x in order to have mkdocs properly installed
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -25,9 +25,11 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
       - name: Install mkdocs
         run: |
-          python -m pip install --upgrade pip
           pip install mkdocs
           mkdocs --version
       - name: Use Node.js 12.x


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

For some unknown reason, mkdocs stopped working on the GitHub Actions runs. This PR fixes that by setting up Python properly as recommended [here](https://github.com/ibi-group/datatools-ui/).