### PR TITLE
LPI UI refactor

### DIFF
--- a/__tests__/test-utils/mock-data/manager.js
+++ b/__tests__/test-utils/mock-data/manager.js
@@ -62,7 +62,6 @@ export function makeMockDeployment (
     tripPlannerVersion: 'OTP_1',
     peliasUpdate: null,
     peliasResetDb: null,
-    peliasWebhookUrl: null,
     peliasCsvFiles: [],
     user: null
   }
@@ -94,6 +93,7 @@ export const mockProject = {
   organizationId: null,
   otpServers: [],
   pinnedDeploymentId: null,
+  peliasWebhookUrl: null,
   routerConfig: {
     carDropoffTime: null,
     numItineraries: null,

--- a/__tests__/test-utils/mock-data/manager.js
+++ b/__tests__/test-utils/mock-data/manager.js
@@ -54,15 +54,15 @@ export function makeMockDeployment (
     osmExtractUrl: null,
     otpCommit: null,
     otpVersion: null,
+    peliasCsvFiles: [],
+    peliasResetDb: null,
+    peliasUpdate: null,
     pinnedfeedVersionIds: [],
-    projectId: project.id,
     projectBounds: {east: 0, west: 0, north: 0, south: 0},
+    projectId: project.id,
     routerId: null,
     skipOsmExtract: false,
     tripPlannerVersion: 'OTP_1',
-    peliasUpdate: null,
-    peliasResetDb: null,
-    peliasCsvFiles: [],
     user: null
   }
 }

--- a/lib/manager/actions/__tests__/__snapshots__/projects.js.snap
+++ b/lib/manager/actions/__tests__/__snapshots__/projects.js.snap
@@ -117,7 +117,6 @@ Object {
           "peliasCsvFiles": Array [],
           "peliasResetDb": null,
           "peliasUpdate": null,
-          "peliasWebhookUrl": null,
           "pinnedfeedVersionIds": Array [],
           "projectBounds": Object {
             "east": 0,
@@ -185,6 +184,7 @@ Object {
       "name": "mock-project-with-deployments",
       "organizationId": null,
       "otpServers": Array [],
+      "peliasWebhookUrl": null,
       "pinnedDeploymentId": null,
       "routerConfig": Object {
         "carDropoffTime": null,

--- a/lib/manager/actions/deployments.js
+++ b/lib/manager/actions/deployments.js
@@ -88,7 +88,7 @@ export function deployToTarget (deployment: Deployment, target: string) {
         // FIXME: Use standard handleJobResponse for deployment job
         if (response.status >= 400 || response.status === 202) {
           // If there is an issue with the deployment, return the JSON response
-          // (handled be below alert)
+          // (handled below alert)
           return response.json()
         } else {
           // If the deployment request succeeded, start monitoring the job.
@@ -114,7 +114,7 @@ export function updatePelias (deployment: Deployment, resetDb?: boolean) {
         // FIXME: Use standard handleJobResponse for deployment job
         if (response.status >= 400 || response.status === 202) {
           // If there is an issue with the deployment, return the JSON response
-          // (handled be below alert)
+          // (handled below alert)
           return response.json()
         } else {
           // If the deployment request succeeded, start monitoring the job.

--- a/lib/manager/actions/deployments.js
+++ b/lib/manager/actions/deployments.js
@@ -103,6 +103,37 @@ export function deployToTarget (deployment: Deployment, target: string) {
   }
 }
 
+export function updatePelias (deployment: Deployment, resetDb?: boolean) {
+  return async function (dispatch: dispatchFn, getState: getStateFn) {
+    if (resetDb) {
+      await dispatch(updateDeployment(deployment, {peliasResetDb: true}))
+    }
+    const {id} = deployment
+    return dispatch(secureFetch(`${DEPLOYMENT_URL}/${id}/updatepelias`, 'post'))
+      .then(response => {
+        // FIXME: Use standard handleJobResponse for deployment job
+        if (response.status >= 400 || response.status === 202) {
+          // If there is an issue with the deployment, return the JSON response
+          // (handled be below alert)
+          return response.json()
+        } else {
+          // If the deployment request succeeded, start monitoring the job.
+          dispatch(startJobMonitor())
+          dispatch(fetchProjectDeployments(deployment.projectId))
+        }
+
+        if (resetDb) {
+          // If peliasResetDb was set, un-set it after getting a response
+          dispatch(updateDeployment(deployment, {peliasResetDb: false}))
+        }
+      })
+      .then(json => {
+        // Show JSON message if there was an issue.
+        json && window.alert(json.message || 'Could not update Local Places Index')
+      })
+  }
+}
+
 export function fetchDeployment (id: ?string) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     dispatch(requestingDeployment())

--- a/lib/manager/actions/deployments.js
+++ b/lib/manager/actions/deployments.js
@@ -109,13 +109,13 @@ export function updatePelias (deployment: Deployment, resetDb?: boolean) {
       await dispatch(updateDeployment(deployment, {peliasResetDb: true}))
     }
     const {id} = deployment
-    return dispatch(secureFetch(`${DEPLOYMENT_URL}/${id}/updatepelias`, 'post'))
+    dispatch(secureFetch(`${DEPLOYMENT_URL}/${id}/updatepelias`, 'post'))
       .then(response => {
         // FIXME: Use standard handleJobResponse for deployment job
         if (response.status >= 400 || response.status === 202) {
-          // If there is an issue with the deployment, return the JSON response
-          // (handled below alert)
-          return response.json()
+          // If there is an issue starting the update, don't launch the job monitor
+          // (instead handle the error in the next promise block)
+          return
         } else {
           // If the deployment request succeeded, start monitoring the job.
           dispatch(startJobMonitor())

--- a/lib/manager/components/ProjectSettingsForm.js
+++ b/lib/manager/components/ProjectSettingsForm.js
@@ -341,6 +341,9 @@ export default class ProjectSettingsForm extends Component<Props, State> {
                     onChange={this._onChangeBounds}
                   />
                   {<InputGroup.Button>
+                    {/* TODO: wait for react-leaflet-draw to update library
+                    to re-enable bounds select. This button appears to be permanently
+                    disabled. The git blame history may provide more detail. */}
                     <Button disabled onClick={this._onOpenMapBoundsModal}>
                       <Glyphicon glyph='fullscreen' />
                     </Button>
@@ -393,11 +396,11 @@ export default class ProjectSettingsForm extends Component<Props, State> {
         </Panel>}
         <Row>
           <Col xs={12}>
-            {}
+            {/* Cancel Button */}
             <Button onClick={this._onCancel} style={{ marginRight: 10 }}>
               {this.messages('cancel')}
             </Button>
-            {}
+            {/* Save Button */}
             <Button
               bsStyle='primary'
               data-test-id='project-settings-form-save-button'

--- a/lib/manager/components/ProjectSettingsForm.js
+++ b/lib/manager/components/ProjectSettingsForm.js
@@ -272,7 +272,7 @@ export default class ProjectSettingsForm extends Component<Props, State> {
       )
     }
     return (
-      (<div>
+      <div>
         <ConfirmModal ref='confirm' />
         <Panel header={<h4>{this.messages('title')}</h4>}>
           <ListGroup fill>
@@ -305,13 +305,13 @@ export default class ProjectSettingsForm extends Component<Props, State> {
                 </Checkbox>
                 {autoFetchChecked
                   ? <DateTimeField
-                    dateTime={typeof autoFetchMinute === 'number' &&
-                typeof autoFetchHour === 'number'
-                      ? +moment().startOf('day').add(autoFetchHour, 'hours').add(
-                        autoFetchMinute,
-                        'minutes'
-                      )
-                      : DEFAULT_FETCH_TIME}
+                    dateTime={
+                      typeof autoFetchMinute === 'number' && typeof autoFetchHour === 'number'
+                        ? +moment().startOf('day').add(autoFetchHour, 'hours').add(
+                          autoFetchMinute,
+                          'minutes'
+                        )
+                        : DEFAULT_FETCH_TIME}
                     mode='time'
                     onChange={this._onChangeDateTime}
                   />
@@ -379,21 +379,23 @@ export default class ProjectSettingsForm extends Component<Props, State> {
           </ListGroup>
         </Panel>
         {showDangerZone &&
-        <Panel bsStyle='danger' header={<h3>Danger zone</h3>}>
-          <ListGroup fill>
-            <ListGroupItem>
-              <Button
-                bsStyle='danger'
-                className='pull-right'
-                data-test-id='delete-project-button'
-                onClick={this._onDeleteProject}>
-                <Icon type='trash' /> Delete project
-              </Button>
-              <h4>Delete this project.</h4>
-              <p>Once you delete an project, the project and all feed sources it contains cannot be recovered.</p>
-            </ListGroupItem>
-          </ListGroup>
-        </Panel>}
+          <Panel bsStyle='danger' header={<h3>Danger zone</h3>}>
+            <ListGroup fill>
+              <ListGroupItem>
+                <Button
+                  bsStyle='danger'
+                  className='pull-right'
+                  data-test-id='delete-project-button'
+                  onClick={this._onDeleteProject}
+                >
+                  <Icon type='trash' /> Delete project
+                </Button>
+                <h4>Delete this project.</h4>
+                <p>Once you delete an project, the project and all feed sources it contains cannot be recovered.</p>
+              </ListGroupItem>
+            </ListGroup>
+          </Panel>
+        }
         <Row>
           <Col xs={12}>
             {/* Cancel Button */}
@@ -412,7 +414,7 @@ export default class ProjectSettingsForm extends Component<Props, State> {
           </Col>
         </Row>
         <MapModal ref='mapModal' />
-      </div>)
+      </div>
     )
   }
 }

--- a/lib/manager/components/ProjectSettingsForm.js
+++ b/lib/manager/components/ProjectSettingsForm.js
@@ -40,7 +40,8 @@ type ProjectModel = {
   bounds?: Bounds,
   defaultTimeZone?: string,
   id?: string,
-  name?: string
+  name?: string,
+  peliasWebhookUrl?: string
 }
 
 type Props = {
@@ -58,7 +59,8 @@ type State = {
   validation: {
     bounds: boolean,
     defaultLocation: boolean,
-    name: boolean
+    name: boolean,
+    webhookUrl: boolean
   }
 }
 
@@ -71,7 +73,8 @@ export default class ProjectSettingsForm extends Component<Props, State> {
     validation: {
       bounds: true,
       defaultLocation: true,
-      name: true
+      name: true,
+      webhookUrl: true
     }
   }
 
@@ -181,13 +184,16 @@ export default class ProjectSettingsForm extends Component<Props, State> {
     this.setState(update(this.state, {model: {$merge: {defaultTimeZone}}}))
   }
 
-  _onChangeName = ({target}: {target: HTMLInputElement}) => {
+  _onChangeTextInput = ({target}: {target: HTMLInputElement}) => {
     const {name, value} = target
     this.setState(
-      update(this.state, {
-        model: { $merge: {[name]: value} },
-        validation: { [name]: { $set: value && value.length > 0 } }
-      })
+      update(
+        this.state,
+        {
+          model: { $merge: { [ name ]: value } },
+          validation: { [ name ]: { $set: value && value.length > 0 } }
+        }
+      )
     )
   }
 
@@ -266,20 +272,19 @@ export default class ProjectSettingsForm extends Component<Props, State> {
       )
     }
     return (
-      <div>
+      (<div>
         <ConfirmModal ref='confirm' />
         <Panel header={<h4>{this.messages('title')}</h4>}>
           <ListGroup fill>
             <ListGroupItem>
               <FormGroup
                 data-test-id='project-name-input-container'
-                validationState={validationState(validation.name)}
-              >
+                validationState={validationState(validation.name)}>
                 <ControlLabel>{this.messages('fields.name')}</ControlLabel>
                 <FormControl
                   value={model.name || ''}
                   name={'name'}
-                  onChange={this._onChangeName}
+                  onChange={this._onChangeTextInput}
                 />
                 <FormControl.Feedback />
                 <HelpBlock>Required.</HelpBlock>
@@ -300,19 +305,17 @@ export default class ProjectSettingsForm extends Component<Props, State> {
                 </Checkbox>
                 {autoFetchChecked
                   ? <DateTimeField
-                    dateTime={(
-                      typeof autoFetchMinute === 'number' &&
-                      typeof autoFetchHour === 'number'
-                    )
-                      ? +moment().startOf('day')
-                        .add(autoFetchHour, 'hours')
-                        .add(autoFetchMinute, 'minutes')
-                      : DEFAULT_FETCH_TIME
-                    }
+                    dateTime={typeof autoFetchMinute === 'number' &&
+                typeof autoFetchHour === 'number'
+                      ? +moment().startOf('day').add(autoFetchHour, 'hours').add(
+                        autoFetchMinute,
+                        'minutes'
+                      )
+                      : DEFAULT_FETCH_TIME}
                     mode='time'
-                    onChange={this._onChangeDateTime} />
-                  : null
-                }
+                    onChange={this._onChangeDateTime}
+                  />
+                  : null}
               </FormGroup>
             </ListGroupItem>
           </ListGroup>
@@ -330,22 +333,18 @@ export default class ProjectSettingsForm extends Component<Props, State> {
                     type='text'
                     defaultValue={model.bounds
                       ? `${model.bounds.west},${model.bounds.south},${model.bounds.east},${model.bounds.north}`
-                      : ''
-                    }
+                      : ''}
                     ref='boundingBox'
-                    placeholder={this.messages('fields.location.boundingBoxPlaceHolder')}
-                    onChange={this._onChangeBounds} />
-                  {
-                    <InputGroup.Button>
-                      <Button
-                        // TODO: wait for react-leaflet-draw to update library
-                        // to re-enable bounds select
-                        disabled
-                        onClick={this._onOpenMapBoundsModal}>
-                        <Glyphicon glyph='fullscreen' />
-                      </Button>
-                    </InputGroup.Button>
-                  }
+                    placeholder={this.messages(
+                      'fields.location.boundingBoxPlaceHolder'
+                    )}
+                    onChange={this._onChangeBounds}
+                  />
+                  {<InputGroup.Button>
+                    <Button disabled onClick={this._onOpenMapBoundsModal}>
+                      <Glyphicon glyph='fullscreen' />
+                    </Button>
+                  </InputGroup.Button>}
                 </InputGroup>
               </FormGroup>
             </ListGroupItem>
@@ -356,53 +355,61 @@ export default class ProjectSettingsForm extends Component<Props, State> {
               </ControlLabel>
               <TimezoneSelect
                 value={model.defaultTimeZone}
-                onChange={this._onChangeTimeZone} />
+                onChange={this._onChangeTimeZone}
+              />
+            </ListGroupItem>
+          </ListGroup>
+        </Panel>
+        <Panel header={<h4>Local Places Index</h4>}>
+          <ListGroup fill>
+            <ListGroupItem>
+              <FormGroup validationState={validationState(validation.webhookUrl)}>
+                <ControlLabel>Webhook URL</ControlLabel>
+                <FormControl
+                  value={model.peliasWebhookUrl || ''}
+                  name={'peliasWebhookUrl'}
+                  onChange={this._onChangeTextInput}
+                />
+                <FormControl.Feedback />
+              </FormGroup>
             </ListGroupItem>
           </ListGroup>
         </Panel>
         {showDangerZone &&
-          <Panel bsStyle='danger' header={<h3>Danger zone</h3>}>
-            <ListGroup fill>
-              <ListGroupItem>
-                <Button
-                  bsStyle='danger'
-                  className='pull-right'
-                  data-test-id='delete-project-button'
-                  onClick={this._onDeleteProject}
-                >
-                  <Icon type='trash' /> Delete project
-                </Button>
-                <h4>Delete this project.</h4>
-                <p>Once you delete an project, the project and all feed sources it contains cannot be recovered.</p>
-              </ListGroupItem>
-            </ListGroup>
-          </Panel>
-        }
+        <Panel bsStyle='danger' header={<h3>Danger zone</h3>}>
+          <ListGroup fill>
+            <ListGroupItem>
+              <Button
+                bsStyle='danger'
+                className='pull-right'
+                data-test-id='delete-project-button'
+                onClick={this._onDeleteProject}>
+                <Icon type='trash' /> Delete project
+              </Button>
+              <h4>Delete this project.</h4>
+              <p>Once you delete an project, the project and all feed sources it contains cannot be recovered.</p>
+            </ListGroupItem>
+          </ListGroup>
+        </Panel>}
         <Row>
           <Col xs={12}>
-            {/* Cancel button */}
-            <Button
-              onClick={this._onCancel}
-              style={{marginRight: 10}}
-            >
+            {}
+            <Button onClick={this._onCancel} style={{ marginRight: 10 }}>
               {this.messages('cancel')}
             </Button>
-            {/* Save button */}
+            {}
             <Button
               bsStyle='primary'
               data-test-id='project-settings-form-save-button'
-              disabled={
-                editDisabled ||
-                this._settingsAreUnedited() ||
-                !this._formIsValid()
-              }
+              disabled={editDisabled || this._settingsAreUnedited() ||
+          !this._formIsValid()}
               onClick={this._onSaveSettings}>
               {this.messages('save')}
             </Button>
           </Col>
         </Row>
         <MapModal ref='mapModal' />
-      </div>
+      </div>)
     )
   }
 }

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -401,11 +401,17 @@ export default class DeploymentViewer extends Component<Props, State> {
             {/* Pelias panel. Only show if deployment is pinned and webhook URL is set */}
             {project.pinnedDeploymentId === deployment.id &&
               project.peliasWebhookUrl && (
-              <PeliasPanel
-                deployment={deployment}
-                updateDeployment={updateDeployment}
-                project={project}
-              />
+              <div>
+                <span>TODO: remove this PeliasPanel wrapper and instead make peliaspanel only show if a dpeloyment exists.
+                  need to adjust the server to have a new endpoint to launch pelias job and there
+                  needs to be a way to get the otpServer info in that new job
+                </span>
+                <PeliasPanel
+                  deployment={deployment}
+                  updateDeployment={updateDeployment}
+                  project={project}
+                />
+              </div>
             )}
           </Col>
           <Col sm={3}>

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -401,8 +401,8 @@ export default class DeploymentViewer extends Component<Props, State> {
             {/* Pelias panel */}
             <PeliasPanel
               deployment={deployment}
-              updateDeployment={updateDeployment}
               project={project}
+              updateDeployment={updateDeployment}
             />
           </Col>
           <Col sm={3}>

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -398,21 +398,12 @@ export default class DeploymentViewer extends Component<Props, State> {
                 )}
               </ListGroup>
             </Panel>
-            {/* Pelias panel. Only show if deployment is pinned and webhook URL is set */}
-            {project.pinnedDeploymentId === deployment.id &&
-              project.peliasWebhookUrl && (
-              <div>
-                <span>TODO: remove this PeliasPanel wrapper and instead make peliaspanel only show if a dpeloyment exists.
-                  need to adjust the server to have a new endpoint to launch pelias job and there
-                  needs to be a way to get the otpServer info in that new job
-                </span>
-                <PeliasPanel
-                  deployment={deployment}
-                  updateDeployment={updateDeployment}
-                  project={project}
-                />
-              </div>
-            )}
+            {/* Pelias panel */}
+            <PeliasPanel
+              deployment={deployment}
+              updateDeployment={updateDeployment}
+              project={project}
+            />
           </Col>
           <Col sm={3}>
             {/* Current deployment panel */}

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -365,39 +365,48 @@ export default class DeploymentViewer extends Component<Props, State> {
     return (
       <div>
         <Title>{title}</Title>
-        {target &&
+        {target && (
           <DeploymentConfirmModal
             deployToTarget={deployToTarget}
             deployment={deployment}
             oldDeployment={oldDeployment}
             onClose={this._onCloseModal}
             project={project}
-            target={target} />
-        }
+            target={target}
+          />
+        )}
         <Row>
           <Col sm={9}>
             <Panel header={this.renderHeader()}>
               <ListGroup fill>
-                <ListGroupItem style={{padding: '0px'}}>
+                <ListGroupItem style={{ padding: '0px' }}>
                   {this.renderMap()}
                 </ListGroupItem>
                 <ListGroupItem>
                   {this.renderDeployentVersionsTableHeader(versions)}
                 </ListGroupItem>
-                {versions.length === 0
-                  ? <p className='lead text-center margin-top-15'>
+                {versions.length === 0 ? (
+                  <p className='lead text-center margin-top-15'>
                     No feed sources found.
                   </p>
-                  : (
-                    <DeploymentVersionsTable
-                      deployment={deployment}
-                      project={project}
-                      versions={versions}
-                    />
-                  )
-                }
+                ) : (
+                  <DeploymentVersionsTable
+                    deployment={deployment}
+                    project={project}
+                    versions={versions}
+                  />
+                )}
               </ListGroup>
             </Panel>
+            {/* Pelias panel. Only show if deployment is pinned and webhook URL is set */}
+            {project.pinnedDeploymentId === deployment.id &&
+              project.peliasWebhookUrl && (
+              <PeliasPanel
+                deployment={deployment}
+                updateDeployment={updateDeployment}
+                project={project}
+              />
+            )}
           </Col>
           <Col sm={3}>
             {/* Current deployment panel */}
@@ -408,18 +417,15 @@ export default class DeploymentViewer extends Component<Props, State> {
               fetchDeployment={this.props.fetchDeployment}
               project={project}
               server={serverDeployedTo}
-              terminateEC2InstanceForDeployment={this.props.terminateEC2InstanceForDeployment} />
+              terminateEC2InstanceForDeployment={
+                this.props.terminateEC2InstanceForDeployment
+              }
+            />
             {/* Configurations panel */}
             <DeploymentConfigurationsPanel
               deployment={deployment}
               updateDeployment={updateDeployment}
             />
-            {/* Pelias panel. Only show if deployment is pinned */}
-            {project.pinnedDeploymentId === deployment.id && <PeliasPanel
-              deployment={deployment}
-              updateDeployment={updateDeployment}
-              project={project}
-            />}
           </Col>
         </Row>
       </div>

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -190,7 +190,6 @@ class PeliasPanel extends Component<Props, State> {
         }
       >
         <ListGroup fill>
-
           <ListGroupItem>
             <ButtonToolbar style={{display: 'flex', flexDirection: 'row'}}>
               <h5>Local Places Index</h5>

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -5,7 +5,8 @@ import { connect } from 'react-redux'
 import React, { Component } from 'react'
 import {
   Button,
-  Checkbox,
+  ButtonGroup,
+  ButtonToolbar,
   ListGroup,
   ListGroupItem,
   Panel
@@ -13,7 +14,7 @@ import {
 
 import SelectFileModal from '../../../common/components/SelectFileModal'
 import ConfirmModal from '../../../common/components/ConfirmModal'
-import { updateDeployment, uploadPeliasWebhookCsvFile } from '../../actions/deployments'
+import { updateDeployment, uploadPeliasWebhookCsvFile, updatePelias } from '../../actions/deployments'
 import { setErrorMessage } from '../../actions/status'
 import type { Deployment, Project } from '../../../types'
 
@@ -22,6 +23,7 @@ type Props = {
   project: Project,
   setErrorMessage: typeof setErrorMessage,
   updateDeployment: typeof updateDeployment,
+  updatePelias: typeof updatePelias,
   uploadPeliasWebhookCsvFile: typeof uploadPeliasWebhookCsvFile
 }
 
@@ -34,21 +36,17 @@ class PeliasPanel extends Component<Props, State> {
     fileToDeleteOnSuccesfulUpload: null
   };
 
+  _onClickPeliasUpdate = () => {
+    const {deployment, updatePelias} = this.props
+    updatePelias(deployment)
+  }
   /**
    *  Method fired when Pelias Update checkbox is checked
    */
-  _onChangeUpdatePelias = () =>
-    this._updateDeployment({
-      peliasUpdate: !this.props.deployment.peliasUpdate
-    });
-
-  /**
-   *  Method fired when Pelias Update checkbox is checked
-   */
-  _onChangeResetPelias = () =>
-    this._updateDeployment({
-      peliasResetDb: !this.props.deployment.peliasResetDb
-    });
+  _onClickPeliasReset = () => {
+    const {deployment, updatePelias} = this.props
+    updatePelias(deployment, true)
+  }
 
   /**
    * Updates state on input changes. Does not persist changes to deployment
@@ -170,7 +168,15 @@ class PeliasPanel extends Component<Props, State> {
   }
 
   render () {
-    const { deployment } = this.props
+    const { deployment, project } = this.props
+
+    // Don't show panel is no webhook url is set
+    if (!project.peliasWebhookUrl) {
+      return null
+    }
+
+    // const peliasButtonsDisabled = !deployment || (deployment.ec2Instances && deployment.ec2Instances.length === 0)
+    const peliasButtonsDisabled = false
 
     return (
       <Panel
@@ -183,30 +189,32 @@ class PeliasPanel extends Component<Props, State> {
         <ListGroup fill>
 
           <ListGroupItem>
-            <Checkbox
-              checked={deployment.peliasUpdate}
-              onChange={this._onChangeUpdatePelias}
-            >
-              Update Local Places Index (including places from GTFS feeds)
-            </Checkbox>
+            <ButtonToolbar>
+              <h5>Update Local Places Index</h5>
+              <ButtonGroup title={peliasButtonsDisabled ? 'Local Places Index can only be updated if there is a running OTP instance' : ''}>
+                {/* If there are no deployments don't allow user to update Pelias yet */}
+                <Button
+                  onClick={this._onClickPeliasUpdate}
+                  disabled={peliasButtonsDisabled}
+                >
+                  Update
+                </Button>
+                <Button
+                  onClick={() => this.refs.reInitLpiModal.open()}
+                  disabled={peliasButtonsDisabled}
+                >Reset</Button>
+              </ButtonGroup>
+            </ButtonToolbar>
             <ConfirmModal
               ref='reInitLpiModal'
               title='Are you sure you want to rebuild the Local Places Index database?'
               body='This will cause custom geocoder responses to be unavailable for about 1 - 5 minutes after deploying. Regular addresses and landmarks will continue to be available. Stops and stations from feeds that are not part of this deployment will be removed from the suggestions.'
-              onConfirm={this._onChangeResetPelias}
+              onConfirm={this._onClickPeliasReset}
             />
-            <Checkbox
-              checked={deployment.peliasResetDb}
-              disabled={!deployment.peliasUpdate}
-              onClick={() => deployment.peliasResetDb ? this._onChangeResetPelias() : this.refs.reInitLpiModal.open()}
-              style={{paddingLeft: 15}}
-            >
-              Rebuild the Local Places Index database during update
-            </Checkbox>
           </ListGroupItem>
           <ListGroupItem >
             <h5>Custom Point Of Interest CSV Files</h5>
-            <p>These files are sent to the Local Places Index when it is updated</p>
+            <p>These files are sent to the Local Places Index when it is updated or reset</p>
             <SelectFileModal
               ref='uploadModal'
               title='Upload CSV File'
@@ -236,7 +244,7 @@ class PeliasPanel extends Component<Props, State> {
   }
 }
 
-const mapDispatchToProps = {uploadPeliasWebhookCsvFile, setErrorMessage}
+const mapDispatchToProps = {uploadPeliasWebhookCsvFile, setErrorMessage, updatePelias}
 
 export default connect(
   null,

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -36,12 +36,16 @@ class PeliasPanel extends Component<Props, State> {
     fileToDeleteOnSuccesfulUpload: null
   };
 
+  /**
+   * Method fired when Pelias *Update* button is pressed
+   */
   _onClickPeliasUpdate = () => {
     const {deployment, updatePelias} = this.props
     updatePelias(deployment)
   }
   /**
-   *  Method fired when Pelias Update checkbox is checked
+   * Method fired when Pelias *Reset* button is pressed. The true
+   * flag tells the webhook to wipe the Pelias database before updating.
    */
   _onClickPeliasReset = () => {
     const {deployment, updatePelias} = this.props

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -6,7 +6,6 @@ import React, { Component } from 'react'
 import {
   Button,
   Checkbox,
-  FormControl,
   ListGroup,
   ListGroupItem,
   Panel
@@ -28,21 +27,11 @@ type Props = {
 
 type State = {
   fileToDeleteOnSuccesfulUpload: string | null,
-  peliasWebhookUrl: string
 }
 
 class PeliasPanel extends Component<Props, State> {
   state = {
-    fileToDeleteOnSuccesfulUpload: null,
-    peliasWebhookUrl: ''
-  };
-
-  componentDidMount = () => {
-    const { deployment } = this.props
-    this.setState({
-    // Auto-populate blank field if project has webhook URL in it
-      peliasWebhookUrl: deployment.peliasWebhookUrl || ''
-    })
+    fileToDeleteOnSuccesfulUpload: null
   };
 
   /**
@@ -182,9 +171,6 @@ class PeliasPanel extends Component<Props, State> {
 
   render () {
     const { deployment } = this.props
-    const { peliasWebhookUrl } = this.state
-
-    const optionsEnabled = peliasWebhookUrl !== ''
 
     return (
       <Panel
@@ -195,21 +181,10 @@ class PeliasPanel extends Component<Props, State> {
         }
       >
         <ListGroup fill>
-          <ListGroupItem>
-            <h5>Local Places Index Webhook URL</h5>
-            <FormControl
-              type='url'
-              id='peliasWebhookUrl'
-              placeholder='Update webhook URL'
-              value={peliasWebhookUrl}
-              onChange={this._onChangeTextInput}
-              onBlur={this._onBlurTextInput}
-            />
-          </ListGroupItem>
+
           <ListGroupItem>
             <Checkbox
-              disabled={!optionsEnabled}
-              checked={deployment.peliasUpdate && optionsEnabled}
+              checked={deployment.peliasUpdate}
               onChange={this._onChangeUpdatePelias}
             >
               Update Local Places Index (including places from GTFS feeds)
@@ -222,7 +197,7 @@ class PeliasPanel extends Component<Props, State> {
             />
             <Checkbox
               checked={deployment.peliasResetDb}
-              disabled={!optionsEnabled || !deployment.peliasUpdate}
+              disabled={!deployment.peliasUpdate}
               onClick={() => deployment.peliasResetDb ? this._onChangeResetPelias() : this.refs.reInitLpiModal.open()}
               style={{paddingLeft: 15}}
             >
@@ -245,12 +220,11 @@ class PeliasPanel extends Component<Props, State> {
             <ul>
               {deployment.peliasCsvFiles &&
                 deployment.peliasCsvFiles.map((url) =>
-                  this.renderCsvUrl(url, optionsEnabled)
+                  this.renderCsvUrl(url, true)
                 )}
             </ul>
             <Button
               style={{ marginTop: '5px' }}
-              disabled={!optionsEnabled}
               onClick={() => this.refs.uploadModal.open()}
             >
               Upload New CSV File

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -175,8 +175,7 @@ class PeliasPanel extends Component<Props, State> {
       return null
     }
 
-    // const peliasButtonsDisabled = !deployment || (deployment.ec2Instances && deployment.ec2Instances.length === 0)
-    const peliasButtonsDisabled = false
+    const peliasButtonsDisabled = !deployment || (deployment.ec2Instances && deployment.ec2Instances.length === 0)
 
     return (
       <Panel
@@ -189,8 +188,8 @@ class PeliasPanel extends Component<Props, State> {
         <ListGroup fill>
 
           <ListGroupItem>
-            <ButtonToolbar>
-              <h5>Update Local Places Index</h5>
+            <ButtonToolbar style={{display: 'flex', flexDirection: 'row'}}>
+              <h5>Local Places Index</h5>
               <ButtonGroup title={peliasButtonsDisabled ? 'Local Places Index can only be updated if there is a running OTP instance' : ''}>
                 {/* If there are no deployments don't allow user to update Pelias yet */}
                 <Button
@@ -200,13 +199,13 @@ class PeliasPanel extends Component<Props, State> {
                   Update
                 </Button>
                 <Button
-                  onClick={() => this.refs.reInitLpiModal.open()}
+                  onClick={() => this.refs.reInitPeliasModal.open()}
                   disabled={peliasButtonsDisabled}
                 >Reset</Button>
               </ButtonGroup>
             </ButtonToolbar>
             <ConfirmModal
-              ref='reInitLpiModal'
+              ref='reInitPeliasModal'
               title='Are you sure you want to rebuild the Local Places Index database?'
               body='This will cause custom geocoder responses to be unavailable for about 1 - 5 minutes after deploying. Regular addresses and landmarks will continue to be available. Stops and stations from feeds that are not part of this deployment will be removed from the suggestions.'
               onConfirm={this._onClickPeliasReset}
@@ -228,10 +227,11 @@ class PeliasPanel extends Component<Props, State> {
             <ul>
               {deployment.peliasCsvFiles &&
                 deployment.peliasCsvFiles.map((url) =>
-                  this.renderCsvUrl(url, true)
+                  this.renderCsvUrl(url, !peliasButtonsDisabled)
                 )}
             </ul>
             <Button
+              disabled={peliasButtonsDisabled}
               style={{ marginTop: '5px' }}
               onClick={() => this.refs.uploadModal.open()}
             >

--- a/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
@@ -72,6 +72,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
           "name": "mock-project",
           "organizationId": null,
           "otpServers": Array [],
+          "peliasWebhookUrl": null,
           "pinnedDeploymentId": null,
           "routerConfig": Object {
             "carDropoffTime": null,
@@ -1938,6 +1939,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                           "name": "mock-project",
                                                           "organizationId": null,
                                                           "otpServers": Array [],
+                                                          "peliasWebhookUrl": null,
                                                           "pinnedDeploymentId": null,
                                                           "routerConfig": Object {
                                                             "carDropoffTime": null,
@@ -1984,6 +1986,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                             "name": "mock-project",
                                                             "organizationId": null,
                                                             "otpServers": Array [],
+                                                            "peliasWebhookUrl": null,
                                                             "pinnedDeploymentId": null,
                                                             "routerConfig": Object {
                                                               "carDropoffTime": null,
@@ -2103,6 +2106,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                                   "name": "mock-project",
                                                                   "organizationId": null,
                                                                   "otpServers": Array [],
+                                                                  "peliasWebhookUrl": null,
                                                                   "pinnedDeploymentId": null,
                                                                   "routerConfig": Object {
                                                                     "carDropoffTime": null,
@@ -2153,6 +2157,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                                     "name": "mock-project",
                                                                     "organizationId": null,
                                                                     "otpServers": Array [],
+                                                                    "peliasWebhookUrl": null,
                                                                     "pinnedDeploymentId": null,
                                                                     "routerConfig": Object {
                                                                       "carDropoffTime": null,
@@ -2222,6 +2227,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                                       "name": "mock-project",
                                                                       "organizationId": null,
                                                                       "otpServers": Array [],
+                                                                      "peliasWebhookUrl": null,
                                                                       "pinnedDeploymentId": null,
                                                                       "routerConfig": Object {
                                                                         "carDropoffTime": null,
@@ -4142,6 +4148,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                           "name": "mock-project",
                                                           "organizationId": null,
                                                           "otpServers": Array [],
+                                                          "peliasWebhookUrl": null,
                                                           "pinnedDeploymentId": null,
                                                           "routerConfig": Object {
                                                             "carDropoffTime": null,
@@ -4257,6 +4264,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                           "name": "mock-project",
                                                           "organizationId": null,
                                                           "otpServers": Array [],
+                                                          "peliasWebhookUrl": null,
                                                           "pinnedDeploymentId": null,
                                                           "routerConfig": Object {
                                                             "carDropoffTime": null,
@@ -4328,6 +4336,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                           "name": "mock-project",
                                                           "organizationId": null,
                                                           "otpServers": Array [],
+                                                          "peliasWebhookUrl": null,
                                                           "pinnedDeploymentId": null,
                                                           "routerConfig": Object {
                                                             "carDropoffTime": null,

--- a/lib/manager/containers/__tests__/__snapshots__/DeploymentsPanel.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/DeploymentsPanel.js.snap
@@ -130,7 +130,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
             "peliasCsvFiles": Array [],
             "peliasResetDb": null,
             "peliasUpdate": null,
-            "peliasWebhookUrl": null,
             "pinnedfeedVersionIds": Array [],
             "projectBounds": Object {
               "east": 0,
@@ -166,7 +165,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
             "peliasCsvFiles": Array [],
             "peliasResetDb": null,
             "peliasUpdate": null,
-            "peliasWebhookUrl": null,
             "pinnedfeedVersionIds": Array [],
             "projectBounds": Object {
               "east": 0,
@@ -234,6 +232,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
         "name": "mock-project-with-deployments",
         "organizationId": null,
         "otpServers": Array [],
+        "peliasWebhookUrl": null,
         "pinnedDeploymentId": "mock-deployment-id-0",
         "routerConfig": Object {
           "carDropoffTime": null,
@@ -367,7 +366,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
               "peliasCsvFiles": Array [],
               "peliasResetDb": null,
               "peliasUpdate": null,
-              "peliasWebhookUrl": null,
               "pinnedfeedVersionIds": Array [],
               "projectBounds": Object {
                 "east": 0,
@@ -403,7 +401,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
               "peliasCsvFiles": Array [],
               "peliasResetDb": null,
               "peliasUpdate": null,
-              "peliasWebhookUrl": null,
               "pinnedfeedVersionIds": Array [],
               "projectBounds": Object {
                 "east": 0,
@@ -471,6 +468,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
           "name": "mock-project-with-deployments",
           "organizationId": null,
           "otpServers": Array [],
+          "peliasWebhookUrl": null,
           "pinnedDeploymentId": "mock-deployment-id-0",
           "routerConfig": Object {
             "carDropoffTime": null,
@@ -656,7 +654,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                       "peliasCsvFiles": Array [],
                       "peliasResetDb": null,
                       "peliasUpdate": null,
-                      "peliasWebhookUrl": null,
                       "pinnedfeedVersionIds": Array [],
                       "projectBounds": Object {
                         "east": 0,
@@ -692,7 +689,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                       "peliasCsvFiles": Array [],
                       "peliasResetDb": null,
                       "peliasUpdate": null,
-                      "peliasWebhookUrl": null,
                       "pinnedfeedVersionIds": Array [],
                       "projectBounds": Object {
                         "east": 0,
@@ -822,7 +818,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                         "peliasCsvFiles": Array [],
                         "peliasResetDb": null,
                         "peliasUpdate": null,
-                        "peliasWebhookUrl": null,
                         "pinnedfeedVersionIds": Array [],
                         "projectBounds": Object {
                           "east": 0,
@@ -858,7 +853,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                         "peliasCsvFiles": Array [],
                         "peliasResetDb": null,
                         "peliasUpdate": null,
-                        "peliasWebhookUrl": null,
                         "pinnedfeedVersionIds": Array [],
                         "projectBounds": Object {
                           "east": 0,
@@ -926,6 +920,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                     "name": "mock-project-with-deployments",
                     "organizationId": null,
                     "otpServers": Array [],
+                    "peliasWebhookUrl": null,
                     "pinnedDeploymentId": "mock-deployment-id-0",
                     "routerConfig": Object {
                       "carDropoffTime": null,
@@ -1201,7 +1196,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                 "peliasCsvFiles": Array [],
                                 "peliasResetDb": null,
                                 "peliasUpdate": null,
-                                "peliasWebhookUrl": null,
                                 "pinnedfeedVersionIds": Array [],
                                 "projectBounds": Object {
                                   "east": 0,
@@ -1331,7 +1325,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                     "peliasCsvFiles": Array [],
                                     "peliasResetDb": null,
                                     "peliasUpdate": null,
-                                    "peliasWebhookUrl": null,
                                     "pinnedfeedVersionIds": Array [],
                                     "projectBounds": Object {
                                       "east": 0,
@@ -1367,7 +1360,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                     "peliasCsvFiles": Array [],
                                     "peliasResetDb": null,
                                     "peliasUpdate": null,
-                                    "peliasWebhookUrl": null,
                                     "pinnedfeedVersionIds": Array [],
                                     "projectBounds": Object {
                                       "east": 0,
@@ -1435,6 +1427,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                 "name": "mock-project-with-deployments",
                                 "organizationId": null,
                                 "otpServers": Array [],
+                                "peliasWebhookUrl": null,
                                 "pinnedDeploymentId": "mock-deployment-id-0",
                                 "routerConfig": Object {
                                   "carDropoffTime": null,
@@ -1615,7 +1608,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                 "peliasCsvFiles": Array [],
                                 "peliasResetDb": null,
                                 "peliasUpdate": null,
-                                "peliasWebhookUrl": null,
                                 "pinnedfeedVersionIds": Array [],
                                 "projectBounds": Object {
                                   "east": 0,
@@ -1745,7 +1737,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                     "peliasCsvFiles": Array [],
                                     "peliasResetDb": null,
                                     "peliasUpdate": null,
-                                    "peliasWebhookUrl": null,
                                     "pinnedfeedVersionIds": Array [],
                                     "projectBounds": Object {
                                       "east": 0,
@@ -1781,7 +1772,6 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                     "peliasCsvFiles": Array [],
                                     "peliasResetDb": null,
                                     "peliasUpdate": null,
-                                    "peliasWebhookUrl": null,
                                     "pinnedfeedVersionIds": Array [],
                                     "projectBounds": Object {
                                       "east": 0,
@@ -1849,6 +1839,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                 "name": "mock-project-with-deployments",
                                 "organizationId": null,
                                 "otpServers": Array [],
+                                "peliasWebhookUrl": null,
                                 "pinnedDeploymentId": "mock-deployment-id-0",
                                 "routerConfig": Object {
                                   "carDropoffTime": null,

--- a/lib/manager/containers/__tests__/__snapshots__/FeedSourceTable.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/FeedSourceTable.js.snap
@@ -129,7 +129,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
             "peliasCsvFiles": Array [],
             "peliasResetDb": null,
             "peliasUpdate": null,
-            "peliasWebhookUrl": null,
             "pinnedfeedVersionIds": Array [],
             "projectBounds": Object {
               "east": 0,
@@ -197,6 +196,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
         "name": "mock-project-with-deployments",
         "organizationId": null,
         "otpServers": Array [],
+        "peliasWebhookUrl": null,
         "pinnedDeploymentId": null,
         "routerConfig": Object {
           "carDropoffTime": null,
@@ -428,7 +428,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
               "peliasCsvFiles": Array [],
               "peliasResetDb": null,
               "peliasUpdate": null,
-              "peliasWebhookUrl": null,
               "pinnedfeedVersionIds": Array [],
               "projectBounds": Object {
                 "east": 0,
@@ -496,6 +495,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
           "name": "mock-project-with-deployments",
           "organizationId": null,
           "otpServers": Array [],
+          "peliasWebhookUrl": null,
           "pinnedDeploymentId": null,
           "routerConfig": Object {
             "carDropoffTime": null,
@@ -704,7 +704,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                     "peliasCsvFiles": Array [],
                     "peliasResetDb": null,
                     "peliasUpdate": null,
-                    "peliasWebhookUrl": null,
                     "pinnedfeedVersionIds": Array [],
                     "projectBounds": Object {
                       "east": 0,
@@ -772,6 +771,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                 "name": "mock-project-with-deployments",
                 "organizationId": null,
                 "otpServers": Array [],
+                "peliasWebhookUrl": null,
                 "pinnedDeploymentId": null,
                 "routerConfig": Object {
                   "carDropoffTime": null,
@@ -911,7 +911,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                       "peliasCsvFiles": Array [],
                       "peliasResetDb": null,
                       "peliasUpdate": null,
-                      "peliasWebhookUrl": null,
                       "pinnedfeedVersionIds": Array [],
                       "projectBounds": Object {
                         "east": 0,
@@ -979,6 +978,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                   "name": "mock-project-with-deployments",
                   "organizationId": null,
                   "otpServers": Array [],
+                  "peliasWebhookUrl": null,
                   "pinnedDeploymentId": null,
                   "routerConfig": Object {
                     "carDropoffTime": null,
@@ -1138,7 +1138,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                         "peliasCsvFiles": Array [],
                         "peliasResetDb": null,
                         "peliasUpdate": null,
-                        "peliasWebhookUrl": null,
                         "pinnedfeedVersionIds": Array [],
                         "projectBounds": Object {
                           "east": 0,
@@ -1206,6 +1205,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                     "name": "mock-project-with-deployments",
                     "organizationId": null,
                     "otpServers": Array [],
+                    "peliasWebhookUrl": null,
                     "pinnedDeploymentId": null,
                     "routerConfig": Object {
                       "carDropoffTime": null,
@@ -3257,7 +3257,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                             "peliasCsvFiles": Array [],
                             "peliasResetDb": null,
                             "peliasUpdate": null,
-                            "peliasWebhookUrl": null,
                             "pinnedfeedVersionIds": Array [],
                             "projectBounds": Object {
                               "east": 0,
@@ -3325,6 +3324,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                         "name": "mock-project-with-deployments",
                         "organizationId": null,
                         "otpServers": Array [],
+                        "peliasWebhookUrl": null,
                         "pinnedDeploymentId": null,
                         "routerConfig": Object {
                           "carDropoffTime": null,
@@ -3528,7 +3528,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                               "peliasCsvFiles": Array [],
                               "peliasResetDb": null,
                               "peliasUpdate": null,
-                              "peliasWebhookUrl": null,
                               "pinnedfeedVersionIds": Array [],
                               "projectBounds": Object {
                                 "east": 0,
@@ -3596,6 +3595,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                           "name": "mock-project-with-deployments",
                           "organizationId": null,
                           "otpServers": Array [],
+                          "peliasWebhookUrl": null,
                           "pinnedDeploymentId": null,
                           "routerConfig": Object {
                             "carDropoffTime": null,
@@ -3854,7 +3854,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                     "peliasCsvFiles": Array [],
                                     "peliasResetDb": null,
                                     "peliasUpdate": null,
-                                    "peliasWebhookUrl": null,
                                     "pinnedfeedVersionIds": Array [],
                                     "projectBounds": Object {
                                       "east": 0,
@@ -3922,6 +3921,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                 "name": "mock-project-with-deployments",
                                 "organizationId": null,
                                 "otpServers": Array [],
+                                "peliasWebhookUrl": null,
                                 "pinnedDeploymentId": null,
                                 "routerConfig": Object {
                                   "carDropoffTime": null,
@@ -4254,7 +4254,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                                   "peliasCsvFiles": Array [],
                                                   "peliasResetDb": null,
                                                   "peliasUpdate": null,
-                                                  "peliasWebhookUrl": null,
                                                   "pinnedfeedVersionIds": Array [],
                                                   "projectBounds": Object {
                                                     "east": 0,
@@ -4322,6 +4321,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                               "name": "mock-project-with-deployments",
                                               "organizationId": null,
                                               "otpServers": Array [],
+                                              "peliasWebhookUrl": null,
                                               "pinnedDeploymentId": null,
                                               "routerConfig": Object {
                                                 "carDropoffTime": null,
@@ -4663,7 +4663,6 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                     "peliasCsvFiles": Array [],
                                     "peliasResetDb": null,
                                     "peliasUpdate": null,
-                                    "peliasWebhookUrl": null,
                                     "pinnedfeedVersionIds": Array [],
                                     "projectBounds": Object {
                                       "east": 0,
@@ -4731,6 +4730,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                 "name": "mock-project-with-deployments",
                                 "organizationId": null,
                                 "otpServers": Array [],
+                                "peliasWebhookUrl": null,
                                 "pinnedDeploymentId": null,
                                 "routerConfig": Object {
                                   "carDropoffTime": null,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -252,7 +252,6 @@ export type Deployment = {
   peliasCsvFiles: ?Array<string>,
   peliasResetDb: ?boolean,
   peliasUpdate: ?boolean,
-  peliasWebhookUrl: ?string,
   pinnedfeedVersionIds: Array<string>,
   projectBounds: Bounds,
   projectId: string,
@@ -796,10 +795,11 @@ export type Project = {
   name: string,
   organizationId: ?string,
   otpServers?: Array<OtpServer>,
+  peliasWebhookUrl: ?string,
   pinnedDeploymentId: ?string,
   routerConfig: RouterConfig,
-  useCustomOsmBounds: boolean,
-  user: ?any // TODO: define more specific type
+  useCustomOsmBounds: boolean, // TODO: define more specific type
+  user: ?any
 }
 
 export type ReactSelectOption = {

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -798,8 +798,8 @@ export type Project = {
   peliasWebhookUrl: ?string,
   pinnedDeploymentId: ?string,
   routerConfig: RouterConfig,
-  useCustomOsmBounds: boolean, // TODO: define more specific type
-  user: ?any
+  useCustomOsmBounds: boolean,
+  user: ?any // TODO: define more specific type
 }
 
 export type ReactSelectOption = {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

LPI was developed without understanding how it would work in the real world. This PR refactors the LPI UI to work better with how users use it. 

The webhook URL is moved to the project settings, and the LPI can now be updated from any deployment with existing servers. The checkbox has also been refactored into a set of buttons which should be simpler to understand. 

This PR also detaches Pelias deployment from OTP deployment -- failures are handled by not allowing Pelias deployment unless OTP is already deployed.

Requires https://github.com/ibi-group/datatools-server/pull/443