### PR TITLE
test(SnapshotModal): fix e2e test

### DIFF
--- a/__tests__/end-to-end.js
+++ b/__tests__/end-to-end.js
@@ -2629,6 +2629,9 @@ describe('end-to-end', () => {
         // wait for dialog to appear
         await waitForSelector('[data-test-id="snapshot-dialog-name"]')
 
+        // confirm that we want to publish with unapproved routes
+        await click('[data-test-id="confirmPublishWithUnapproved"]')
+
         // enter name
         await type('[data-test-id="snapshot-dialog-name"]', 'test-snapshot')
 

--- a/lib/editor/components/CreateSnapshotModal.js
+++ b/lib/editor/components/CreateSnapshotModal.js
@@ -164,6 +164,7 @@ class CreateSnapshotModal extends Component<Props, State> {
               </ul>
               <FormGroup>
                 <Checkbox
+                  data-test-id='confirmPublishWithUnapproved'
                   checked={confirmPublishWithUnapproved}
                   name='confirmPublishWithUnapproved'
                   onChange={this._onTogglePublishUnapproved}>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] All tests and CI builds passing
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

Simple change to allow the e2e test to handle the new snapshot dialog.