### PR TITLE
fix(PeliasPanel): support windows csv mime type

### DIFF
--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -106,7 +106,7 @@ class PeliasPanel extends Component<Props, State> {
 
     const file = files[0]
     // TODO: more extensive csv validation?
-    if (file.type !== 'text/csv') {
+    if (file.type !== 'text/csv' && file.type !== 'application/vnd.ms-excel') {
       return false
     }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Thanks to @philip-cline for spotting this issue and finding the fix. From Phil: 

> The `file.type` for a windows csv file can get set to "application/vnd.ms-excel" no matter what you do w/ the file. Including that case in the condition at that line would solve that