### PR TITLE
fix(LabelEditor): show admin-only checkbox to project admins

### DIFF
--- a/lib/manager/components/LabelEditor.js
+++ b/lib/manager/components/LabelEditor.js
@@ -69,12 +69,6 @@ class LabelEditor extends React.Component<Props, State> {
       }
     }
 
-    userIsAdmin = (user: ManagerUserState) => {
-      const {permissions} = user
-      if (!permissions) return false
-      else return permissions.isApplicationAdmin() || permissions.canAdministerAnOrganization()
-    }
-
   _onFormChange = ({target}: {target: HTMLInputElement}) => {
     const {checked, name, value: targetValue, type} = target
 
@@ -146,7 +140,8 @@ class LabelEditor extends React.Component<Props, State> {
 
   render () {
     const { newLabel, validation } = this.state
-    const { user } = this.props
+    const { user, projectId } = this.props
+    const isProjectAdmin = user && user.permissions && user.permissions.isProjectAdmin(projectId)
 
     return (
       <Form onChange={(e) => this._onFormChange(e)}>
@@ -186,7 +181,7 @@ class LabelEditor extends React.Component<Props, State> {
                     <FormControl.Feedback />
                   </FormGroup>
                 </Col>
-                {this.userIsAdmin(user) && (
+                {isProjectAdmin && (
                   <Col xs={9}>
                     <Checkbox
                       checked={newLabel.adminOnly}

--- a/lib/manager/components/LabelEditorModal.js
+++ b/lib/manager/components/LabelEditorModal.js
@@ -60,7 +60,7 @@ export default class LabelEditorModal extends React.Component<
           <LabelEditor
             label={label}
             onDone={this.close}
-            projectId={projectId}
+            projectId={projectId || label.projectId}
           />
         </Body>
       </Modal>

--- a/lib/manager/components/LabelEditorModal.js
+++ b/lib/manager/components/LabelEditorModal.js
@@ -60,6 +60,9 @@ export default class LabelEditorModal extends React.Component<
           <LabelEditor
             label={label}
             onDone={this.close}
+            /* If a new label is being created, project ID will be passed in via props.
+               If an existing label is being edited, extract project ID from the label
+            */
             projectId={projectId || label.projectId}
           />
         </Body>

--- a/lib/manager/components/LabelPanel.js
+++ b/lib/manager/components/LabelPanel.js
@@ -29,7 +29,7 @@ export default class LabelPanel extends Component<Props> {
     const { labels, id: projectId } = project
 
     const projectAdmin =
-      user && user.permissions && user.permissions.isProjectAdmin(project.id)
+      user && user.permissions && user.permissions.isProjectAdmin(projectId)
 
     let labelBody = (
       <div className='noLabelsMessage'>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
### Description

Closes #705. Permissions for the admin-only checkbox were being determined incorrectly. Fixed by having it match the method used to show the edit/delete buttons, which is also the method used by the server.