### PR TITLE
Fix timetable previous stop time checks from checking text columns.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ env.yml-original
 scripts/*client.json
 
 # Vs code settings
-.vscode
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ env.yml-original
 .env
 !configurations/test/env.yml
 scripts/*client.json
+
+# Vs code settings
+.vscode

--- a/lib/editor/selectors/timetable.js
+++ b/lib/editor/selectors/timetable.js
@@ -150,7 +150,7 @@ const isCellValueInvalid = (
       let previousValue = null
       let previousIndex = colIndex - 1
       // Find previous stop time
-      while (previousValue === null && previousIndex >= 0 && columns[previousIndex].type !== 'TEXT') {
+      while (previousValue === null && previousIndex >= 0 && (columns[previousIndex].type === 'ARRIVAL_TIME' || columns[previousIndex].type === 'DEPARTURE_TIME')) {
         const previousCol = columns[previousIndex]
         previousValue = previousCol && row && objectPath.get(row, previousCol.key)
         previousIndex--

--- a/lib/editor/selectors/timetable.js
+++ b/lib/editor/selectors/timetable.js
@@ -4,14 +4,12 @@ import objectPath from 'object-path'
 
 import { getAbbreviatedStopName, getTableById } from '../util/gtfs'
 import { isTimeFormat } from '../util/timetable'
-
 import type {
   GtfsStop,
   Pattern,
   TimetableColumn,
   Trip
 } from '../../types'
-
 import type { AppState } from '../../types/reducers'
 import type { EditorValidationIssue } from '../util/validation'
 
@@ -152,7 +150,7 @@ const isCellValueInvalid = (
       let previousValue = null
       let previousIndex = colIndex - 1
       // Find previous stop time
-      while (previousValue === null && previousIndex >= 0) {
+      while (previousValue === null && previousIndex >= 0 && columns[previousIndex].type !== 'TEXT') {
         const previousCol = columns[previousIndex]
         previousValue = previousCol && row && objectPath.get(row, previousCol.key)
         previousIndex--


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Currently, naming a trip ID (or filling any other text field) with a number greater than the start time of the first arrival time produces a validation error in the UI since validation takes place for _all_ columns left of the stop time. This PR adds a condition to only check columns that are not of type 'TEXT'. 

The PR also adds VS code `settings.json` to the `.gitignore` file, which I hope won't be controversial. 

Issue screenshot: 
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/63798641/158633998-3bbc3bd8-e6d9-4bb1-a35a-fda0330fc4a6.png">

