### PR TITLE
Add route_attributes.txt support

### DIFF
--- a/gtfsplus.yml
+++ b/gtfsplus.yml
@@ -350,57 +350,36 @@
     inputType: GTFS_ROUTE
     columnWidth: 4
     helpContent: From GTFS routes.txt file. This is necessary to maintain relationship between routes in this file and routes in the standard GTFS routes.txt file.
-  - name: category_id
+  - name: category
     required: true
     inputType: DROPDOWN
     options:
-    - value: '1'
-      text: Interregional / Intercity
-    - value: '2'
-      text: Regional
-    - value: '3'
-      text: Local
-    - value: '4'
-      text: Community
-    - value: '5'
-      text: Connector
-  - name: subcategory_id
+    - value: 'Interregional / Intercity'
+    - value: 'Regional'
+    - value: Local
+    - value: Community
+    - value: Connector
+  - name: subcategory
     required: true
     inputType: DROPDOWN
     options:
-    - value: '1'
-      text: Interregional / Intercity
-    - value: '2'
-      text: Regional All Day
-    - value: '3'
-      text: Regional Peak
-    - value: '4'
-      text: Regional Owl
-    - value: '5'
-      text: Local All Day
-    - value: '6'
-      text: Local Peak
-    - value: '7'
-      text: Local Owl
-    - value: '8'
-      text: Community All Day
-    - value: '9'
-      text: Community Special
-    - value: '10'
-      text: Community On Demand
-    - value: '11'
-      text: First / Last Mile Connector
-  - name: running_way_id
+    - value: Interregional / Intercity
+    - value: Regional All Day
+    - value: Regional Peak
+    - value: Regional Owl
+    - value: Local All Day
+    - value: Local Peak
+    - value: Local Owl
+    - value: Community All Day
+    - value: Community Special
+    - value: Community On Demand
+    - value: First / Last Mile Connector
+  - name: running_way
     required: true
     inputType: DROPDOWN
     options:
-      - value: '1'
-        text: Fully / Primarily Dedicated
-      - value: '2'
-        text: "Limited Dedicated: Highway/HOV"
-      - value: '3'
-        text: "Limited Dedicated: Local Roadway"
-      - value: '4'
-        text: "Shared, With Signal Priority"
-      - value: '5'
-        text: "Shared, No Priority"
+      - value: Fully / Primarily Dedicated
+      - value: "Limited Dedicated: Highway/HOV"
+      - value: "Limited Dedicated: Local Roadway"
+      - value: "Shared, With Signal Priority"
+      - value: "Shared, No Priority"

--- a/gtfsplus.yml
+++ b/gtfsplus.yml
@@ -340,3 +340,67 @@
     inputType: TEXT
     maxLength: 35
     helpContent: Public name of the fare zone, as it should appear on 511.org such as EastBay, WestBay, etc
+
+- id: route_attributes
+  name: route_attributes.txt
+  helpContent: foobar
+  fields:
+  - name: route_id
+    required: true
+    inputType: GTFS_ROUTE
+    columnWidth: 4
+    helpContent: From GTFS routes.txt file. This is necessary to maintain relationship between routes in this file and routes in the standard GTFS routes.txt file.
+  - name: category_id
+    required: true
+    inputType: DROPDOWN
+    options:
+    - value: '1'
+      text: Interregional / Intercity
+    - value: '2'
+      text: Regional
+    - value: '3'
+      text: Local
+    - value: '4'
+      text: Community
+    - value: '5'
+      text: Connector
+  - name: subcategory_id
+    required: true
+    inputType: DROPDOWN
+    options:
+    - value: '1'
+      text: Interregional / Intercity
+    - value: '2'
+      text: Regional All Day
+    - value: '3'
+      text: Regional Peak
+    - value: '4'
+      text: Regional Owl
+    - value: '5'
+      text: Local All Day
+    - value: '6'
+      text: Local Peak
+    - value: '7'
+      text: Local Owl
+    - value: '8'
+      text: Community All Day
+    - value: '9'
+      text: Community Special
+    - value: '10'
+      text: Community On Demand
+    - value: '11'
+      text: First / Last Mile Connector
+  - name: running_way_id
+    required: true
+    inputType: DROPDOWN
+    options:
+      - value: '1'
+        text: Fully / Primarily Dedicated
+      - value: '2'
+        text: "Limited Dedicated: Highway/HOV"
+      - value: '3'
+        text: "Limited Dedicated: Local Roadway"
+      - value: '4'
+        text: "Shared, With Signal Priority"
+      - value: '5'
+        text: "Shared, No Priority"

--- a/gtfsplus.yml
+++ b/gtfsplus.yml
@@ -366,30 +366,42 @@
           text: Connector
     - name: subcategory
       required: true
