### PR TITLE
Allow language code to match code with region

### DIFF
--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1,4 +1,4 @@
-_id: pl-PL
+_id: pl
 _name: Polski
 components:
   Breadcrumbs:

--- a/lib/common/util/config.js
+++ b/lib/common/util/config.js
@@ -121,8 +121,9 @@ function initializeConfig () {
   const languageId = window.localStorage.getItem('lang')
     ? window.localStorage.getItem('lang')
     : navigator.language
-  const active = languages.find(l => languageId.includes(l._id)) ||
-    languages.find(l => l._id === 'en-US')
+  const active = languages.find(
+    l => l._id === languageId || languageId.startsWith(l._id)
+  ) || languages.find(l => l._id === 'en-US')
   if (!active) throw new Error('Language file is misconfigured!')
   // is an array containing all the matching modules
   config.messages = {

--- a/lib/common/util/config.js
+++ b/lib/common/util/config.js
@@ -121,7 +121,7 @@ function initializeConfig () {
   const languageId = window.localStorage.getItem('lang')
     ? window.localStorage.getItem('lang')
     : navigator.language
-  const active = languages.find(l => l._id.includes(languageId)) ||
+  const active = languages.find(l => languageId.includes(l._id)) ||
     languages.find(l => l._id === 'en-US')
   if (!active) throw new Error('Language file is misconfigured!')
   // is an array containing all the matching modules

--- a/lib/common/util/config.js
+++ b/lib/common/util/config.js
@@ -121,7 +121,7 @@ function initializeConfig () {
   const languageId = window.localStorage.getItem('lang')
     ? window.localStorage.getItem('lang')
     : navigator.language
-  const active = languages.find(l => l._id === languageId) ||
+  const active = languages.find(l => l._id.includes(languageId)) ||
     languages.find(l => l._id === 'en-US')
   if (!active) throw new Error('Language file is misconfigured!')
   // is an array containing all the matching modules


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds support for matching a language code without a region to the specific ID in our language files (i.e. "pl" is matched because it is included in "pl-PL"). This should hopefully allow easier use of internationalization in datatools. 