### PR TITLE
Display null continuous_pickup as 1 (no continous pickup)

### DIFF
--- a/lib/editor/components/pattern/PatternStopCard.js
+++ b/lib/editor/components/pattern/PatternStopCard.js
@@ -424,7 +424,7 @@ class PatternStopContents extends Component<Props, State> {
               selectType='continuousPickup'
               shouldHaveDisabledOption
               title='Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path.'
-              value={patternStop.continuousPickup || ''}
+              value={patternStop.continuousPickup || 1}
             />
           </Col>
           <Col xs={6}>
@@ -435,7 +435,7 @@ class PatternStopContents extends Component<Props, State> {
               selectType='continuousDropOff'
               shouldHaveDisabledOption
               title='Indicates whether a rider can alight from the transit vehicle at any point along the vehicle’s travel path.'
-              value={patternStop.continuousDropOff || ''}
+              value={patternStop.continuousDropOff || 1}
             />
           </Col>
         </Row>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Empty values of continuous_pickup and drop_off are misinterpreted by the front end as “0 - Available”. The correct value is 1 - Not Available. 