-      inputType: GTFS_PLUS_ROUTE_SUBCATEGORY
+      inputType: DROPDOWN
+      parent: 'category'
       options:
-        - value: '0'
+        - parentValue: '0'
           text: Interregional / Intercity
-        - value: '1'
+          value: '0'
+        - parentValue: '1'
           text: Regional All Day
-        - value: '2'
+          value: '1'
+        - parentValue: '1'
           text: Regional Peak
-        - value: '3'
+          value: '2'
+        - parentValue: '1'
           text: Regional Owl
-        - value: '4'
+          value: '3'
+        - parentValue: '2'
           text: Local All Day
-        - value: '5'
+          value: '4'
+        - parentValue: '2'
           text: Local Peak
-        - value: '6'
+          value: '5'
+        - parentValue: '2'
           text: Local Owl
-        - value: '7'
+          value: '6'
+        - parentValue: '3'
           text: Community All Day
-        - value: '8'
+          value: '7'
+        - parentValue: '3'
           text: Community Special
-        - value: '9'
+          value: '8'
+        - parentValue: '3'
           text: Community On Demand
-        - value: '10'
+          value: '9'
+        - parentValue: '4'
           text: First / Last Mile Connector
+          value: '10'
     - name: running_way
       required: true
       inputType: DROPDOWN

--- a/gtfsplus.yml
+++ b/gtfsplus.yml
@@ -350,7 +350,7 @@
       inputType: GTFS_ROUTE
       columnWidth: 4
       helpContent: From GTFS routes.txt file. This is necessary to maintain relationship between routes in this file and routes in the standard GTFS routes.txt file.
-    - name: category
+    - name: category_id
       required: true
       inputType: DROPDOWN
       options:
@@ -364,7 +364,7 @@
           text: Community
         - value: '4'
           text: Connector
-    - name: subcategory
+    - name: subcategory_id
       required: true
       inputType: DROPDOWN
       options:
@@ -390,7 +390,7 @@
           text: Community On Demand
         - value: '10'
           text: First / Last Mile Connector
-    - name: running_way
+    - name: running_way_id
       required: true
       inputType: DROPDOWN
       options:

--- a/gtfsplus.yml
+++ b/gtfsplus.yml
@@ -350,7 +350,7 @@
       inputType: GTFS_ROUTE
       columnWidth: 4
       helpContent: From GTFS routes.txt file. This is necessary to maintain relationship between routes in this file and routes in the standard GTFS routes.txt file.
-    - name: category_id
+    - name: category
       required: true
       inputType: DROPDOWN
       options:
@@ -364,9 +364,9 @@
           text: Community
         - value: '4'
           text: Connector
-    - name: subcategory_id
+    - name: subcategory
       required: true
-      inputType: DROPDOWN
+      inputType: GTFS_PLUS_ROUTE_SUBCATEGORY
       options:
         - value: '0'
           text: Interregional / Intercity
@@ -390,7 +390,7 @@
           text: Community On Demand
         - value: '10'
           text: First / Last Mile Connector
-    - name: running_way_id
+    - name: running_way
       required: true
       inputType: DROPDOWN
       options:

--- a/gtfsplus.yml
+++ b/gtfsplus.yml
@@ -343,43 +343,64 @@
 
 - id: route_attributes
   name: route_attributes.txt
-  helpContent: foobar
+  helpContent: From GTFS+ route_attributes.txt file
   fields:
