### PR TITLE
Add optional admin-only visibility for notes

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -487,13 +487,16 @@ components:
     info: "Tip: when changing travel times, consider
     using the 'Normalize stop times' button above to automatically update
     all stop times to the updated travel time."
+  NoteForm:
+    adminOnly: 'Admin only?'
+    new: Post
+    postComment: Post a New Comment
   NotesViewer:
+    adminOnly: 'This message is visible to admins only.'
     all: All Comments
     feedSource: Feed Source
     feedVersion: Version
-    new: Post
     none: No comments.
-    postComment: Post a New Comment
     refresh: Refresh
     title: Comments
   OrganizationList:

--- a/lib/manager/components/NoteForm.js
+++ b/lib/manager/components/NoteForm.js
@@ -1,0 +1,103 @@
+// @flow
+
+import Icon from '@conveyal/woonerf/components/icon'
+import React, {Component} from 'react'
+import { Button, Checkbox, Col, FormControl, Media, Panel } from 'react-bootstrap'
+
+import {getComponentMessages} from '../../common/util/config'
+import { getProfileLink } from '../../common/util/util'
+import type {Feed} from '../../types'
+import type {ManagerUserState} from '../../types/reducers'
+
+type Props = {
+  feedSource: Feed,
+  newNotePosted: ({body: string}) => void,
+  stacked?: boolean,
+  user: ManagerUserState
+}
+
+type State = {
+  adminOnly: boolean,
+  body: string
+}
+
+const DEFAULT_STATE = {
+  adminOnly: false,
+  body: ''
+}
+
+export default class NoteForm extends Component<Props, State> {
+  messages = getComponentMessages('NoteForm')
+  state = DEFAULT_STATE
+
+  _onChange = ({target}: {target: HTMLInputElement}) =>
+    this.setState({[target.name]: target.type === 'checkbox' ? target.checked : target.value})
+
+  _onClickPublish = () => {
+    this.props.newNotePosted(this.state)
+    this.setState(DEFAULT_STATE)
+  }
+
+  render () {
+    const {
+      feedSource,
+      stacked,
+      user
+    } = this.props
+    const {Body, Heading, Left} = Media
+    const {adminOnly, body} = this.state
+    const {profile} = user
+    if (!profile) {
+      console.warn('Could not locate user profile', user)
+      return null
+    }
+    const isProjectAdmin = user.permissions && user.permissions.isProjectAdmin(
+      feedSource.projectId, feedSource.organizationId
+    )
+    const userLink = user
+      ? <a href={getProfileLink(profile.email)}>{profile.email}</a>
+      : 'Unknown user'
+    return (
+      <Col xs={12} sm={stacked ? 12 : 4} md={stacked ? 12 : 6}>
+        <h3>{this.messages('postComment')}</h3>
+        <Media>
+          <Left>
+            <img
+              alt={profile.email}
+              width={64}
+              height={64}
+              src={user ? profile.picture : ''} />
+          </Left>
+          <Body>
+            <Panel
+              className='comment-panel'
+              header={<Heading>{userLink}</Heading>}>
+              <FormControl
+                ref='newNoteBody'
+                componentClass='textarea'
+                name='body'
+                value={body}
+                onChange={this._onChange} />
+              <Button
+                className='pull-right'
+                style={{marginTop: '10px'}}
+                disabled={body === ''}
+                onClick={this._onClickPublish}>
+                {this.messages('new')}
+              </Button>
+              {isProjectAdmin &&
+                <Checkbox
+                  name='adminOnly'
+                  onChange={this._onChange}
+                  value={adminOnly}
+                >
+                  <Icon type='lock' /> {this.messages('adminOnly')}
+                </Checkbox>
+              }
+            </Panel>
+          </Body>
+        </Media>
+      </Col>
+    )
+  }
+}

--- a/lib/manager/components/NoteForm.js
+++ b/lib/manager/components/NoteForm.js
@@ -26,6 +26,10 @@ const DEFAULT_STATE = {
   body: ''
 }
 
