### PR TITLE
fix(editor/util/gtfs): include route_desc in entity name

### DIFF
--- a/lib/editor/util/gtfs.js
+++ b/lib/editor/util/gtfs.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {latLngBounds} from 'leaflet'
+
 import {getGtfsSpec} from '../../common/util/config'
 import {
   generateUID,
@@ -9,7 +10,6 @@ import {
   idealTextColor
 } from '../../common/util/util'
 import {getEntityTableString} from '../../gtfs/util'
-
 import type {
   // EditorTableData,
   Entity,
@@ -260,6 +260,9 @@ export function getEntityName (entity: any): string {
         route.route_long_name !== '""') {
         return `${route.route_short_name} - ${route.route_long_name}`
       } else if (route.route_short_name && route.route_short_name !== '""') {
+        if (route.route_desc && route.route_desc !== '""') {
+          return `${route.route_short_name} - ${route.route_desc}`
+        }
         return route.route_short_name
       } else if (route.route_long_name && route.route_long_name !== '""') {
         return route.route_long_name


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Closes #745 by including the route description in the entity name only if the route_long_name doesn't exist.