-  - name: route_id
-    required: true
-    inputType: GTFS_ROUTE
-    columnWidth: 4
-    helpContent: From GTFS routes.txt file. This is necessary to maintain relationship between routes in this file and routes in the standard GTFS routes.txt file.
-  - name: category
-    required: true
-    inputType: DROPDOWN
-    options:
-    - value: 'Interregional / Intercity'
-    - value: 'Regional'
-    - value: Local
-    - value: Community
-    - value: Connector
-  - name: subcategory
-    required: true
-    inputType: DROPDOWN
-    options:
-    - value: Interregional / Intercity
-    - value: Regional All Day
-    - value: Regional Peak
-    - value: Regional Owl
-    - value: Local All Day
-    - value: Local Peak
-    - value: Local Owl
-    - value: Community All Day
-    - value: Community Special
-    - value: Community On Demand
-    - value: First / Last Mile Connector
-  - name: running_way
-    required: true
-    inputType: DROPDOWN
-    options:
-      - value: Fully / Primarily Dedicated
-      - value: "Limited Dedicated: Highway/HOV"
-      - value: "Limited Dedicated: Local Roadway"
-      - value: "Shared, With Signal Priority"
-      - value: "Shared, No Priority"
+    - name: route_id
+      required: true
+      inputType: GTFS_ROUTE
+      columnWidth: 4
+      helpContent: From GTFS routes.txt file. This is necessary to maintain relationship between routes in this file and routes in the standard GTFS routes.txt file.
+    - name: category
+      required: true
+      inputType: DROPDOWN
+      options:
+        - value: '0'
+          text: 'Interregional / Intercity'
+        - value: '1'
+          text: 'Regional'
+        - value: '2'
+          text: Local
+        - value: '3'
+          text: Community
+        - value: '4'
+          text: Connector
+    - name: subcategory
+      required: true
+      inputType: DROPDOWN
+      options:
+        - value: '0'
+          text: Interregional / Intercity
+        - value: '1'
+          text: Regional All Day
+        - value: '2'
+          text: Regional Peak
+        - value: '3'
+          text: Regional Owl
+        - value: '4'
+          text: Local All Day
+        - value: '5'
+          text: Local Peak
+        - value: '6'
+          text: Local Owl
+        - value: '7'
+          text: Community All Day
+        - value: '8'
+          text: Community Special
+        - value: '9'
+          text: Community On Demand
+        - value: '10'
+          text: First / Last Mile Connector
+    - name: running_way
+      required: true
+      inputType: DROPDOWN
+      options:
+        - value: '0'
+          text: Fully / Primarily Dedicated
+        - value: '1'
+          text: "Limited Dedicated: Highway/HOV"
+        - value: '2'
+          text: "Limited Dedicated: Local Roadway"
+        - value: '3'
+          text: "Shared, With Signal Priority"
+        - value: '4'
+          text: "Shared, No Priority"

--- a/gtfsplus.yml
+++ b/gtfsplus.yml
@@ -355,9 +355,9 @@
       inputType: DROPDOWN
       options:
         - value: '0'
-          text: 'Interregional / Intercity'
+          text: Interregional / Intercity
         - value: '1'
-          text: 'Regional'
+          text: Regional
         - value: '2'
           text: Local
         - value: '3'
@@ -413,6 +413,6 @@
         - value: '2'
           text: "Limited Dedicated: Local Roadway"
         - value: '3'
-          text: "Shared, With Signal Priority"
+          text: Shared, With Signal Priority
         - value: '4'
-          text: "Shared, No Priority"
+          text: Shared, No Priority

--- a/lib/gtfsplus/components/GtfsPlusField.js
+++ b/lib/gtfsplus/components/GtfsPlusField.js
@@ -12,25 +12,10 @@ import type {Props as GtfsPlusTableProps} from './GtfsPlusTable'
 
 type Props = GtfsPlusTableProps & {
   currentValue: any,
+  data: any,
   field: GtfsPlusFieldType,
   row: number
 }
