### PR TITLE
fix(DeploymentsPanel): Exclude deployments where deployedTo is null.

### DIFF
--- a/lib/manager/components/deployment/DeploymentsPanel.js
+++ b/lib/manager/components/deployment/DeploymentsPanel.js
@@ -62,8 +62,11 @@ export default class DeploymentsPanel extends Component<Props> {
       updateDeployment,
       updateProject
     } = this.props
-    const deployment = project.deployments &&
-      project.deployments.find(d => d.id && d.id === deploymentId)
+    // Grab the feed-source-specific deployment that is both actively deployed.
+    const deployment = project.deployments && project.deployments.find(d =>
+      d.deployedTo &&
+      d.id && d.id === deploymentId
+    )
     if (deployment) {
       return (
         <ActiveDeploymentViewer


### PR DESCRIPTION
### Checklist
- [X] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [X] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [na] All tests and CI builds passing

### Description

Fix to #666 in response to the `Deploy` button not working in the feed version navigator. Uses similar logic than for displaying the `Preview` button in the feed version navigator.
