### PR TITLE
Add feedback for invalid substitution patterns.

### DIFF
--- a/lib/manager/components/transform/NormalizeField.js
+++ b/lib/manager/components/transform/NormalizeField.js
@@ -1,6 +1,7 @@
 // @flow
 
 import Icon from '@conveyal/woonerf/components/icon'
+import { isEqual } from 'lodash'
 import React, { Component } from 'react'
 import {
   Button,
@@ -24,7 +25,33 @@ import type {
 } from '../../../types'
 
 type State = {
-  activeEditingIndex: number
+  activeEditingIndex: number,
+  // Holds the contents that should be shown in the SubstitutionRow component.
+  activeSubstitution: ?Substitution,
+  // Last edited contents.
+  previousEditingIndex: number,
+  previousSubstitution: ?Substitution
+}
+
+/**
+ * Determines whether two substitutions are equal (except for the valid field).
+ */
+function areEqual (sub1: ?Substitution, sub2: ?Substitution): boolean {
+  if (!sub1 || !sub2) return false
+  return isEqual(
+    {
+      description: sub1.description,
+      normalizeSpace: sub1.normalizeSpace,
+      pattern: sub1.pattern,
+      replacement: sub1.replacement
+    },
+    {
+      description: sub2.description,
+      normalizeSpace: sub2.normalizeSpace,
+      pattern: sub2.pattern,
+      replacement: sub2.replacement
+    }
+  )
 }
 
 /**
@@ -32,7 +59,10 @@ type State = {
  */
 export default class NormalizeField extends Component<TransformProps<NormalizeFieldFields>, State> {
   state = {
-    activeEditingIndex: -1
+    activeEditingIndex: -1,
+    activeSubstitution: null,
+    previousEditingIndex: -1,
+    previousSubstitution: null
   }
 
   componentDidMount () {
@@ -42,6 +72,21 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
   componentDidUpdate (prevProps: TransformProps<NormalizeFieldFields>) {
     if (prevProps.transformation !== this.props.transformation) {
       this._updateErrors()
+
+      // If user entered an invalid substitution pattern and clicks save,
+      // it will be rejected and the values entered will be lost.
+      // To avoid that, keep the new row visible and in editing state.
+      const { previousEditingIndex, previousSubstitution: editedSubstitution } = this.state
+      const loadedSubstitution = this.props.transformation.substitutions[previousEditingIndex]
+      if (previousEditingIndex !== -1 && !areEqual(editedSubstitution, loadedSubstitution)) {
+        this.setState({
+          activeEditingIndex: previousEditingIndex,
+          activeSubstitution: {
+            ...editedSubstitution,
+            valid: false
+          }
+        })
+      }
     }
   }
 
@@ -60,12 +105,17 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
   _onChangeSubstitution = (substitution: Substitution, index: number) => {
     const newSubstitutions = [].concat(this.props.transformation.substitutions)
     newSubstitutions[index] = substitution
+    this.setState({
+      activeSubstitution: null,
+      previousSubstitution: substitution
+    })
     this._updateTransformation({substitutions: newSubstitutions})
   }
 
   _onRemoveSubstitution = (index: number) => {
     const newSubstitutions = [].concat(this.props.transformation.substitutions)
     newSubstitutions.splice(index, 1)
+    this.setState({ previousEditingIndex: -1 })
     this._updateTransformation({substitutions: newSubstitutions})
   }
 
@@ -101,7 +151,11 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
   }
 
   _onEndEditSubstitution = () => {
-    this.setState({ activeEditingIndex: -1 })
+    this.setState({
+      activeEditingIndex: -1,
+      activeSubstitution: null,
+      previousEditingIndex: this.state.activeEditingIndex
+    })
   }
 
   /**
@@ -129,7 +183,7 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
 
   render () {
     const { index, transformation } = this.props
-    const { activeEditingIndex } = this.state
+    const { activeEditingIndex, activeSubstitution } = this.state
     const {
       capitalizationExceptions,
       capitalize,
@@ -233,7 +287,7 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
                 onChange={this._onChangeSubstitution}
                 onEndEdit={this._onEndEditSubstitution}
                 onRemove={this._onRemoveSubstitution}
-                substitution={s}
+                substitution={activeEditingIndex === i ? (activeSubstitution || s) : s}
               />
             ))}
             {activeEditingIndex === substitutions.length &&
@@ -244,10 +298,10 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
                 key={activeEditingIndex}
                 onChange={this._onChangeSubstitution}
                 onEndEdit={this._onEndEditSubstitution}
-                substitution={{
-                  invalid: false,
+                substitution={activeSubstitution || {
                   pattern: '',
-                  replacement: ''
+                  replacement: '',
+                  valid: true
                 }}
               />
             }

--- a/lib/manager/components/transform/NormalizeField.js
+++ b/lib/manager/components/transform/NormalizeField.js
@@ -14,7 +14,7 @@ import {
 import Select from 'react-select'
 
 import GtfsFieldSelector from '../GtfsFieldSelector'
-import SubstitutionRow, { isSubstitutionInvalid } from './SubstitutionRow'
+import SubstitutionRow, { isSubstitutionBlank, isSubstitutionInvalid } from './SubstitutionRow'
 
 import type {
   NormalizeFieldFields,
@@ -37,6 +37,12 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
 
   componentDidMount () {
     this._updateErrors()
+  }
+
+  componentDidUpdate (prevProps: TransformProps<NormalizeFieldFields>) {
+    if (prevProps.transformation !== this.props.transformation) {
+      this._updateErrors()
+    }
   }
 
   _onChangeFieldToNormalize = (fieldOption: ReactSelectOption) => {
@@ -70,6 +76,7 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
   _getValidationErrors (fields: NormalizeFieldFields): Array<string> {
     const issues = []
     const { fieldName } = fields
+    const { substitutions } = this.props.transformation
 
     // fieldName must be defined.
     if (!fieldName || fieldName.length === 0) {
@@ -77,8 +84,13 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
     }
 
     // The pattern for substitutions must not be null or empty.
-    if (this.props.transformation.substitutions.filter(isSubstitutionInvalid).length > 0) {
+    if (substitutions.filter(isSubstitutionBlank).length > 0) {
       issues.push('Substitution patterns must be defined.')
+    }
+
+    // The pattern for substitutions must be valid.
+    if (substitutions.filter(isSubstitutionInvalid).length > 0) {
+      issues.push('Some substitution patterns are invalid.')
     }
 
     return issues
@@ -233,6 +245,7 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
                 onChange={this._onChangeSubstitution}
                 onEndEdit={this._onEndEditSubstitution}
                 substitution={{
+                  invalid: false,
                   pattern: '',
                   replacement: ''
                 }}

--- a/lib/manager/components/transform/NormalizeField.js
+++ b/lib/manager/components/transform/NormalizeField.js
@@ -15,7 +15,8 @@ import {
 import Select from 'react-select'
 
 import GtfsFieldSelector from '../GtfsFieldSelector'
-import SubstitutionRow, { isSubstitutionBlank, isSubstitutionInvalid } from './SubstitutionRow'
+import SubstitutionRow from './SubstitutionRow'
+import { isSubstitutionBlank, isSubstitutionInvalid } from '../../util/transform'
 
 import type {
   NormalizeFieldFields,
@@ -36,7 +37,7 @@ type State = {
 /**
  * Determines whether two substitutions are equal (except for the valid field).
  */
-function areEqual (sub1: ?Substitution, sub2: ?Substitution): boolean {
+function areSubstitutionsEqual (sub1: ?Substitution, sub2: ?Substitution): boolean {
   if (!sub1 || !sub2) return false
   return isEqual(
     {
@@ -78,7 +79,7 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
       // To avoid that, keep the new row visible and in editing state.
       const { previousEditingIndex, previousSubstitution: editedSubstitution } = this.state
       const loadedSubstitution = this.props.transformation.substitutions[previousEditingIndex]
-      if (previousEditingIndex !== -1 && !areEqual(editedSubstitution, loadedSubstitution)) {
+      if (previousEditingIndex !== -1 && !areSubstitutionsEqual(editedSubstitution, loadedSubstitution)) {
         this.setState({
           activeEditingIndex: previousEditingIndex,
           activeSubstitution: {

--- a/lib/manager/components/transform/SubstitutionRow.js
+++ b/lib/manager/components/transform/SubstitutionRow.js
@@ -29,9 +29,10 @@ const buttonGroupStyle = { width: '60px' }
  * Extract just the subset of fields to build the state variable.
  */
 function extractStateFields (props: Props): Substitution {
-  const { description, normalizeSpace, pattern, replacement } = props.substitution
+  const { description, invalid, normalizeSpace, pattern, replacement } = props.substitution
   return {
     description: description || '',
+    invalid,
     normalizeSpace,
     pattern,
     replacement
@@ -41,8 +42,15 @@ function extractStateFields (props: Props): Substitution {
 /**
  * @returns true if the given substitution pattern is null or empty, false otherwise.
  */
-export function isSubstitutionInvalid (substitution: Substitution) {
+export function isSubstitutionBlank (substitution: Substitution) {
   return !substitution.pattern || substitution.pattern === ''
+}
+
+/**
+ * @returns true if the given substitution is marked invalid by the backend, false otherwise.
+ */
+export function isSubstitutionInvalid (substitution: Substitution) {
+  return substitution.invalid
 }
 
 /**
@@ -137,17 +145,28 @@ export default class SubstitutionRow extends Component<Props, Substitution> {
   }
 
   render () {
-    const { activeEditingIndex } = this.props
-    const { description, normalizeSpace, pattern, replacement } = this.state
+    const { activeEditingIndex, substitution: originalSubstitution } = this.props
+    const { description, invalid, normalizeSpace, pattern, replacement } = this.state
     const regexTestLink = `https://regexr.com/?expression=${encodeURIComponent(pattern)}&text=${STRING_FOR_REGEXR_TEST}`
     const isEditing = this._isEditing()
     const allowEdit = activeEditingIndex === -1
-    const isEditingInvalid = isSubstitutionInvalid(this.state)
+    const isPatternBlank = isSubstitutionBlank(this.state)
+    const isPatternInvalid = invalid && pattern === originalSubstitution.pattern
+    const isEditingInvalid = isPatternBlank || isPatternInvalid
+    let validationMessage = null
+    if (isPatternBlank) {
+      validationMessage = 'The substitution search pattern cannot be empty'
+    } else if (isPatternInvalid) {
+      validationMessage = `The substitution search pattern '${originalSubstitution.pattern}' is invalid`
+    }
 
     // Construct CSS class for row
     const editingClassName = isEditing ? '' : 'inactive'
     const allowEditClassName = allowEdit ? 'allow-edit' : ''
     const rowClassName = `substitution-row ${editingClassName} ${allowEditClassName}`
+
+    // Override style for inputs with invalid search patterns.
+    const patternStyleOverride = isPatternInvalid ? { borderColor: 'inherit' } : null
 
     return (
       <tr className={rowClassName}>
@@ -163,10 +182,11 @@ export default class SubstitutionRow extends Component<Props, Substitution> {
                 onKeyDown={this._onKeyDown}
                 placeholder='Text (regex) to find'
                 readOnly={!isEditing}
-                title={isEditingInvalid ? 'Substitution search pattern cannot be empty' : null}
+                style={patternStyleOverride}
+                title={validationMessage}
                 value={pattern}
               />
-              <InputGroup.Addon>
+              <InputGroup.Addon style={patternStyleOverride}>
                 <a
                   href={regexTestLink}
                   target='_blank'
@@ -217,9 +237,9 @@ export default class SubstitutionRow extends Component<Props, Substitution> {
               <ButtonGroup style={buttonGroupStyle}>
                 <Button
                   bsSize='xsmall'
-                  disabled={isEditingInvalid}
+                  disabled={isPatternInvalid}
                   onClick={this._onClickSave}
-                  title={isEditingInvalid ? 'Unable to save, there are errors in this row.' : 'Save changes in this row'}
+                  title={isPatternInvalid ? 'Unable to save, there are errors in this row.' : 'Save changes in this row'}
                 >
                   <Icon type='check' />
                 </Button>

--- a/lib/manager/components/transform/SubstitutionRow.js
+++ b/lib/manager/components/transform/SubstitutionRow.js
@@ -5,6 +5,8 @@ import { isEqual } from 'lodash'
 import React, { Component } from 'react'
 import { Button, ButtonGroup, FormControl, FormGroup, InputGroup } from 'react-bootstrap'
 
+import { isSubstitutionBlank } from '../../util/transform'
+
 import type {
   Substitution
 } from '../../../types'
@@ -37,20 +39,6 @@ function extractStateFields (props: Props): Substitution {
     replacement,
     valid
   }
-}
-
-/**
- * @returns true if the given substitution pattern is null or empty, false otherwise.
- */
-export function isSubstitutionBlank (substitution: Substitution) {
-  return !substitution.pattern || substitution.pattern === ''
-}
-
-/**
- * @returns true if the given substitution is marked invalid by the backend, false otherwise.
- */
-export function isSubstitutionInvalid (substitution: Substitution) {
-  return !substitution.valid
 }
 
 /**

--- a/lib/manager/components/transform/SubstitutionRow.js
+++ b/lib/manager/components/transform/SubstitutionRow.js
@@ -29,13 +29,13 @@ const buttonGroupStyle = { width: '60px' }
  * Extract just the subset of fields to build the state variable.
  */
 function extractStateFields (props: Props): Substitution {
-  const { description, invalid, normalizeSpace, pattern, replacement } = props.substitution
+  const { description, normalizeSpace, pattern, replacement, valid } = props.substitution
   return {
     description: description || '',
-    invalid,
-    normalizeSpace,
+    normalizeSpace: normalizeSpace || false,
     pattern,
-    replacement
+    replacement,
+    valid
   }
 }
 
@@ -50,7 +50,7 @@ export function isSubstitutionBlank (substitution: Substitution) {
  * @returns true if the given substitution is marked invalid by the backend, false otherwise.
  */
 export function isSubstitutionInvalid (substitution: Substitution) {
-  return substitution.invalid
+  return !substitution.valid
 }
 
 /**
@@ -66,7 +66,7 @@ export default class SubstitutionRow extends Component<Props, Substitution> {
     const { index, substitution } = this.props
 
     // If a new substition is associated with this component, reset its state.
-    if (prevProps.index !== index || !isEqual(prevProps.substitution, substitution)) {
+    if (prevProps.index !== index || prevProps.substitution !== substitution) {
       this.setState(extractStateFields(this.props))
     }
   }
@@ -146,12 +146,12 @@ export default class SubstitutionRow extends Component<Props, Substitution> {
 
   render () {
     const { activeEditingIndex, substitution: originalSubstitution } = this.props
-    const { description, invalid, normalizeSpace, pattern, replacement } = this.state
+    const { description, normalizeSpace, pattern, replacement, valid } = this.state
     const regexTestLink = `https://regexr.com/?expression=${encodeURIComponent(pattern)}&text=${STRING_FOR_REGEXR_TEST}`
     const isEditing = this._isEditing()
     const allowEdit = activeEditingIndex === -1
     const isPatternBlank = isSubstitutionBlank(this.state)
-    const isPatternInvalid = invalid && pattern === originalSubstitution.pattern
+    const isPatternInvalid = !valid && pattern === originalSubstitution.pattern
     const isEditingInvalid = isPatternBlank || isPatternInvalid
     let validationMessage = null
     if (isPatternBlank) {
@@ -166,7 +166,7 @@ export default class SubstitutionRow extends Component<Props, Substitution> {
     const rowClassName = `substitution-row ${editingClassName} ${allowEditClassName}`
 
     // Override style for inputs with invalid search patterns.
-    const patternStyleOverride = isPatternInvalid ? { borderColor: 'inherit' } : null
+    const patternStyleOverride = isPatternInvalid ? { borderColor: '#a94442' } : null
 
     return (
       <tr className={rowClassName}>

--- a/lib/manager/util/transform.js
+++ b/lib/manager/util/transform.js
@@ -3,7 +3,8 @@ import {getComponentMessages} from '../../common/util/config'
 
 import type {
   FeedTransformation,
-  FeedVersion
+  FeedVersion,
+  Substitution
 } from '../../types'
 
 /**
@@ -67,4 +68,18 @@ export function getTransformationPlaceholder (
   return message.indexOf(messageId) !== -1
     ? messages(`general.${placeholderId}`)
     : message
+}
+
+/**
+ * @returns true if the given substitution pattern is null or empty, false otherwise.
+ */
+export function isSubstitutionBlank (substitution: Substitution) {
+  return !substitution.pattern || substitution.pattern === ''
+}
+
+/**
+ * @returns true if the given substitution is marked invalid by the backend, false otherwise.
+ */
+export function isSubstitutionInvalid (substitution: Substitution) {
+  return !substitution.valid
 }

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -301,10 +301,10 @@ export type FetchFrequency = $Values<typeof FETCH_FREQUENCIES>
 
 export type Substitution = {
   description?: string,
-  invalid: boolean,
   normalizeSpace?: boolean,
   pattern: string,
-  replacement: string
+  replacement: string,
+  valid: boolean
 }
 
 export type NormalizeFieldFields = {

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -301,6 +301,7 @@ export type FetchFrequency = $Values<typeof FETCH_FREQUENCIES>
 
 export type Substitution = {
   description?: string,
+  invalid: boolean,
   normalizeSpace?: boolean,
   pattern: string,
   replacement: string


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Companion PR to https://github.com/ibi-group/datatools-server/pull/392 to address https://github.com/ibi-group/datatools-server/issues/391.

This PR adds UI feedback for invalid substitution patterns.

To test on configurations that enable Normalize Field Transformation:
1. Follow steps 1-3 from https://github.com/ibi-group/datatools-server/issues/391
2. ~After you enter the invalid substitution pattern~ EDIT for previously saved invalid substitutions, notice the feedback on the UI (see screenshot). Modify the incorrect substitution pattern to remove the red feedback box, and click the check mark to save the changes and observe the subsequent UI feedback.
3. EDIT Add a new/change a substitution with an invalid search pattern and click Save. Note the error dialog about the invalid pattern. The new/changed substitution row with the entered values will still be available with the same visual feedback.

![image](https://user-images.githubusercontent.com/56846598/122061519-96a6ed80-cdbc-11eb-9200-7ec70e32bcb7.png)