-
-// Maps subcategories to categories, shown as strings to avoid conversion ambiguities.
-const routeSubcategoryToCategory = {
-  '0': '0',
-  '1': '1',
-  '2': '1',
-  '3': '1',
-  '4': '2',
-  '5': '2',
-  '6': '2',
-  '7': '3',
-  '8': '3',
-  '9': '3',
-  '10': '4'
-}
-
 export default class GtfsPlusField extends Component<Props> {
   _onChangeRoute = ({route}: {route: GtfsRoute}) => {
     const {field, receiveGtfsEntities, row: rowIndex, table, updateGtfsPlusField} = this.props
@@ -58,7 +43,6 @@ export default class GtfsPlusField extends Component<Props> {
 
   render () {
     const {currentValue, data, feedVersion, field, getGtfsEntity} = this.props
-    let filterOptions
     switch (field.inputType) {
       case 'TEXT':
       case 'GTFS_TRIP':
@@ -70,10 +54,6 @@ export default class GtfsPlusField extends Component<Props> {
             value={currentValue}
             onChange={this._onChangeValue} />
         )
-      case 'GTFS_PLUS_ROUTE_SUBCATEGORY':
-        filterOptions = (option) => routeSubcategoryToCategory[option.value] === data.category
-      // FIXME:
-      // eslint-disable-next-line no-fallthrough
       case 'DROPDOWN':
         const {options} = field
         if (!options) {
@@ -81,15 +61,15 @@ export default class GtfsPlusField extends Component<Props> {
           return null
         }
 
-        // console.log(options)
-        console.log(data)
-        const filteredOptions = filterOptions ? options.filter(filterOptions) : options
-        console.log(filteredOptions)
-
         // NOTE: client has requested that GTFS+ fields be case insensitive
         // (hence the toUpperCase call)
         const option = currentValue &&
           options.find(o => o.value.toUpperCase() === currentValue.toUpperCase())
+
+        const filteredOptions = field.parent && option && option.parentValue
+          ? options.filter((option) => option.parentValue === data[field.parent])
+          : options
+
         return (
           <FormControl componentClass='select'
             value={option ? option.value : ''}

--- a/lib/gtfsplus/components/GtfsPlusField.js
+++ b/lib/gtfsplus/components/GtfsPlusField.js
@@ -6,14 +6,29 @@ import {FormControl} from 'react-bootstrap'
 import EditableTextField from '../../common/components/EditableTextField'
 import {getRouteName} from '../../editor/util/gtfs'
 import GtfsSearch from '../../gtfs/components/gtfs-search'
+import type {GtfsSpecField as GtfsPlusFieldType, GtfsRoute, GtfsStop} from '../../types'
 
 import type {Props as GtfsPlusTableProps} from './GtfsPlusTable'
-import type {GtfsSpecField as GtfsPlusFieldType, GtfsRoute, GtfsStop} from '../../types'
 
 type Props = GtfsPlusTableProps & {
   currentValue: any,
   field: GtfsPlusFieldType,
   row: number
+}
+
+// Maps subcategories to categories, shown as strings to avoid conversion ambiguities.
+const routeSubcategoryToCategory = {
+  '0': '0',
+  '1': '1',
+  '2': '1',
+  '3': '1',
+  '4': '2',
+  '5': '2',
+  '6': '2',
+  '7': '3',
+  '8': '3',
+  '9': '3',
+  '10': '4'
 }
 
 export default class GtfsPlusField extends Component<Props> {
@@ -42,7 +57,8 @@ export default class GtfsPlusField extends Component<Props> {
   }
 
   render () {
-    const {currentValue, feedVersion, field, getGtfsEntity} = this.props
+    const {currentValue, data, feedVersion, field, getGtfsEntity} = this.props
+    let filterOptions
     switch (field.inputType) {
       case 'TEXT':
       case 'GTFS_TRIP':
@@ -54,12 +70,22 @@ export default class GtfsPlusField extends Component<Props> {
             value={currentValue}
             onChange={this._onChangeValue} />
         )
+      case 'GTFS_PLUS_ROUTE_SUBCATEGORY':
+        filterOptions = (option) => routeSubcategoryToCategory[option.value] === data.category
+      // FIXME:
+      // eslint-disable-next-line no-fallthrough
       case 'DROPDOWN':
         const {options} = field
         if (!options) {
           console.warn(`GTFS+ field has no options defined.`, field)
           return null
         }
+
+        // console.log(options)
+        console.log(data)
+        const filteredOptions = filterOptions ? options.filter(filterOptions) : options
+        console.log(filteredOptions)
+
         // NOTE: client has requested that GTFS+ fields be case insensitive
         // (hence the toUpperCase call)
         const option = currentValue &&
@@ -69,7 +95,7 @@ export default class GtfsPlusField extends Component<Props> {
             value={option ? option.value : ''}
             onChange={this._onChange}>
             {/* Add field for empty string value if that is not an allowable option so that user selection triggers onChange */}
-            {options.findIndex(option => option.value === '') === -1
+            {filteredOptions.findIndex(option => option.value === '') === -1
               ? <option
                 disabled
                 value=''>
@@ -77,7 +103,7 @@ export default class GtfsPlusField extends Component<Props> {
               </option>
               : null
             }
-            {options.map(option => {
+            {filteredOptions.map(option => {
               // NOTE: client has requested that GTFS+ fields be case
               // insensitive (hence the toLowerCase call)
               return <option value={option.value} key={option.value}>

--- a/lib/gtfsplus/components/GtfsPlusField.js
+++ b/lib/gtfsplus/components/GtfsPlusField.js
@@ -66,8 +66,8 @@ export default class GtfsPlusField extends Component<Props> {
         const option = currentValue &&
           options.find(o => o.value.toUpperCase() === currentValue.toUpperCase())
 
-        const filteredOptions = field.parent && option && option.parentValue
-          ? options.filter((option) => option.parentValue === data[field.parent])
+        const filteredOptions = field.parent
+          ? options.filter((option) => option.parentValue ? option.parentValue === data[field.parent] : true)
           : options
 
         return (

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -655,7 +655,8 @@ export type GtfsSpecField = {
   helpContent?: string,
   inputType: InputType,
   name: string,
-  options?: Array<{text: string, value: string}>,
+  options?: Array<{parentValue?: string, text: string, value: string}>,
+  parent?: string,
   placeholder?: string,
   required: boolean
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

The schema for the gtfsplus.yml file was modified slightly to accommodate the new route_attributes.txt GTFS+ file. This adds the ability for dropdown fields to have a "parent" field, which limits the option in the child field based on the parent. 
