### PR TITLE
fix(TimetableEditor): Add continuousPickup and Dropoff values to Stop…

### DIFF
--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -1,25 +1,25 @@
 // @flow
 
-import {camelCaseKeys} from '../../../common/util/map-keys'
 import clone from 'lodash/cloneDeep'
 import objectPath from 'object-path'
 import React, {Component} from 'react'
 import {Button} from 'react-bootstrap'
 
+import {camelCaseKeys} from '../../../common/util/map-keys'
 import * as activeActions from '../../actions/active'
 import * as tripActions from '../../actions/trip'
 import {ENTITY} from '../../constants'
 import {generateNullProps} from '../../util/gtfs'
 import {entityIsNew} from '../../util/objects'
 import {isTimeFormat} from '../../util/timetable'
-import Timetable from './Timetable'
-import TimetableHeader from './TimetableHeader'
-import TimetableHelpModal from './TimetableHelpModal'
-
 import type {Props as ContainerProps} from '../../containers/ActiveTimetableEditor'
 import type {Feed, FetchStatus, Pattern, StopTime, TimetableColumn, Trip, TripCounts} from '../../../types'
 import type {TripValidationIssues} from '../../selectors/timetable'
 import type {EditorTables, TimetableState} from '../../../types/reducers'
+
+import TimetableHelpModal from './TimetableHelpModal'
+import TimetableHeader from './TimetableHeader'
+import Timetable from './Timetable'
 
 type Props = ContainerProps & {
   activeCell?: ?string,
@@ -192,6 +192,8 @@ export default class TimetableEditor extends Component<Props, State> {
         cumulativeTravelTime += +stop.defaultDwellTime
         // if (stop.timepoint === null || stop.timepoint) {
         objectPath.set(newRow, `stopTimes.${i}.departureTime`, cumulativeTravelTime)
+        objectPath.set(newRow, `stopTimes.${i}.continuousPickup`, stop.continuousPickup)
+        objectPath.set(newRow, `stopTimes.${i}.continuousDropOff`, stop.continuousDropOff)
         objectPath.set(newRow, `stopTimes.${i}.timepoint`, stop.timepoint || 0)
         objectPath.set(newRow, `stopTimes.${i}.shapeDistTraveled`, stop.shapeDistTraveled)
         // Use pattern stop index to set stop sequence. Stop sequences should all


### PR DESCRIPTION
…Times object

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

In the current version of datatools, continuous pickup and dropoff values are not properly saved when creating a new trip, only when editing an existing trip. This PR modifies the `constructNewRow` method to add them to the `StopTimes` object when a new trip is created. 

Fixes #755 
