### PR TITLE
Add optional parameter to avoid motorways in Graphhopper routing

### DIFF
--- a/lib/editor/actions/map/index.js
+++ b/lib/editor/actions/map/index.js
@@ -19,7 +19,6 @@ import {
   newControlPoint,
   shapePointsToSimpleCoordinates
 } from '../../util/map'
-
 import type {Feed, LatLng, Pattern, ControlPoint} from '../../../types'
 import type {dispatchFn, getStateFn} from '../../../types/reducers'
 
@@ -163,8 +162,9 @@ export function handleControlPointDrag (
   patternCoordinates: any
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    const {currentDragId, followStreets} = getState().editor.editSettings.present
+    const {avoidMotorways, currentDragId, followStreets} = getState().editor.editSettings.present
     recalculateShape({
+      avoidMotorways,
       controlPoints,
       defaultToStraightLine: false,
       dragId: currentDragId,
@@ -204,8 +204,9 @@ export function handleControlPointDragEnd (
     dispatch(controlPointDragOrEnd())
 
     // recalculate shape for final position
-    const {followStreets} = getState().editor.editSettings.present
+    const {avoidMotorways, followStreets} = getState().editor.editSettings.present
     recalculateShape({
+      avoidMotorways,
       controlPoints,
       defaultToStraightLine: false,
       editType: 'update',
@@ -243,11 +244,12 @@ export function handleControlPointDragStart (controlPoint: ControlPoint) {
 
 export function removeControlPoint (controlPoints: Array<ControlPoint>, index: number, pattern: Pattern, patternCoordinates: any) {
   return async function (dispatch: dispatchFn, getState: getStateFn) {
-    const {followStreets} = getState().editor.editSettings.present
+    const {avoidMotorways, followStreets} = getState().editor.editSettings.present
     const {
       coordinates,
       updatedControlPoints
     } = await recalculateShape({
+      avoidMotorways,
       controlPoints,
       editType: 'delete',
       index,

--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -32,7 +32,6 @@ import {
   constructPoint
 } from '../../util/map'
 import {coordinatesFromShapePoints} from '../../util/objects'
-
 import type {ControlPoint, GtfsStop, LatLng, Pattern} from '../../../types'
 import type {dispatchFn, getStateFn} from '../../../types/reducers'
 
@@ -223,7 +222,7 @@ export function addStopAtInterval (latlng: LatLng, activePattern: Pattern, contr
 export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?number) {
   return async function (dispatch: dispatchFn, getState: getStateFn) {
     const {data, editSettings} = getState().editor
-    const {followStreets} = editSettings.present
+    const {avoidMotorways, followStreets} = editSettings.present
     const {patternStops: currentPatternStops, shapePoints} = pattern
     const patternStops = clone(currentPatternStops)
     const {controlPoints, patternSegments} = getControlPoints(getState())
@@ -273,7 +272,7 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
           }
           const points = [previousStop, stop]
             .map((stop, index) => ({lng: stop.stop_lon, lat: stop.stop_lat}))
-          const patternSegments = await getPolyline(points, true)
+          const patternSegments = await getPolyline(points, true, avoidMotorways)
           // Update pattern stops and geometry.
           const controlPoints = controlPointsFromSegments(patternStops, patternSegments)
           dispatch(updatePatternGeometry({controlPoints, patternSegments}))
@@ -332,6 +331,7 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
         let result
         try {
           result = await recalculateShape({
+            avoidMotorways,
             controlPoints: clonedControlPoints,
             defaultToStraightLine: false,
             editType: 'update',
@@ -372,6 +372,7 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
         clonedPatternSegments.splice(0, 0, [])
         try {
           result = await recalculateShape({
+            avoidMotorways: avoidMotorways,
             controlPoints: clonedControlPoints,
             defaultToStraightLine: false,
             editType: 'update',
@@ -405,12 +406,12 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
  */
 function extendPatternToPoint (pattern, endPoint, newEndPoint, stop = null, splitInterval = 0) {
   return async function (dispatch: dispatchFn, getState: getStateFn) {
-    const {followStreets} = getState().editor.editSettings.present
+    const {avoidMotorways, followStreets} = getState().editor.editSettings.present
     const {controlPoints, patternSegments} = getControlPoints(getState())
     const clonedControlPoints = clone(controlPoints)
     let newShape
     if (followStreets) {
-      newShape = await getPolyline([endPoint, newEndPoint])
+      newShape = await getPolyline([endPoint, newEndPoint], false, avoidMotorways)
     }
     if (!newShape) {
       // Get single coordinate for straight line if polyline fails or if not
@@ -502,10 +503,11 @@ export function removeStopFromPattern (pattern: Pattern, stop: GtfsStop, index: 
       // If pattern has no shape points, don't attempt to refactor pattern shape
       console.log('pattern coordinates do not exist')
     } else {
-      const {followStreets} = getState().editor.editSettings.present
+      const {avoidMotorways, followStreets} = getState().editor.editSettings.present
       let result
       try {
         result = await recalculateShape({
+          avoidMotorways,
           controlPoints: clonedControlPoints,
           editType: 'delete',
           index: cpIndex,

--- a/lib/editor/components/pattern/EditSettings.js
+++ b/lib/editor/components/pattern/EditSettings.js
@@ -65,7 +65,7 @@ export default class EditSettings extends Component<Props, State> {
     } = editSettings
     const SETTINGS = [
       {type: 'followStreets', label: 'Snap to streets'},
-      {type: 'avoidMotorways', label: 'Avoid motorways in routing'},
+      {type: 'avoidMotorways', label: 'Avoid highways in routing'},
       {type: 'hideStopHandles', label: 'Hide stop handles'},
       {type: 'hideInactiveSegments', label: 'Hide inactive segments'},
       {type: 'showStops', label: 'Show stops'},

--- a/lib/editor/components/pattern/EditSettings.js
+++ b/lib/editor/components/pattern/EditSettings.js
@@ -7,7 +7,6 @@ import Rcslider from 'rc-slider'
 import {updateEditSetting} from '../../actions/active'
 import {CLICK_OPTIONS} from '../../util'
 import toSentenceCase from '../../../common/util/to-sentence-case'
-
 import type {EditSettingsState} from '../../../types/reducers'
 
 type Props = {
@@ -60,11 +59,13 @@ export default class EditSettings extends Component<Props, State> {
     const {editSettings, patternSegment, updateEditSetting} = this.props
     const {
       editGeometry,
+      followStreets,
       onMapClick,
       stopInterval
     } = editSettings
     const SETTINGS = [
       {type: 'followStreets', label: 'Snap to streets'},
+      {type: 'avoidMotorways', label: 'Avoid motorways in routing'},
       {type: 'hideStopHandles', label: 'Hide stop handles'},
       {type: 'hideInactiveSegments', label: 'Hide inactive segments'},
       {type: 'showStops', label: 'Show stops'},
@@ -80,7 +81,10 @@ export default class EditSettings extends Component<Props, State> {
             key={s.type}
             // Disable hide inactive segments if no segment is selected (hiding in
             // this state would cause the entire shape to disappear).
-            disabled={s.type === 'hideInactiveSegments' && noSegmentIsActive}
+            disabled={
+              (s.type === 'hideInactiveSegments' && noSegmentIsActive) ||
+              (s.type === 'avoidMotorways' && !followStreets)
+            }
             name={s.type}
             style={{margin: '3px 0'}}
             onChange={this._onCheckboxChange}>

--- a/lib/editor/components/pattern/EditShapePanel.js
+++ b/lib/editor/components/pattern/EditShapePanel.js
@@ -13,7 +13,6 @@ import * as mapActions from '../../actions/map'
 import {ARROW_MAGENTA, PATTERN_TO_STOP_DISTANCE_THRESHOLD_METERS} from '../../constants'
 import * as tripPatternActions from '../../actions/tripPattern'
 import OptionButton from '../../../common/components/OptionButton'
-import EditSettings from './EditSettings'
 import * as statusActions from '../../../manager/actions/status'
 import {polyline as getPolyline} from '../../../scenario-editor/utils/valhalla'
 import {
@@ -22,9 +21,10 @@ import {
   getPatternDistance,
   isValidStopControlPoint
 } from '../../util/map'
-
 import type {ControlPoint, LatLng, Pattern, GtfsStop} from '../../../types'
 import type {EditSettingsUndoState} from '../../../types/reducers'
+
+import EditSettings from './EditSettings'
 
 type Props = {
   activePattern: Pattern,
@@ -49,10 +49,10 @@ export default class EditShapePanel extends Component<Props> {
    * Construct new pattern geometry from the pattern stop locations.
    */
   async drawPatternFromStops (pattern: Pattern, stopsCoordinates: Array<LatLng>, followStreets: boolean): Promise<any> {
-    const {saveActiveGtfsEntity, setErrorMessage, updatePatternGeometry} = this.props
+    const {editSettings, saveActiveGtfsEntity, setErrorMessage, updatePatternGeometry} = this.props
     let patternSegments = []
     if (followStreets) {
-      patternSegments = await getPolyline(stopsCoordinates, true)
+      patternSegments = await getPolyline(stopsCoordinates, true, editSettings.present.avoidMotorways)
     } else {
       // Construct straight-line segments using stop coordinates
       stopsCoordinates

--- a/lib/editor/reducers/settings.js
+++ b/lib/editor/reducers/settings.js
@@ -10,12 +10,12 @@ import {
   updateTempPatternGeometry
 } from '../actions/map'
 import { CLICK_OPTIONS } from '../util'
-
 import type {EditSettingsState} from '../../types/reducers'
 
 export const defaultState = {
   addStops: false,
   afterIntersection: true,
+  avoidMotorways: false,
   controlPoints: null,
   currentDragId: null,
   distanceFromIntersection: 5,

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -16,9 +16,7 @@ import {ENTITY, POINT_TYPE} from '../constants'
 import {getSegment} from '../../scenario-editor/utils/valhalla'
 import {generateUID} from '../../common/util/util'
 import {getConfigProperty} from '../../common/util/config'
-import {coordinatesFromShapePoints} from './objects'
 import {reverseEsri as reverse} from '../../scenario-editor/utils/reverse'
-
 import type {
   ControlPoint,
   Coordinate,
@@ -33,6 +31,8 @@ import type {
   ShapePoint,
   StopTime
 } from '../../types'
+
+import {coordinatesFromShapePoints} from './objects'
 
 type R5Response = {
   data: {
@@ -258,6 +258,7 @@ export function getPatternEndPoint (pattern: Pattern, controlPoints?: Array<Cont
 
 /* eslint-disable complexity */
 export async function recalculateShape ({
+  avoidMotorways = false,
   controlPoints,
   defaultToStraightLine = true,
   dragId,
@@ -268,6 +269,7 @@ export async function recalculateShape ({
   patternCoordinates,
   snapControlPointToNewSegment = false
 }: {
+  avoidMotorways?: boolean,
   controlPoints: Array<ControlPoint>,
   defaultToStraightLine?: boolean,
   dragId?: null | string,
@@ -391,7 +393,8 @@ export async function recalculateShape ({
   const newSegment = await getSegment(
     pointsToRoute,
     followStreets,
-    defaultToStraightLine
+    defaultToStraightLine,
+    avoidMotorways
   )
   if (!newSegment || !newSegment.coordinates) {
     // If new segment calculation is unsuccessful, return null for coordinates and

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -149,7 +149,8 @@ export async function polyline (
 export async function getSegment (
   points: Coordinates,
   followRoad: boolean,
-  defaultToStraightLine: boolean = true
+  defaultToStraightLine: boolean = true,
+  avoidMotorways: boolean = false
 ): Promise<?{
   coordinates: Coordinates,
   type: 'LineString'
@@ -159,7 +160,9 @@ export async function getSegment (
   if (followRoad) {
     // if snapping to streets, use routing service.
     const coordinates = await polyline(
-      points.map(p => ({lng: p[0], lat: p[1]}))
+      points.map(p => ({lng: p[0], lat: p[1]})),
+      false,
+      avoidMotorways
     )
     if (!coordinates) {
       // If routing was unsuccessful, default to straight line (if desired by
@@ -213,7 +216,6 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   }
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   // Avoiding motorways requires a POST request with a formatted body
-  console.log('avoidMotorways:', avoidMotorways)
   const graphHopperRequest = avoidMotorways
     ? fetch(`${GRAPH_HOPPER_URL}route?key=${params.key}`,
       {

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -3,7 +3,6 @@
 import fetch from 'isomorphic-fetch'
 import {decode as decodePolyline} from 'polyline'
 import {isEqual as coordinatesAreEqual} from '@conveyal/lonlat'
-import qs from 'qs'
 import lineString from 'turf-linestring'
 
 // This can be used for logging line strings to geojson.io URLs for easy
@@ -204,14 +203,27 @@ export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopp
   }
   // Use custom url if it exists, otherwise default to the hosted service.
   const GRAPH_HOPPER_URL = process.env.GRAPH_HOPPER_URL || 'https://graphhopper.com/api/1/'
-  const params = {
-    key: process.env.GRAPH_HOPPER_KEY,
-    vehicle: 'car',
-    debug: true,
-    type: 'json'
-  }
-  const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
+
   return fetch(
-    `${GRAPH_HOPPER_URL}route?${locations}&${qs.stringify(params)}`
+    `${GRAPH_HOPPER_URL}route?key=${process.env.GRAPH_HOPPER_KEY}`,
+    // New custom routing headers
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        'ch.disable': true,
+        custom_model: {
+          'priority': [{
+            'if': 'road_class == MOTORWAY',
+            'multiply_by': 0.1
+          }]
+        },
+        key: process.env.GRAPH_HOPPER_KEY,
+        points: points.map(p => [p.lng, p.lat]),
+        profile: 'car'
+      })
+    }
   ).then(res => res.json())
 }

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -3,6 +3,7 @@
 import fetch from 'isomorphic-fetch'
 import {decode as decodePolyline} from 'polyline'
 import {isEqual as coordinatesAreEqual} from '@conveyal/lonlat'
+import qs from 'qs'
 import lineString from 'turf-linestring'
 
 // This can be used for logging line strings to geojson.io URLs for easy
@@ -104,7 +105,8 @@ function handleGraphHopperRouting (path: Path, individualLegs: boolean = false):
  */
 export async function polyline (
   points: Array<LatLng>,
-  individualLegs?: boolean = false
+  individualLegs?: boolean = false,
+  avoidMotorways?: boolean = false
 ): Promise<any> {
   let json
   const geometry = []
@@ -124,7 +126,7 @@ export async function polyline (
       const beginIndex = i + offset
       const endIndex = i + chunk + offset
       const chunkedPoints = points.slice(beginIndex, endIndex)
-      json = await routeWithGraphHopper(chunkedPoints)
+      json = await routeWithGraphHopper(chunkedPoints, avoidMotorways)
       const path = json && json.paths && json.paths[0]
       // Route between chunked list of points
       if (path) {
@@ -193,7 +195,7 @@ export async function getSegment (
  *
  * Example URL: https://graphhopper.com/api/1/route?point=49.932707,11.588051&point=50.3404,11.64705&vehicle=car&debug=true&&type=json
  */
-export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopperResponse> {
+export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: boolean): ?Promise<GraphHopperResponse> {
   if (points.length < 2) {
     console.warn('need at least two points to route with graphhopper', points)
     return null
@@ -203,27 +205,37 @@ export function routeWithGraphHopper (points: Array<LatLng>): ?Promise<GraphHopp
   }
   // Use custom url if it exists, otherwise default to the hosted service.
   const GRAPH_HOPPER_URL = process.env.GRAPH_HOPPER_URL || 'https://graphhopper.com/api/1/'
-
-  return fetch(
-    `${GRAPH_HOPPER_URL}route?key=${process.env.GRAPH_HOPPER_KEY}`,
-    // New custom routing headers
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        'ch.disable': true,
-        custom_model: {
-          'priority': [{
-            'if': 'road_class == MOTORWAY',
-            'multiply_by': 0.1
-          }]
+  const params = {
+    key: process.env.GRAPH_HOPPER_KEY,
+    vehicle: 'car',
+    debug: true,
+    type: 'json'
+  }
+  const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
+  // Avoiding motorways requires a POST request with a formatted body
+  console.log('avoidMotorways:', avoidMotorways)
+  const graphHopperRequest = avoidMotorways
+    ? fetch(`${GRAPH_HOPPER_URL}route?key=${params.key}`,
+      {
+        body: JSON.stringify({
+          'ch.disable': true,
+          // Custom model disincentives motorways
+          custom_model: {
+            'priority': [{
+              'if': 'road_class == MOTORWAY',
+              'multiply_by': 0.1
+            }]
+          },
+          debug: params.debug,
+          points: points.map(p => [p.lng, p.lat]),
+          profile: params.vehicle
+        }),
+        headers: {
+          'Content-Type': 'application/json'
         },
-        key: process.env.GRAPH_HOPPER_KEY,
-        points: points.map(p => [p.lng, p.lat]),
-        profile: 'car'
+        method: 'POST'
       })
-    }
-  ).then(res => res.json())
+    : fetch(`${GRAPH_HOPPER_URL}route?${locations}&${qs.stringify(params)}`)
+
+  return graphHopperRequest.then(res => res.json())
 }

--- a/lib/types/reducers.js
+++ b/lib/types/reducers.js
@@ -209,6 +209,7 @@ export type DataState = {
 export type EditSettingsState = {
   addStops: boolean,
   afterIntersection: boolean,
+  avoidMotorways: boolean,
   controlPoints: null | Array<ControlPoint>,
   currentDragId: null | string,
   distanceFromIntersection: number,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

This PR adds a checkbox to allow graphhopper routing to avoid the OSM road class "[Motorways](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway#:~:text=The%20tag%20highway%20%3D%20motorway%20is,local%20context%20and%20prevailing%20convention.)". 
