### PR TITLE
Grab deployment that is actively deployed

### DIFF
--- a/lib/manager/components/deployment/DeploymentConfigurationsPanel.js
+++ b/lib/manager/components/deployment/DeploymentConfigurationsPanel.js
@@ -163,8 +163,6 @@ export default class DeploymentConfigurationsPanel extends Component<{
   render () {
     const { deployment, updateDeployment } = this.props
     const { customFileEditIdx, otp: options } = this.state
-    const isOtp = deployment.tripPlannerVersion.startsWith('OTP_')
-
     return (
       <Panel header={<h3><Icon type='cog' /> OTP Configuration</h3>}>
         <ListGroup fill>
@@ -182,17 +180,15 @@ export default class DeploymentConfigurationsPanel extends Component<{
               onChange={this._onUpdateTripPlannerVersion}
               options={TRIP_PLANNER_VERSIONS}
             />
-            {isOtp && (
-              <div>
-                OTP jar file
-                <Select
-                  clearable={false}
-                  value={deployment.otpVersion}
-                  onChange={this._onUpdateVersion}
-                  options={options ? options.map(v => ({value: v, label: v})) : []}
-                />
-              </div>
-            )}
+            <div>
+              OTP jar file
+              <Select
+                clearable={false}
+                value={deployment.otpVersion}
+                onChange={this._onUpdateVersion}
+                options={options ? options.map(v => ({value: v, label: v})) : []}
+              />
+            </div>
           </ListGroupItem>
           <ListGroupItem>
             Deploying to the{' '}

--- a/lib/manager/components/version/FeedVersionNavigator.js
+++ b/lib/manager/components/version/FeedVersionNavigator.js
@@ -161,10 +161,15 @@ export default class FeedVersionNavigator extends Component<Props, State> {
       version,
       versionSection
     } = this.props
+    // Grab the feed-source-specific deployment that is both actively deployed
+    // and contains the selected version's GTFS.
     const deploymentForVersion =
       version &&
       feedSource.deployments &&
-      feedSource.deployments.find(d => d.feedVersions.findIndex(v => v.id === version.id) !== -1)
+      feedSource.deployments.find(d =>
+        d.deployedTo &&
+        d.feedVersions.findIndex(v => v.id === version.id) !== -1
+      )
     const dropdownTitle = `${this.messages('version')} ${feedVersionIndex} ${this.messages('of')} ${sortedVersions.length}`
     return (
       <div>

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -247,7 +247,7 @@ export type Deployment = {
   projectId: string,
   routerId: ?string,
   skipOsmExtract: boolean,
-  tripPlannerVersion: 'OTP_1' | 'OTP_2',
+  tripPlannerVersion?: 'OTP_1' | 'OTP_2',
   user: ?any // TODO add more specific type
 }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #665 by isolating the feed version that is actively deployed. Previously, there could be multiple deployments for that feed version and one which was not active was interfering.