### PR TITLE
fix(EntityListButton): Fix `New Exception` button formatting

### DIFF
--- a/lib/editor/components/EntityListButtons.js
+++ b/lib/editor/components/EntityListButtons.js
@@ -170,7 +170,9 @@ export default class EntityListButtons extends Component<Props, State> {
             data-test-id={`new-${activeComponent}-button`}
             disabled={entities && entities.findIndex(entityIsNew) !== -1}
             onClick={this._onClickNew}
-            // Setting the max width to display value so the button does not move to new line
+            // Setting the max width based on the width of the 'New Calendar' button
+            // so the button does not move to a new line in deployed systems.
+            // Note the width of the button text varies depending on the font used.
             style={{maxWidth: '95.375px'}}>
             New {componentToText(activeComponent)}
           </Button>


### PR DESCRIPTION
Avoid `New Exception` button being moved to new lines based on size. Fixes #725.

fix #725

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Changed the New Exception button maxWidth property to avoid the button being moved to a new line, as in issue #725.