### PR TITLE
fix(gtfsplus): trim extra spaces from fields

### DIFF
--- a/lib/gtfsplus/reducers/gtfsplus.js
+++ b/lib/gtfsplus/reducers/gtfsplus.js
@@ -3,7 +3,6 @@
 import update from 'react-addons-update'
 
 import {constructNewGtfsPlusRow} from '../util'
-
 import type {Action} from '../../types/actions'
 import type {GtfsPlusReducerState} from '../../types/reducers'
 
@@ -58,7 +57,7 @@ const gtfsplus = (
           continue
         }
         const fields = lines[0].split(',')
-        const COLUMN_REGEX = /,(?=(?:(?:[^"]*"){2})*[^"]*$)/
+        const COLUMN_REGEX = / *, *(?=(?:(?:[^"]*"){2})*[^"]*$)/
         const tableName = filename.split('.')[0]
         newTableData[tableName] = lines.slice(1)
         // Do not include blank lines (e.g., at the end of the file).

--- a/lib/gtfsplus/reducers/gtfsplus.js
+++ b/lib/gtfsplus/reducers/gtfsplus.js
@@ -57,6 +57,7 @@ const gtfsplus = (
           continue
         }
         const fields = lines[0].split(',')
+        // Column selector includes extra spaces on either side of comma.
         const COLUMN_REGEX = / *, *(?=(?:(?:[^"]*"){2})*[^"]*$)/
         const tableName = filename.split('.')[0]
         newTableData[tableName] = lines.slice(1)


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] The description lists all relevant PRs included in this release _(remove this if not merging to master)_

### Description

Simple regex change (like 4 characters) to trim the extra spaces from beginning and end of fields in the GTFS Plus files. Spaces inside quotations will be left intact. 