+/**
+ * This component shows a form that allows a user to submit a note for either a
+ * feed source or feed version.
+ */
 export default class NoteForm extends Component<Props, State> {
   messages = getComponentMessages('NoteForm')
   state = DEFAULT_STATE
@@ -41,6 +45,7 @@ export default class NoteForm extends Component<Props, State> {
   }
 
   render () {
+    console.log(this.state)
     const {
       feedSource,
       stacked,
@@ -57,54 +62,56 @@ export default class NoteForm extends Component<Props, State> {
       feedSource.projectId, feedSource.organizationId
     )
     return (
-      <Col xs={12} sm={stacked ? 12 : 4} md={stacked ? 12 : 6}>
-        <h3>{this.messages('postComment')}</h3>
-        <Media>
-          <Left>
-            <img
-              alt={profile.email}
-              height={64}
-              width={64}
-              src={profile.picture} />
-          </Left>
-          <Body>
-            <Panel
-              className='comment-panel'
-              header={
-                <Heading>
-                  <a href={getProfileLink(profile.email)}>{profile.email}</a>
-                </Heading>
-              }
-            >
-              <FormControl
-                componentClass='textarea'
-                name='body'
-                ref='newNoteBody'
-                style={{resize: 'none'}}
-                onChange={this._onChange}
-                value={body} />
-              <Button
-                className='pull-right'
-                disabled={body === ''}
-                onClick={this._onClickPublish}
-                // Ensure button clicking is not obscured by checkbox.
-                style={{marginTop: '10px', position: 'relative', zIndex: 2}}
+      <form>
+        <Col xs={12} sm={stacked ? 12 : 4} md={stacked ? 12 : 6}>
+          <h3>{this.messages('postComment')}</h3>
+          <Media>
+            <Left>
+              <img
+                alt={profile.email}
+                height={64}
+                width={64}
+                src={profile.picture} />
+            </Left>
+            <Body>
+              <Panel
+                className='comment-panel'
+                header={
+                  <Heading>
+                    <a href={getProfileLink(profile.email)}>{profile.email}</a>
+                  </Heading>
+                }
               >
-                {this.messages('new')}
-              </Button>
-              {isProjectAdmin &&
-                <Checkbox
-                  name='adminOnly'
+                <FormControl
+                  componentClass='textarea'
+                  name='body'
+                  style={{resize: 'none'}}
                   onChange={this._onChange}
-                  value={adminOnly}
+                  value={body} />
+                <Button
+                  className='pull-right'
+                  disabled={body === ''}
+                  onClick={this._onClickPublish}
+                  // Ensure button clicking is not obscured by checkbox.
+                  style={{marginTop: '10px', position: 'relative', zIndex: 2}}
+                  type='submit'
                 >
-                  <Icon type='lock' /> {this.messages('adminOnly')}
-                </Checkbox>
-              }
-            </Panel>
-          </Body>
-        </Media>
-      </Col>
+                  {this.messages('new')}
+                </Button>
+                {isProjectAdmin &&
+                  <Checkbox
+                    checked={adminOnly}
+                    name='adminOnly'
+                    onChange={this._onChange}
+                  >
+                    <Icon type='lock' /> {this.messages('adminOnly')}
+                  </Checkbox>
+                }
+              </Panel>
+            </Body>
+          </Media>
+        </Col>
+      </form>
     )
   }
 }

--- a/lib/manager/components/NoteForm.js
+++ b/lib/manager/components/NoteForm.js
@@ -80,7 +80,8 @@ export default class NoteForm extends Component<Props, State> {
                 onChange={this._onChange} />
               <Button
                 className='pull-right'
-                style={{marginTop: '10px'}}
+                // Ensure button clicking is not obscured by checkbox.
+                style={{marginTop: '10px', position: 'relative', zIndex: 2}}
                 disabled={body === ''}
                 onClick={this._onClickPublish}>
                 {this.messages('new')}

--- a/lib/manager/components/NoteForm.js
+++ b/lib/manager/components/NoteForm.js
@@ -30,8 +30,10 @@ export default class NoteForm extends Component<Props, State> {
   messages = getComponentMessages('NoteForm')
   state = DEFAULT_STATE
 
-  _onChange = ({target}: {target: HTMLInputElement}) =>
-    this.setState({[target.name]: target.type === 'checkbox' ? target.checked : target.value})
+  _onChange = ({target}: {target: HTMLInputElement}) => {
+    const value = target.type === 'checkbox' ? target.checked : target.value
+    this.setState({[target.name]: value})
+  }
 
   _onClickPublish = () => {
     this.props.newNotePosted(this.state)
@@ -54,9 +56,6 @@ export default class NoteForm extends Component<Props, State> {
     const isProjectAdmin = user.permissions && user.permissions.isProjectAdmin(
       feedSource.projectId, feedSource.organizationId
     )
-    const userLink = user
-      ? <a href={getProfileLink(profile.email)}>{profile.email}</a>
-      : 'Unknown user'
     return (
       <Col xs={12} sm={stacked ? 12 : 4} md={stacked ? 12 : 6}>
         <h3>{this.messages('postComment')}</h3>
@@ -64,26 +63,33 @@ export default class NoteForm extends Component<Props, State> {
           <Left>
             <img
               alt={profile.email}
-              width={64}
               height={64}
-              src={user ? profile.picture : ''} />
+              width={64}
+              src={profile.picture} />
           </Left>
           <Body>
             <Panel
               className='comment-panel'
-              header={<Heading>{userLink}</Heading>}>
+              header={
+                <Heading>
+                  <a href={getProfileLink(profile.email)}>{profile.email}</a>
+                </Heading>
+              }
+            >
               <FormControl
-                ref='newNoteBody'
                 componentClass='textarea'
                 name='body'
-                value={body}
-                onChange={this._onChange} />
+                ref='newNoteBody'
+                style={{resize: 'none'}}
+                onChange={this._onChange}
+                value={body} />
               <Button
                 className='pull-right'
+                disabled={body === ''}
+                onClick={this._onClickPublish}
                 // Ensure button clicking is not obscured by checkbox.
                 style={{marginTop: '10px', position: 'relative', zIndex: 2}}
-                disabled={body === ''}
-                onClick={this._onClickPublish}>
+              >
                 {this.messages('new')}
               </Button>
               {isProjectAdmin &&

--- a/lib/manager/components/NotesViewer.js
+++ b/lib/manager/components/NotesViewer.js
@@ -79,6 +79,12 @@ export default class NotesViewer extends Component<Props> {
                       className='comment-panel'
                       header={
                         <Heading>
+                          {note.adminOnly &&
+                            <Icon
+                              className='pull-right'
+                              title={this.messages('adminOnly')}
+                              type='lock' />
+                          }
                           <a href={getProfileLink(note.userEmail)}>
                             {note.userEmail}
                           </a>
@@ -86,13 +92,6 @@ export default class NotesViewer extends Component<Props> {
                           <small title={noteDate.format('h:MMa, MMM. DD YYYY')}>
                             commented {noteDate.fromNow()}
                           </small>
-                          {note.adminOnly &&
-                            <span
-                              title={this.messages('adminOnly')}
-                              className='pull-right'>
-                              <Icon type='lock' />
-                            </span>
-                          }
                         </Heading>
                       }>
                       <p>{note.body || '(no content)'}</p>

--- a/lib/manager/components/NotesViewer.js
+++ b/lib/manager/components/NotesViewer.js
@@ -1,47 +1,32 @@
 // @flow
 
+import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
 import moment from 'moment'
 import gravatar from 'gravatar'
-import { Panel, Row, Col, Glyphicon, FormControl, Button, ButtonToolbar, Media } from 'react-bootstrap'
+import { Panel, Row, Col, Glyphicon, Button, ButtonToolbar, Media } from 'react-bootstrap'
 
 import {getComponentMessages} from '../../common/util/config'
 import { getProfileLink } from '../../common/util/util'
-
-import type {Feed, Note, FeedVersion} from '../../types'
+import type {Feed, Note} from '../../types'
 import type {ManagerUserState} from '../../types/reducers'
 
+import NoteForm from './NoteForm'
+
 type Props = {
-  feedSource?: Feed,
+  feedSource: Feed,
   newNotePosted: ({body: string}) => void,
   notes: ?Array<Note>,
   notesRequested: () => void,
   stacked?: boolean,
-  type: string,
-  user: ManagerUserState,
-  version?: FeedVersion
+  user: ManagerUserState
 }
 
-type State = {
-  value: string
-}
-
-export default class NotesViewer extends Component<Props, State> {
+export default class NotesViewer extends Component<Props> {
   messages = getComponentMessages('NotesViewer')
-  state = {
-    value: ''
-  }
 
   componentWillMount () {
     this.props.notesRequested()
-  }
-
-  _onChangeBody = (evt: SyntheticInputEvent<HTMLInputElement>) =>
-    this.setState({value: evt.target.value})
-
-  _onClickPublish = () => {
-    this.props.newNotePosted({body: this.state.value})
-    this.setState({value: ''})
   }
 
   _getUserUrl = (email: string): string =>
@@ -49,19 +34,13 @@ export default class NotesViewer extends Component<Props, State> {
 
   render () {
     const {
+      feedSource,
+      newNotePosted,
       notes,
       notesRequested,
       stacked,
       user
     } = this.props
-    const {profile} = user
-    if (!profile) {
-      console.warn('Could not locate user profile', user)
-      return null
-    }
-    const userLink = user
-      ? <a href={getProfileLink(profile.email)}>{profile.email}</a>
-      : 'Unknown user'
     const {Body, Heading, Left} = Media
     return (
       <Row>
@@ -84,7 +63,7 @@ export default class NotesViewer extends Component<Props, State> {
           </h3>
           {/* List of notes */}
           {notes && notes.length > 0
-            ? notes.map(note => {
+            ? notes.sort((a, b) => b.dateCreated - a.dateCreated).map(note => {
               const noteDate = moment(note.date)
               return (
                 <Media key={note.id}>
@@ -107,6 +86,13 @@ export default class NotesViewer extends Component<Props, State> {
                           <small title={noteDate.format('h:MMa, MMM. DD YYYY')}>
                             commented {noteDate.fromNow()}
                           </small>
+                          {note.adminOnly &&
+                            <span
+                              title={this.messages('adminOnly')}
+                              className='pull-right'>
+                              <Icon type='lock' />
+                            </span>
+                          }
                         </Heading>
                       }>
                       <p>{note.body || '(no content)'}</p>
@@ -118,37 +104,12 @@ export default class NotesViewer extends Component<Props, State> {
             : <p><i>{this.messages('none')}</i></p>
           }
         </Col>
-        {/* Post note form */}
-        <Col xs={12} sm={stacked ? 12 : 4} md={stacked ? 12 : 6}>
-          <h3>{this.messages('postComment')}</h3>
-          <Media>
-            <Left>
-              <img
-                alt={profile.email}
-                width={64}
-                height={64}
-                src={user ? profile.picture : ''} />
-            </Left>
-            <Body>
-              <Panel
-                className='comment-panel'
-                header={<Heading>{userLink}</Heading>}>
-                <FormControl
-                  ref='newNoteBody'
-                  componentClass='textarea'
-                  value={this.state.value}
-                  onChange={this._onChangeBody} />
-                <Button
-                  className='pull-right'
-                  style={{marginTop: '10px'}}
-                  disabled={this.state.value === ''}
-                  onClick={this._onClickPublish}>
-                  {this.messages('new')}
-                </Button>
-              </Panel>
-            </Body>
-          </Media>
-        </Col>
+        <NoteForm
+          feedSource={feedSource}
+          newNotePosted={newNotePosted}
+          stacked={stacked}
+          user={user}
+        />
       </Row>
     )
   }

--- a/lib/manager/components/version/FeedVersionViewer.js
+++ b/lib/manager/components/version/FeedVersionViewer.js
@@ -18,19 +18,19 @@ import { LinkContainer } from 'react-router-bootstrap'
 import * as versionsActions from '../../actions/versions'
 import {getComponentMessages, isModuleEnabled} from '../../../common/util/config'
 import Loading from '../../../common/components/Loading'
-import DeltaStat from './DeltaStat'
 import * as snapshotActions from '../../../editor/actions/snapshots'
-import FeedVersionReport from './FeedVersionReport'
 import * as plusActions from '../../../gtfsplus/actions/gtfsplus'
 import ActiveGtfsPlusVersionSummary from '../../../gtfsplus/containers/ActiveGtfsPlusVersionSummary'
-import VersionDateLabel from './VersionDateLabel'
 import NotesViewer from '../NotesViewer'
 import {errorPriorityLevels, getTableFatalExceptions} from '../../util/version'
 import GtfsValidationViewer from '../validation/GtfsValidationViewer'
-import VersionButtonToolbar from './VersionButtonToolbar'
-
 import type {Feed, FeedVersion, GtfsPlusValidation, Note, Project} from '../../../types'
 import type {GtfsState, ManagerUserState} from '../../../types/reducers'
+
+import VersionButtonToolbar from './VersionButtonToolbar'
+import VersionDateLabel from './VersionDateLabel'
+import FeedVersionReport from './FeedVersionReport'
+import DeltaStat from './DeltaStat'
 
 export type Props = {
   comparedVersion?: FeedVersion,
@@ -125,6 +125,7 @@ export default class FeedVersionViewer extends Component<Props> {
                   version={version} />
                 : versionSection === 'comments'
                   ? <NotesViewer
+                    feedSource={feedSource}
                     type='feed-version'
                     stacked
                     user={user}

--- a/lib/manager/components/version/FeedVersionViewer.js
+++ b/lib/manager/components/version/FeedVersionViewer.js
@@ -126,12 +126,9 @@ export default class FeedVersionViewer extends Component<Props> {
                 : versionSection === 'comments'
                   ? <NotesViewer
                     feedSource={feedSource}
-                    type='feed-version'
                     stacked
                     user={user}
-                    version={version}
                     notes={version.notes}
-                    noteCount={version.noteCount}
                     notesRequested={notesRequested}
                     newNotePosted={newNotePosted} />
                   : null

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -7,7 +7,6 @@ import {
   FETCH_FREQUENCIES,
   RETRIEVAL_METHODS
 } from '../common/constants'
-
 import type UserPermissions from '../common/user/UserPermissions'
 
 type InputType =
@@ -154,8 +153,10 @@ type DatatoolsSettings = {
 }
 
 export type Note = {
+  adminOnly: boolean,
   body: string,
   date: number,
+  dateCreated: number,
   id: string,
   type: string,
   userEmail: string


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Adds admin only option for a note. re #702

Note viewer is visible at http://localhost:9966/feed/FEED_ID/comments

![image](https://user-images.githubusercontent.com/2370911/128207566-dbc4e7b6-db8f-486c-aa81-941db7ec2ca4.png)
