### PR TITLE
fix(saveEntity, saveTripsForCalendar): Resolve missing defaults with GTFS spec changes

### DIFF
--- a/lib/editor/actions/active.js
+++ b/lib/editor/actions/active.js
@@ -6,10 +6,8 @@ import {createAction, type ActionType} from 'redux-actions'
 
 import {createVoidPayloadAction, secureFetch} from '../../common/actions'
 import {ENTITY} from '../constants'
-import {newGtfsEntity, fetchBaseGtfs} from './editor'
 import {fetchFeedSourceAndProject} from '../../manager/actions/feeds'
 import {fetchGTFSEntities} from '../../manager/actions/versions'
-import {saveTripPattern} from './tripPattern'
 import {
   getEditorNamespace,
   getTableById,
@@ -18,9 +16,11 @@ import {
   subSubComponentList
 } from '../util/gtfs'
 import {getMapFromGtfsStrategy, entityIsNew} from '../util/objects'
-
 import type {Entity, Feed} from '../../types'
 import type {dispatchFn, getStateFn, AppState} from '../../types/reducers'
+
+import {saveTripPattern} from './tripPattern'
+import {newGtfsEntity, fetchBaseGtfs} from './editor'
 
 export const clearGtfsContent = createVoidPayloadAction('CLEAR_GTFSEDITOR_CONTENT')
 const receivedNewEntity = createAction(
@@ -331,14 +331,25 @@ export function saveEntity (
       return
     }
     dispatch(savingActiveGtfsEntity())
-    const notNew = !entityIsNew(entity)
+    // Add default vals for component
+    const defaults = {}
+    if (component === 'route') {
+      defaults.continuous_pickup = 1 // Default value for no continuous pickup
+      defaults.continuous_drop_off = 1 // Default value for no continuous drop off
+    } else if (component === 'feedinfo') {
+      defaults.default_lang = ''
+      defaults.feed_contact_url = ''
+      defaults.feed_contact_email = ''
+    }
+    const entityWithDefaults = {...defaults, ...(entity: any)} // add defaults, if any.
+    const notNew = !entityIsNew(entityWithDefaults)
     const method = notNew ? 'put' : 'post'
-    const idParam = notNew ? `/${entity.id || ''}` : ''
+    const idParam = notNew ? `/${entityWithDefaults.id || ''}` : ''
     const {sessionId} = getState().editor.data.lock
     const route = component === 'fare' ? 'fareattribute' : component
     const url = `/api/editor/secure/${route}${idParam}?feedId=${feedId}&sessionId=${sessionId || ''}`
     const mappingStrategy = getMapFromGtfsStrategy(component)
-    const data = mappingStrategy(entity)
+    const data = mappingStrategy(entityWithDefaults)
     return dispatch(secureFetch(url, method, data))
       .then(res => res.json())
       .then(savedEntity => {

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -8,7 +8,6 @@ import {createAction, type ActionType} from 'redux-actions'
 
 import {createVoidPayloadAction, fetchGraphQL, secureFetch} from '../../common/actions'
 import {generateUID} from '../../common/util/util'
-import {clearGtfsContent, saveActiveGtfsEntity, setActiveGtfsEntity} from './active'
 import {ENTITY} from '../constants'
 import {
   generateNullProps,
@@ -17,7 +16,6 @@ import {
   getTableById
 } from '../util/gtfs'
 import {fetchGTFSEntities} from '../../manager/actions/versions'
-
 import type {
   dispatchFn,
   getStateFn,
@@ -25,6 +23,8 @@ import type {
   EditorTables,
   LockState
 } from '../../types/reducers'
+
+import {clearGtfsContent, saveActiveGtfsEntity, setActiveGtfsEntity} from './active'
 
 export const updateEntitySort = createAction('UPDATE_ENTITY_SORT')
 
@@ -384,6 +384,9 @@ export function fetchBaseGtfs ({
             feed_version
             default_route_color
             default_route_type
+            default_lang
+            feed_contact_url
+            feed_contact_email
           }
           agency (limit: -1) {
             id

--- a/lib/editor/actions/trip.js
+++ b/lib/editor/actions/trip.js
@@ -172,7 +172,7 @@ export function saveTripsForCalendar (
       const url = tripExists && trip.id
         ? `/api/editor/secure/trip/${trip.id}?feedId=${feedId}&sessionId=${sessionId}`
         : `/api/editor/secure/trip?feedId=${feedId}&sessionId=${sessionId}`
-      return dispatch(secureFetch(url, method, trip))
+      return dispatch(secureFetch(url, method, tripCopy))
         .then(res => res.json())
         .catch(err => {
           console.warn(err)

--- a/lib/editor/actions/trip.js
+++ b/lib/editor/actions/trip.js
@@ -1,5 +1,5 @@
 // @flow
-
+import clone from 'lodash/cloneDeep'
 import {createAction, type ActionType} from 'redux-actions'
 
 import {snakeCaseKeys} from '../../common/util/map-keys'
@@ -158,8 +158,9 @@ export function saveTripsForCalendar (
     trips = trips.map(snakeCaseKeys)
     return Promise.all(trips.filter(t => t).map((trip, index) => {
       const tripExists = !entityIsNew(trip) && trip.id !== null
-      const tripCopy: any = (trip: any)
+      const tripCopy: any = clone((trip: any))
       // Add default value to continuous pickup if not provided
+      // Editing continuous pickup/drop off is not currently supported in the schedule editor
       const defaults = {
         continuous_pickup: 1,
         continuous_drop_off: 1

--- a/lib/editor/actions/trip.js
+++ b/lib/editor/actions/trip.js
@@ -7,7 +7,6 @@ import {createVoidPayloadAction, fetchGraphQL, secureFetch} from '../../common/a
 import {setErrorMessage} from '../../manager/actions/status'
 import {entityIsNew} from '../util/objects'
 import {getEditorNamespace} from '../util/gtfs'
-
 import type {Pattern, TimetableColumn, Trip} from '../../types'
 import type {dispatchFn, getStateFn, TripCounts} from '../../types/reducers'
 
@@ -159,6 +158,15 @@ export function saveTripsForCalendar (
     trips = trips.map(snakeCaseKeys)
     return Promise.all(trips.filter(t => t).map((trip, index) => {
       const tripExists = !entityIsNew(trip) && trip.id !== null
+      const tripCopy: any = (trip: any)
+      // Add default value to continuous pickup if not provided
+      const defaults = {
+        continuous_pickup: 1,
+        continuous_drop_off: 1
+      }
+      tripCopy.stop_times = tripCopy.stop_times.map((stopTime, index) => {
+        return {...defaults, ...(stopTime: any)}
+      })
       const method = tripExists ? 'put' : 'post'
       const url = tripExists && trip.id
         ? `/api/editor/secure/trip/${trip.id}?feedId=${feedId}&sessionId=${sessionId}`


### PR DESCRIPTION
Closes #716, #717. New fields added with the changes to the GTFS spec (https://github.com/ibi-group/datatools-ui/pull/668) are missing from old feeds when a GTFS entity is saved, producing a `field missing from JSON object` error. Fixed by providing default values which are overridden if the feed provides its own values for the new fields. 

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

