### PR TITLE
Add auto-publish support (MTC ext. req'd)

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -225,18 +225,25 @@ components:
       PUBLISHED: Published Version
     createFirst: Create first feed source!
   FeedSourceTableRow:
+    badges:
+      autoFetch: Auto fetch
+      autoPublish: Auto publish
+      deployable: Deployable
+      edit: Edit
+      private: Private
+      public: Public
     status:
-        active: Active
-        all: All
-        expired: Expired
-        expiring-within-20-days: Expiring within 20 days
-        expiring-within-5-days: Expiring within 5 days
-        feedNotInDeployment: Feed not in deployment
-        feedNotPublished: Feed not published
-        future: Future
-        no-version: No version
-        same-as-deployed: Same as Deployed
-        same-as-published: Same as Published
+      active: Active
+      all: All
+      expired: Expired
+      expiring-within-20-days: Expiring within 20 days
+      expiring-within-5-days: Expiring within 5 days
+      feedNotInDeployment: Feed not in deployment
+      feedNotPublished: Feed not published
+      future: Future
+      no-version: No version
+      same-as-deployed: Same as Deployed
+      same-as-published: Same as Published
   FeedSourceViewer:
     deploy: Deploy
     edit: Edit GTFS

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -210,6 +210,13 @@ components:
     fetchFeedEvery: Fetch feed every
     HOURS: hours
     MINUTES: minutes
+  FeedInfo:
+    autoFetch: Auto fetch
+    autoPublish: Auto publish
+    deployable: Deployable
+    edit: Edit
+    private: Private
+    public: Public
   FeedInfoPanel:
     uploadShapefile:
       body: 'Select a zipped shapefile to display on map. Note: this is only for use as a visual aid.'
@@ -225,13 +232,6 @@ components:
       PUBLISHED: Published Version
     createFirst: Create first feed source!
   FeedSourceTableRow:
-    badges:
-      autoFetch: Auto fetch
-      autoPublish: Auto publish
-      deployable: Deployable
-      edit: Edit
-      private: Private
-      public: Public
     status:
       active: Active
       all: All

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -235,6 +235,13 @@ components:
     fetchFeedEvery: Pobieraj kanał co
     HOURS: godzin
     MINUTES: minut
+  FeedInfo: # Need to check these translations.
+    autoFetch: Automatyczne pobieranie
+    autoPublish: Automatycznie publikuj
+    deployable: Rozmieszczany
+    edit: Edytować
+    private: Prywatny
+    public: Publiczny
   FeedInfoPanel:
     uploadShapefile:
       body: >-

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -162,9 +162,12 @@ export function publishFeedVersion (feedVersion: FeedVersion) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     if (
       feedVersion.feedSource.autoPublish &&
+      feedVersion.sentToExternalPublisher &&
       !window.confirm('Are you sure you want publish this feed version again?')
     ) {
-      // For feed set to auto-publish, if the user does not confirm, do nothing.
+      // For a feed source set to auto-publish,
+      // if the version has already been sent to publishing
+      // and the user does not confirm, do nothing.
       return
     }
     const url = `${SECURE_API_PREFIX}feedversion/${feedVersion.id}/publish`

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -12,11 +12,11 @@ import {ENTITY} from '../../editor/constants'
 import {getKeyForId} from '../../editor/util/gtfs'
 import {getEntityGraphQLRoot, getEntityIdField, getGraphQLFieldsForEntity} from '../../gtfs/util'
 import {validateGtfsPlusFeed} from '../../gtfsplus/actions/gtfsplus'
-import {handleJobResponse, setErrorMessage, startJobMonitor} from './status'
-import {fetchFeedSource} from './feeds'
-
 import type {Feed, FeedVersion, ShapefileExportType} from '../../types'
 import type {dispatchFn, getStateFn, ValidationIssueCount} from '../../types/reducers'
+
+import {handleJobResponse, setErrorMessage, startJobMonitor} from './status'
+import {fetchFeedSource} from './feeds'
 
 const deletingFeedVersion = createVoidPayloadAction('DELETING_FEEDVERSION')
 const publishedFeedVersion = createAction(
@@ -160,6 +160,13 @@ export function fetchFeedVersion (feedVersionId: string) {
  */
 export function publishFeedVersion (feedVersion: FeedVersion) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
+    if (
+      feedVersion.feedSource.autoPublish &&
+      !window.confirm('Are you sure you want publish this feed version again?')
+    ) {
+      // For feed set to auto-publish, if the user does not confirm, do nothing.
+      return
+    }
     const url = `${SECURE_API_PREFIX}feedversion/${feedVersion.id}/publish`
     return dispatch(secureFetch(url, 'post'))
       .then(response => response.json())

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -160,16 +160,6 @@ export function fetchFeedVersion (feedVersionId: string) {
  */
 export function publishFeedVersion (feedVersion: FeedVersion) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    if (
-      feedVersion.feedSource.autoPublish &&
-      feedVersion.sentToExternalPublisher &&
-      !window.confirm('Are you sure you want publish this feed version again?')
-    ) {
-      // For a feed source set to auto-publish,
-      // if the version has already been sent to publishing
-      // and the user does not confirm, do nothing.
-      return
-    }
     const url = `${SECURE_API_PREFIX}feedversion/${feedVersion.id}/publish`
     return dispatch(secureFetch(url, 'post'))
       .then(response => response.json())

--- a/lib/manager/components/AutoPublishSettings.js
+++ b/lib/manager/components/AutoPublishSettings.js
@@ -1,0 +1,70 @@
+// @flow
+
+import React, { Component } from 'react'
+import {
+  Checkbox,
+  Col,
+  FormGroup,
+  ListGroup,
+  ListGroupItem,
+  Panel
+} from 'react-bootstrap'
+
+import * as feedsActions from '../actions/feeds'
+import type { Feed } from '../../types'
+
+type Props = {
+  disabled: ?boolean,
+  feedSource: Feed,
+  updateFeedSource: typeof feedsActions.updateFeedSource
+}
+
+/**
+ * This component displays auto-publish settings for a feed.
+ * Auto-publish settings are kept in a separate section per MTC request.
+ */
+export default class AutoPublishSettings extends Component<Props> {
+  _onToggleAutoPublish = () => {
+    const {feedSource, updateFeedSource} = this.props
+    updateFeedSource(feedSource, {autoPublish: !feedSource.autoPublish})
+  }
+
+  render () {
+    const {
+      disabled,
+      feedSource
+    } = this.props
+    // Do not allow users without manage-feed permission to modify auto-publish settings.
+    if (disabled) {
+      return (
+        <p className='lead'>
+          User is not authorized to modify auto-publish settings.
+        </p>
+      )
+    }
+    return (
+      <Col xs={7}>
+        {/* Settings */}
+        <Panel header={<h3>Auto-publish Settings</h3>}>
+          <ListGroup fill>
+            <ListGroupItem>
+              <FormGroup>
+                <Checkbox
+                  checked={feedSource.autoPublish}
+                  disabled={disabled}
+                  onChange={this._onToggleAutoPublish}
+                >
+                  <strong>Auto-publish this feed after auto-fetch</strong>
+                </Checkbox>
+                <small>
+                  Set this feed source to be automatically published
+                  when a new version is fetched automatically.
+                </small>
+              </FormGroup>
+            </ListGroupItem>
+          </ListGroup>
+        </Panel>
+      </Col>
+    )
+  }
+}

--- a/lib/manager/components/CreateFeedSource.js
+++ b/lib/manager/components/CreateFeedSource.js
@@ -73,6 +73,7 @@ export default class CreateFeedSource extends Component<Props, State> {
     this.setState({
       model: {
         autoFetchFeed: false,
+        autoPublish: false,
         deployable: false,
         fetchFrequency: 'DAYS',
         fetchInterval: 1,

--- a/lib/manager/components/CreateFeedSource.js
+++ b/lib/manager/components/CreateFeedSource.js
@@ -249,7 +249,7 @@ export default class CreateFeedSource extends Component<Props, State> {
                     </Checkbox>
                     <small>
                       Set this feed source to be automatically published
-                      when a new version is created.
+                      when a new version is automatically fetched.
                     </small>
                   </FormGroup>
                 </ListGroupItem>

--- a/lib/manager/components/CreateFeedSource.js
+++ b/lib/manager/components/CreateFeedSource.js
@@ -21,10 +21,11 @@ import validator from 'validator'
 import {createFeedSource} from '../actions/feeds'
 import Loading from '../../common/components/Loading'
 import {FREQUENCY_INTERVALS} from '../../common/constants'
-import FeedFetchFrequency from './FeedFetchFrequency'
+import {isExtensionEnabled} from '../../common/util/config'
 import {validationState} from '../util'
-
 import type {FetchFrequency, NewFeed} from '../../types'
+
+import FeedFetchFrequency from './FeedFetchFrequency'
 
 type Props = {
   createFeedSource: typeof createFeedSource,
@@ -235,6 +236,26 @@ export default class CreateFeedSource extends Component<Props, State> {
               </ListGroupItem>
             </ListGroup>
           </Panel>
+          {isExtensionEnabled('mtc') && (
+            <Panel header={<h3>Automatic publishing</h3>}>
+              <ListGroup fill>
+                <ListGroupItem>
+                  <FormGroup>
+                    <Checkbox
+                      checked={model.autoPublish}
+                      onChange={this._toggleCheckBox('autoPublish')}
+                    >
+                      <strong>Auto-publish this feed</strong>
+                    </Checkbox>
+                    <small>
+                      Set this feed source to be automatically published
+                      when a new version is created.
+                    </small>
+                  </FormGroup>
+                </ListGroupItem>
+              </ListGroup>
+            </Panel>
+          )}
         </Col>
         <Col xs={12}>
           <Button

--- a/lib/manager/components/FeedSourceSettings.js
+++ b/lib/manager/components/FeedSourceSettings.js
@@ -48,7 +48,7 @@ export default class FeedSourceSettings extends Component<Props> {
     const isProjectAdmin = user.permissions && user.permissions.isProjectAdmin(
       project.id, project.organizationId
     )
-    const resourceType = activeComponent === ('settings' && activeSubComponent && activeSubComponent.toLowerCase()) || ''
+    const resourceType = (activeComponent === 'settings' && activeSubComponent && activeSubComponent.toLowerCase()) || ''
 
     if (disabled) {
       return (

--- a/lib/manager/components/FeedSourceSettings.js
+++ b/lib/manager/components/FeedSourceSettings.js
@@ -48,7 +48,7 @@ export default class FeedSourceSettings extends Component<Props> {
     const isProjectAdmin = user.permissions && user.permissions.isProjectAdmin(
       project.id, project.organizationId
     )
-    const resourceType = activeComponent === 'settings' && activeSubComponent && activeSubComponent.toLowerCase()
+    const resourceType = activeComponent === ('settings' && activeSubComponent && activeSubComponent.toLowerCase()) || ''
 
     if (disabled) {
       return (

--- a/lib/manager/components/FeedSourceSettings.js
+++ b/lib/manager/components/FeedSourceSettings.js
@@ -11,13 +11,15 @@ import {
 import {LinkContainer} from 'react-router-bootstrap'
 
 import * as feedsActions from '../actions/feeds'
+import {isExtensionEnabled} from '../../common/util/config'
 import toSentenceCase from '../../common/util/to-sentence-case'
+import type {Feed, Project} from '../../types'
+import type {ManagerUserState} from '../../types/reducers'
+
+import AutoPublishSettings from './AutoPublishSettings'
 import ExternalPropertiesTable from './ExternalPropertiesTable'
 import FeedTransformationSettings from './transform/FeedTransformationSettings'
 import GeneralSettings from './GeneralSettings'
-
-import type {Feed, Project} from '../../types'
-import type {ManagerUserState} from '../../types/reducers'
 
 type Props = {
   activeComponent: string,
@@ -35,9 +37,9 @@ export default class FeedSourceSettings extends Component<Props> {
     const {
       activeComponent,
       activeSubComponent,
-      updateExternalFeedResource,
       feedSource,
       project,
+      updateExternalFeedResource,
       user
     } = this.props
     const disabled = user.permissions && !user.permissions.hasFeedPermission(
@@ -46,8 +48,8 @@ export default class FeedSourceSettings extends Component<Props> {
     const isProjectAdmin = user.permissions && user.permissions.isProjectAdmin(
       project.id, project.organizationId
     )
-    const resourceType = activeComponent === 'settings' && activeSubComponent && activeSubComponent.toUpperCase()
-    const showTransformationsTab = resourceType === 'TRANSFORMATIONS'
+    const resourceType = activeComponent === 'settings' && activeSubComponent && activeSubComponent.toLowerCase()
+
     if (disabled) {
       return (
         <Row>
@@ -57,39 +59,12 @@ export default class FeedSourceSettings extends Component<Props> {
         </Row>
       )
     }
-    return (
-      <Row>
-        <Col xs={3}>
-          {/* Side panel */}
-          <Panel>
-            <ListGroup fill>
-              <LinkContainer
-                to={`/feed/${feedSource.id}/settings`}
-                active={!activeSubComponent}>
-                <ListGroupItem>General</ListGroupItem>
-              </LinkContainer>
-              <LinkContainer
-                to={`/feed/${feedSource.id}/settings/transformations`}
-                active={showTransformationsTab}>
-                <ListGroupItem>Feed Transformations</ListGroupItem>
-              </LinkContainer>
-              {Object.keys(feedSource.externalProperties || {}).map(resourceType => {
-                const resourceLowerCase = resourceType.toLowerCase()
-                return (
-                  <LinkContainer
-                    key={resourceType}
-                    to={`/feed/${feedSource.id}/settings/${resourceLowerCase}`}
-                    active={activeSubComponent === resourceLowerCase}>
-                    <ListGroupItem>{toSentenceCase(resourceType)} properties</ListGroupItem>
-                  </LinkContainer>
-                )
-              })}
-            </ListGroup>
-          </Panel>
-        </Col>
-        <Col xs={6} />
-        {!resourceType
-          ? <GeneralSettings
+
+    const tabs = [
+      {
+        condition: true,
+        render: () => (
+          <GeneralSettings
             confirmDeleteFeedSource={this.props.confirmDeleteFeedSource}
             disabled={disabled}
             feedSource={feedSource}
@@ -97,27 +72,85 @@ export default class FeedSourceSettings extends Component<Props> {
             updateFeedSource={this.props.updateFeedSource}
             user={user}
           />
-          : showTransformationsTab
-            ? <FeedTransformationSettings
-              disabled={disabled}
-              feedSource={feedSource}
-              project={project}
-              updateFeedSource={this.props.updateFeedSource}
-              user={user}
-            />
-            : <Col xs={7}>
+        ),
+        subPath: '',
+        title: 'General'
+      },
+      {
+        condition: true,
+        render: () => (
+          <FeedTransformationSettings
+            disabled={disabled}
+            feedSource={feedSource}
+            project={project}
+            updateFeedSource={this.props.updateFeedSource}
+            user={user}
+          />
+        ),
+        subPath: 'transformations',
+        title: 'Feed Transformations'
+      },
+      {
+        condition: isExtensionEnabled('mtc'),
+        render: () => (
+          <AutoPublishSettings
+            disabled={disabled}
+            feedSource={feedSource}
+            updateFeedSource={this.props.updateFeedSource}
+          />
+        ),
+        subPath: 'autopublish',
+        title: 'Auto-publish'
+      },
+      ...Object.keys(feedSource.externalProperties || {}).map(resourceType => {
+        const resourceLowerCase = resourceType.toLowerCase()
+        return {
+          condition: true,
+          render: () => (
+            <Col xs={7}>
               <ExternalPropertiesTable
-                resourceType={resourceType}
-                feedSource={feedSource}
                 editingIsDisabled={disabled}
+                feedSource={feedSource}
                 isProjectAdmin={isProjectAdmin}
                 resourceProps={feedSource.externalProperties
                   ? feedSource.externalProperties[resourceType]
                   : {}
                 }
+                resourceType={resourceType.toUpperCase()}
                 updateExternalFeedResource={updateExternalFeedResource} />
             </Col>
+          ),
+          subPath: resourceLowerCase,
+          title: `${toSentenceCase(resourceType)} properties`
         }
+      })
+    ]
+
+    const activeTab = tabs.find(tab => resourceType === tab.subPath) || tabs[0]
+
+    return (
+      <Row>
+        <Col xs={3}>
+          {/* Side panel */}
+          <Panel>
+            <ListGroup fill>
+              {tabs.map((tab, index) => {
+                return (
+                  <LinkContainer
+                    active={resourceType === tab.subPath}
+                    key={index}
+                    to={`/feed/${feedSource.id}/settings${tab.subPath === '' ? '' : `/${tab.subPath}`}`}
+                  >
+                    <ListGroupItem>{tab.title}</ListGroupItem>
+                  </LinkContainer>
+                )
+              })}
+            </ListGroup>
+          </Panel>
+        </Col>
+        <Col xs={6} />
+
+        {activeTab.render()}
       </Row>
     )
   }

--- a/lib/manager/components/FeedSourceTableRow.js
+++ b/lib/manager/components/FeedSourceTableRow.js
@@ -249,7 +249,7 @@ export default class FeedSourceTableRow extends PureComponent<Props> {
 }
 
 class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user: ManagerUserState }> {
-  messages = getComponentMessages('FeedSourceTableRow')
+  messages = getComponentMessages('FeedInfo')
 
   render () {
     const { feedSource, project, user } = this.props
@@ -284,23 +284,23 @@ class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user:
           {feedSource.retrievalMethod === 'FETCHED_AUTOMATICALLY' && (
             <Col xs={6}>
               <Icon type='feed' />
-              {this.messages('badges.autoFetch')}
+              {this.messages('autoFetch')}
             </Col>
           )}
           {feedSource.deployable && (
             <Col xs={6}>
               <Icon type='rocket' />
-              {this.messages('badges.deployable')}
+              {this.messages('deployable')}
             </Col>
           )}
           <Col xs={6}>
             <Icon type={feedSource.isPublic ? 'globe' : 'lock'} />
-            {this.messages(feedSource.isPublic ? 'badges.public' : 'badges.private')}
+            {this.messages(feedSource.isPublic ? 'public' : 'private')}
           </Col>
           {isExtensionEnabled('mtc') && feedSource.autoPublish && (
             <Col xs={6}>
               <Icon type='cloud-upload' />
-              {this.messages('badges.autoPublish')}
+              {this.messages('autoPublish')}
             </Col>
           )}
           <Col xs={12}>
@@ -319,7 +319,7 @@ class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user:
                   style={{ marginRight: '5px' }}
                   onClick={() => this.refs.labelAssignerModal.open()}
                 >
-                  {this.messages('badges.edit')}
+                  {this.messages('edit')}
                 </button>)}
               <div className='feedLabelContainer'>
                 {deStringifyLabels(feedSource.labelIds, project).map((label) => (

--- a/lib/manager/components/FeedSourceTableRow.js
+++ b/lib/manager/components/FeedSourceTableRow.js
@@ -13,6 +13,7 @@ import * as versionsActions from '../actions/versions'
 import { deStringifyLabels } from '../util'
 import {
   getComponentMessages,
+  isExtensionEnabled,
   isModuleEnabled,
   getConfigProperty
 } from '../../common/util/config'
@@ -248,6 +249,8 @@ export default class FeedSourceTableRow extends PureComponent<Props> {
 }
 
 class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user: ManagerUserState }> {
+  messages = getComponentMessages('FeedSourceTableRow')
+
   render () {
     const { feedSource, project, user } = this.props
 
@@ -281,19 +284,25 @@ class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user:
           {feedSource.retrievalMethod === 'FETCHED_AUTOMATICALLY' && (
             <Col xs={6}>
               <Icon type='feed' />
-              Auto fetch
+              {this.messages('badges.autoFetch')}
             </Col>
           )}
           {feedSource.deployable && (
             <Col xs={6}>
               <Icon type='rocket' />
-              Deployable
+              {this.messages('badges.deployable')}
             </Col>
           )}
           <Col xs={6}>
             <Icon type={feedSource.isPublic ? 'globe' : 'lock'} />
-            {feedSource.isPublic ? 'Public' : 'Private'}
+            {this.messages(feedSource.isPublic ? 'badges.public' : 'badges.private')}
           </Col>
+          {isExtensionEnabled('mtc') && feedSource.autoPublish && (
+            <Col xs={6}>
+              <Icon type='cloud-upload' />
+              {this.messages('badges.autoPublish')}
+            </Col>
+          )}
           <Col xs={12}>
             <div className='feedSourceLabelRow'>
               {project.labels.length > 0 && (
@@ -310,7 +319,7 @@ class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user:
                   style={{ marginRight: '5px' }}
                   onClick={() => this.refs.labelAssignerModal.open()}
                 >
-                  Edit
+                  {this.messages('badges.edit')}
                 </button>)}
               <div className='feedLabelContainer'>
                 {deStringifyLabels(feedSource.labelIds, project).map((label) => (

--- a/lib/manager/components/GeneralSettings.js
+++ b/lib/manager/components/GeneralSettings.js
@@ -17,7 +17,6 @@ import {
 
 import * as feedsActions from '../actions/feeds'
 import { FREQUENCY_INTERVALS } from '../../common/constants'
-import { isExtensionEnabled } from '../../common/util/config'
 import LabelAssigner from '../components/LabelAssigner'
 import type { Feed, FetchFrequency, Project } from '../../types'
 import type { ManagerUserState } from '../../types/reducers'
@@ -68,12 +67,6 @@ export default class GeneralSettings extends Component<Props, State> {
       ? 'MANUALLY_UPLOADED'
       : 'FETCHED_AUTOMATICALLY'
     updateFeedSource(feedSource, {retrievalMethod: value})
-  }
-
-  // FIXME_QBD: refactor similar code (See CreateFeedSource).
-  _onToggleAutoPublish = () => {
-    const {feedSource, updateFeedSource} = this.props
-    updateFeedSource(feedSource, {autoPublish: !feedSource.autoPublish})
   }
 
   _onSelectFetchInterval = (fetchInterval: number) => {
@@ -208,28 +201,6 @@ export default class GeneralSettings extends Component<Props, State> {
             </ListGroupItem>
           </ListGroup>
         </Panel>
-        {isExtensionEnabled('mtc') && (
-          <Panel header={<h3>Automatic publishing</h3>}>
-            <ListGroup fill>
-              <ListGroupItem>
-                <FormGroup>
-                  <Checkbox
-                    checked={feedSource.autoPublish}
-                    disabled={disabled}
-                    onChange={this._onToggleAutoPublish}
-                    bsStyle='danger'
-                  >
-                    <strong>Auto-publish this feed</strong>
-                  </Checkbox>
-                  <small>
-                    Set this feed source to be automatically published
-                    when a new version is created.
-                  </small>
-                </FormGroup>
-              </ListGroupItem>
-            </ListGroup>
-          </Panel>
-        )}
         <Panel header={<h3>Labels</h3>}>
           <LabelAssigner feedSource={feedSource} project={project} />
         </Panel>

--- a/lib/manager/components/GeneralSettings.js
+++ b/lib/manager/components/GeneralSettings.js
@@ -17,9 +17,10 @@ import {
 
 import * as feedsActions from '../actions/feeds'
 import { FREQUENCY_INTERVALS } from '../../common/constants'
+import { isExtensionEnabled } from '../../common/util/config'
+import LabelAssigner from '../components/LabelAssigner'
 import type { Feed, FetchFrequency, Project } from '../../types'
 import type { ManagerUserState } from '../../types/reducers'
-import LabelAssigner from '../components/LabelAssigner'
 
 import FeedFetchFrequency from './FeedFetchFrequency'
 
@@ -67,6 +68,12 @@ export default class GeneralSettings extends Component<Props, State> {
       ? 'MANUALLY_UPLOADED'
       : 'FETCHED_AUTOMATICALLY'
     updateFeedSource(feedSource, {retrievalMethod: value})
+  }
+
+  // FIXME_QBD: refactor similar code (See CreateFeedSource).
+  _onToggleAutoPublish = () => {
+    const {feedSource, updateFeedSource} = this.props
+    updateFeedSource(feedSource, {autoPublish: !feedSource.autoPublish})
   }
 
   _onSelectFetchInterval = (fetchInterval: number) => {
@@ -201,6 +208,28 @@ export default class GeneralSettings extends Component<Props, State> {
             </ListGroupItem>
           </ListGroup>
         </Panel>
+        {isExtensionEnabled('mtc') && (
+          <Panel header={<h3>Automatic publishing</h3>}>
+            <ListGroup fill>
+              <ListGroupItem>
+                <FormGroup>
+                  <Checkbox
+                    checked={feedSource.autoPublish}
+                    disabled={disabled}
+                    onChange={this._onToggleAutoPublish}
+                    bsStyle='danger'
+                  >
+                    <strong>Auto-publish this feed</strong>
+                  </Checkbox>
+                  <small>
+                    Set this feed source to be automatically published
+                    when a new version is created.
+                  </small>
+                </FormGroup>
+              </ListGroupItem>
+            </ListGroup>
+          </Panel>
+        )}
         <Panel header={<h3>Labels</h3>}>
           <LabelAssigner feedSource={feedSource} project={project} />
         </Panel>

--- a/lib/manager/components/version/FeedVersionDetails.js
+++ b/lib/manager/components/version/FeedVersionDetails.js
@@ -15,12 +15,12 @@ import bboxPoly from 'turf-bbox-polygon'
 import * as versionsActions from '../../actions/versions'
 import {getConfigProperty, isExtensionEnabled} from '../../../common/util/config'
 import {BLOCKING_ERROR_TYPES} from '../../util/version'
+import type {FeedVersion, GtfsPlusValidation, Bounds, Feed} from '../../../types'
+import type {ManagerUserState} from '../../../types/reducers'
+
 import FeedVersionSpanChart from './FeedVersionSpanChart'
 import VersionRetrievalBadge from './VersionRetrievalBadge'
 import VersionSelectorDropdown from './VersionSelectorDropdown'
-
-import type {FeedVersion, GtfsPlusValidation, Bounds, Feed} from '../../../types'
-import type {ManagerUserState} from '../../../types/reducers'
 
 type Props = {
   comparedVersion: ?FeedVersion,
@@ -111,6 +111,28 @@ export default class FeedVersionDetails extends Component<Props> {
     const mergeButtonLabel = isMergedServicePeriods
       ? 'Cannot re-merge feed'
       : 'Merge with version'
+
+    const hasMtcExtension = isExtensionEnabled('mtc')
+    let publishWarningMessage
+    if (hasMtcExtension) {
+      if (hasBlockingIssue || hasGtfsPlusBlockingIssue) {
+        publishWarningMessage = (
+          <span>
+            Cannot publish version because it has a{' '}
+            {hasGtfsPlusBlockingIssue ? 'GTFS+ ' : ''}
+            blocking issue.
+            (See{' '}
+            <Link
+              to={`/feed/${feedSource.id}/version/${version.version}/${hasGtfsPlusBlockingIssue ? 'gtfsplus' : 'issues'}`}>
+              {hasGtfsPlusBlockingIssue ? 'GTFS+' : 'validation'} issues
+            </Link>.)
+          </span>
+        )
+      } else if (feedSource.autoPublish) {
+        publishWarningMessage = 'Reminder: this feed is already set to be auto-published!'
+      }
+    }
+
     return (
       <ListGroupItem>
         <h4 className='pull-left' style={{ marginBottom: '2px' }}>
@@ -119,7 +141,7 @@ export default class FeedVersionDetails extends Component<Props> {
             Feed validity dates
           </span>
         </h4>
-        {isExtensionEnabled('mtc') &&
+        {hasMtcExtension &&
           <ButtonToolbar className='pull-right' style={{ marginTop: '2px' }}>
             <VersionSelectorDropdown
               dropdownProps={{
@@ -155,8 +177,7 @@ export default class FeedVersionDetails extends Component<Props> {
             </Button>
           </ButtonToolbar>
         }
-        {(hasBlockingIssue || hasGtfsPlusBlockingIssue) &&
-          isExtensionEnabled('mtc') &&
+        {hasMtcExtension && (
           <div
             className='pull-right text-danger'
             style={{
@@ -165,17 +186,11 @@ export default class FeedVersionDetails extends Component<Props> {
               marginLeft: '5px',
               textAlign: 'right',
               width: '180px'
-            }}>
-            Cannot publish version because it has a{' '}
-            {hasGtfsPlusBlockingIssue ? 'GTFS+ ' : ''}
-            blocking issue.
-            (See{' '}
-            <Link
-              to={`/feed/${feedSource.id}/version/${version.version}/${hasGtfsPlusBlockingIssue ? 'gtfsplus' : 'issues'}`}>
-              {hasGtfsPlusBlockingIssue ? 'GTFS+' : 'validation'} issues
-            </Link>.)
+            }}
+          >
+            {publishWarningMessage}
           </div>
-        }
+        )}
 
         <FeedVersionSpanChart
           activeVersion={version}

--- a/lib/manager/components/version/FeedVersionDetails.js
+++ b/lib/manager/components/version/FeedVersionDetails.js
@@ -129,7 +129,7 @@ export default class FeedVersionDetails extends Component<Props> {
           </span>
         )
       } else if (feedSource.autoPublish) {
-        publishWarningMessage = 'Reminder: this feed is already set to be auto-published!'
+        publishWarningMessage = 'Reminder: this feed is already set to be auto-published after auto-fetch!'
       }
     }
 

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -378,6 +378,7 @@ export type FeedTransformRules = {
 }
 
 export type Feed = {
+  autoPublish?: boolean,
   dateCreated: number,
   deployable: boolean,
   deployments?: Array<Deployment>,
@@ -413,6 +414,7 @@ export type Feed = {
 
 export type NewFeed = {
   autoFetchFeed?: boolean,
+  autoPublish?: boolean,
   deployable?: boolean,
   fetchFrequency: FetchFrequency,
   fetchInterval: number,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds support for auto-publishing feeds (requires the MTC extension and https://github.com/ibi-group/datatools-server/pull/442).
