### PR TITLE
Improve feed versions load

### DIFF
--- a/lib/gtfsplus/components/GtfsPlusVersionSummary.js
+++ b/lib/gtfsplus/components/GtfsPlusVersionSummary.js
@@ -15,7 +15,6 @@ import {
 import {browserHistory, Link} from 'react-router'
 
 import * as gtfsPlusActions from '../actions/gtfsplus'
-
 import {getGtfsPlusSpec} from '../../common/util/config'
 import type {Props as ContainerProps} from '../containers/ActiveGtfsPlusVersionSummary'
 import type {GtfsPlusValidationIssue} from '../../types'
@@ -110,7 +109,7 @@ export default class GtfsPlusVersionSummary extends Component<Props, State> {
       gtfsplus,
       user,
       version,
-      versions
+      versionSummaries = []
     } = this.props
     const { feedSource } = version
     const editingIsDisabled = !user.permissions ||
@@ -133,7 +132,7 @@ export default class GtfsPlusVersionSummary extends Component<Props, State> {
       </h3>
     )
 
-    const derivedVersions = versions.filter(v => v.originNamespace === version.namespace)
+    const derivedVersions = versionSummaries.filter(v => v.originNamespace === version.namespace)
     return (
       <Panel header={header}>
         <Row>
@@ -145,7 +144,7 @@ export default class GtfsPlusVersionSummary extends Component<Props, State> {
                   Versions created from this version of GTFS+:
                   <ul>
                     {derivedVersions.map(v => {
-                      const url = `/feed/${v.feedSource.id}/version/${v.version}`
+                      const url = `/feed/${feedSource.id}/version/${v.version}`
                       return (
                         <li key={v.id}>
                           <Link to={url}>

--- a/lib/gtfsplus/containers/ActiveGtfsPlusVersionSummary.js
+++ b/lib/gtfsplus/containers/ActiveGtfsPlusVersionSummary.js
@@ -3,16 +3,14 @@
 import {connect} from 'react-redux'
 
 import GtfsPlusVersionSummary from '../components/GtfsPlusVersionSummary'
-
 import {deleteGtfsPlusFeed, downloadGtfsPlusFeed, publishGtfsPlusFeed} from '../actions/gtfsplus'
 import {getValidationIssuesForTable} from '../selectors'
-
-import type {FeedVersion} from '../../types'
+import type {FeedVersion, FeedVersionSummary} from '../../types'
 import type {AppState} from '../../types/reducers'
 
 export type Props = {
   version: FeedVersion,
-  versions: Array<FeedVersion>
+  versionSummaries?: Array<FeedVersionSummary>
 }
 
 const mapStateToProps = (state: AppState, ownProps: Props) => {

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -616,26 +616,24 @@ export function setVersionIndex (
   }
 }
 
-// Sets the compared feed version.
+/**
+ * Sets the compared feed version.
+ */
 export const settingComparedVersion = createAction(
   'SET_COMPARED_FEEDVERSION',
   (payload: FeedVersion) => payload
 )
+
+/**
+ * Sets the compared feed version based on the provided index.
+ */
 export function setComparedVersion (
   feed: Feed,
   oneBasedIndex: number
 ) {
   return async function (dispatch: dispatchFn, getState: getStateFn) {
     const newComparedVersion = await dispatch(ensureVersionIndexIsFetched(feed, oneBasedIndex))
-    // Dispatch action to set value in reducer.
     dispatch(settingComparedVersion(newComparedVersion))
-    if (newComparedVersion) {
-      // Fetch validation issue count. NOTE: future version-specific data fetching
-      // could also be triggered here.
-      dispatch(fetchValidationIssueCount(newComparedVersion))
-      // Also, fetch GTFS+ validation if module enabled.
-      if (isModuleEnabled('gtfsplus')) dispatch(validateGtfsPlusFeed(newComparedVersion.id))
-    }
   }
 }
 

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -581,7 +581,6 @@ export function ensureVersionIndexIsFetched (
   oneBasedIndex: number
 ) {
   return async function (dispatch: dispatchFn, getState: getStateFn) {
-    console.log('Requesting version ', oneBasedIndex)
     if (!oneBasedIndex || oneBasedIndex < 1) return null
 
     const requestedVersion = feed.feedVersions && feed.feedVersions[oneBasedIndex - 1]

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -129,7 +129,7 @@ export function fetchFeedVersions (feedSource: Feed, unsecured: ?boolean = false
   return function (dispatch: dispatchFn, getState: getStateFn) {
     dispatch(requestingFeedVersions())
     const apiRoot = unsecured ? 'public' : 'secure'
-    const url = `/api/manager/${apiRoot}/feedversion?feedSourceId=${feedSource.id}`
+    const url = `/api/manager/${apiRoot}/feedversionsummaries?feedSourceId=${feedSource.id}`
     return dispatch(secureFetch(url))
       .then(response => response.json())
       .then(versions => {
@@ -583,11 +583,26 @@ export function setVersionIndex (
   isPublic?: boolean
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    if (feed.feedVersions) {
-      dispatch(setActiveVersion(feed.feedVersions[index - 1]))
-
-      if (push) {
-        browserHistory.push(`${isPublic ? '/public' : ''}/feed/${feed.id}/version/${index}`)
+    console.log('trying to set active version', index)
+    if (feed.feedVersionSummaries) {
+      const newActiveVersion = feed.feedVersions && feed.feedVersions[index - 1]
+      if (!newActiveVersion) {
+        // If the requested version has not been fetched yet, async fetch it.
+        const versionId = feed.feedVersionSummaries[index - 1].id
+        dispatch(fetchFeedVersion(versionId))
+          .then((version) => {
+            // TODO: Refactor
+            dispatch(setActiveVersion(version))
+            if (push) {
+              browserHistory.push(`${isPublic ? '/public' : ''}/feed/${feed.id}/version/${index}`)
+            }
+          })
+      } else {
+        // TODO: Refactor
+        dispatch(setActiveVersion(newActiveVersion))
+        if (push) {
+          browserHistory.push(`${isPublic ? '/public' : ''}/feed/${feed.id}/version/${index}`)
+        }
       }
     } else {
       console.warn('No feed versions for feed were found.', feed)

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -580,14 +580,17 @@ export function ensureVersionIndexIsFetched (
   feed: Feed,
   oneBasedIndex: number
 ) {
-  return function (dispatch: dispatchFn, getState: getStateFn) {
-    const requestedVersion = feed.feedVersions && feed.feedVersions[oneBasedIndex - 1]
+  return async function (dispatch: dispatchFn, getState: getStateFn) {
     console.log('Requesting version ', oneBasedIndex)
+    if (!oneBasedIndex || oneBasedIndex < 1) return null
+
+    const requestedVersion = feed.feedVersions && feed.feedVersions[oneBasedIndex - 1]
     if (!requestedVersion) {
       if (feed.feedVersionSummaries) {
         // If the requested version has not been fetched yet, async fetch it.
         const versionId = feed.feedVersionSummaries[oneBasedIndex - 1].id
-        return dispatch(fetchFeedVersion(versionId))
+        const { payload } = await dispatch(fetchFeedVersion(versionId))
+        return payload
       }
     }
     return requestedVersion
@@ -602,7 +605,7 @@ export function setVersionIndex (
 ) {
   return async function (dispatch: dispatchFn, getState: getStateFn) {
     if (feed.feedVersionSummaries) {
-      const { payload: newActiveVersion } = await dispatch(ensureVersionIndexIsFetched(feed, oneBasedIndex))
+      const newActiveVersion = await dispatch(ensureVersionIndexIsFetched(feed, oneBasedIndex))
       dispatch(setActiveVersion(newActiveVersion))
       if (push) {
         browserHistory.push(`${isPublic ? '/public' : ''}/feed/${feed.id}/version/${oneBasedIndex}`)
@@ -623,7 +626,7 @@ export function setComparedVersion (
   oneBasedIndex: number
 ) {
   return async function (dispatch: dispatchFn, getState: getStateFn) {
-    const { payload: newComparedVersion } = await dispatch(ensureVersionIndexIsFetched(feed, oneBasedIndex))
+    const newComparedVersion = await dispatch(ensureVersionIndexIsFetched(feed, oneBasedIndex))
     // Dispatch action to set value in reducer.
     dispatch(settingComparedVersion(newComparedVersion))
     if (newComparedVersion) {

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -100,11 +100,6 @@ export function setActiveVersion (version: FeedVersion) {
     }
   }
 }
-// Sets the compared feed version.
-export const setComparedVersion = createAction(
-  'SET_COMPARED_FEEDVERSION',
-  (payload: ?FeedVersion) => payload
-)
 
 const uploadingFeed = createVoidPayloadAction('UPLOADING_FEED')
 
@@ -576,36 +571,67 @@ export function renameFeedVersion (
   }
 }
 
+/**
+ * Ensures that the requested feed version has been fetched,
+ * and fetches the version if necessary.
+ * This method can be called using await.
+ */
+export function ensureVersionIndexIsFetched (
+  feed: Feed,
+  oneBasedIndex: number
+) {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    const requestedVersion = feed.feedVersions && feed.feedVersions[oneBasedIndex - 1]
+    console.log('Requesting version ', oneBasedIndex)
+    if (!requestedVersion) {
+      if (feed.feedVersionSummaries) {
+        // If the requested version has not been fetched yet, async fetch it.
+        const versionId = feed.feedVersionSummaries[oneBasedIndex - 1].id
+        return dispatch(fetchFeedVersion(versionId))
+      }
+    }
+    return requestedVersion
+  }
+}
+
 export function setVersionIndex (
   feed: Feed,
-  index: number,
+  oneBasedIndex: number,
   push?: boolean = true,
   isPublic?: boolean
 ) {
-  return function (dispatch: dispatchFn, getState: getStateFn) {
-    console.log('trying to set active version', index)
+  return async function (dispatch: dispatchFn, getState: getStateFn) {
     if (feed.feedVersionSummaries) {
-      const newActiveVersion = feed.feedVersions && feed.feedVersions[index - 1]
-      if (!newActiveVersion) {
-        // If the requested version has not been fetched yet, async fetch it.
-        const versionId = feed.feedVersionSummaries[index - 1].id
-        dispatch(fetchFeedVersion(versionId))
-          .then((version) => {
-            // TODO: Refactor
-            dispatch(setActiveVersion(version))
-            if (push) {
-              browserHistory.push(`${isPublic ? '/public' : ''}/feed/${feed.id}/version/${index}`)
-            }
-          })
-      } else {
-        // TODO: Refactor
-        dispatch(setActiveVersion(newActiveVersion))
-        if (push) {
-          browserHistory.push(`${isPublic ? '/public' : ''}/feed/${feed.id}/version/${index}`)
-        }
+      const { payload: newActiveVersion } = await dispatch(ensureVersionIndexIsFetched(feed, oneBasedIndex))
+      dispatch(setActiveVersion(newActiveVersion))
+      if (push) {
+        browserHistory.push(`${isPublic ? '/public' : ''}/feed/${feed.id}/version/${oneBasedIndex}`)
       }
     } else {
       console.warn('No feed versions for feed were found.', feed)
+    }
+  }
+}
+
+// Sets the compared feed version.
+export const settingComparedVersion = createAction(
+  'SET_COMPARED_FEEDVERSION',
+  (payload: FeedVersion) => payload
+)
+export function setComparedVersion (
+  feed: Feed,
+  oneBasedIndex: number
+) {
+  return async function (dispatch: dispatchFn, getState: getStateFn) {
+    const { payload: newComparedVersion } = await dispatch(ensureVersionIndexIsFetched(feed, oneBasedIndex))
+    // Dispatch action to set value in reducer.
+    dispatch(settingComparedVersion(newComparedVersion))
+    if (newComparedVersion) {
+      // Fetch validation issue count. NOTE: future version-specific data fetching
+      // could also be triggered here.
+      dispatch(fetchValidationIssueCount(newComparedVersion))
+      // Also, fetch GTFS+ validation if module enabled.
+      if (isModuleEnabled('gtfsplus')) dispatch(validateGtfsPlusFeed(newComparedVersion.id))
     }
   }
 }

--- a/lib/manager/components/ManagerHeader.js
+++ b/lib/manager/components/ManagerHeader.js
@@ -10,8 +10,7 @@ import numeral from 'numeral'
 import WatchButton from '../../common/containers/WatchButton'
 import StarButton from '../../common/containers/StarButton'
 import { getConfigProperty } from '../../common/util/config'
-
-import type {Feed, FeedVersion, Project} from '../../types'
+import type {Feed, FeedVersionSummary, Project} from '../../types'
 import type {ManagerUserState} from '../../types/reducers'
 
 type Props = {
@@ -21,15 +20,15 @@ type Props = {
 }
 
 export default class ManagerHeader extends Component<Props> {
-  getAverageFileSize (feedVersions: ?Array<FeedVersion>) {
-    // if (!feedVersions) return
+  getAverageFileSize (feedVersionSummaries: ?Array<FeedVersionSummary>) {
+    // if (!feedVersionSummaries) return
     let sum = 0
     let avg
-    if (feedVersions) {
-      for (var i = 0; i < feedVersions.length; i++) {
-        sum += feedVersions[i].fileSize
+    if (feedVersionSummaries) {
+      for (let i = 0; i < feedVersionSummaries.length; i++) {
+        sum += feedVersionSummaries[i].fileSize
       }
-      avg = sum / feedVersions.length
+      avg = sum / feedVersionSummaries.length
     }
     return numeral(avg || 0).format('0 b')
   }
@@ -98,7 +97,7 @@ export default class ManagerHeader extends Component<Props> {
             </li>
             <li>
               <Icon type='file-archive-o' />{' '}
-              {this.getAverageFileSize(feedSource.feedVersions)}
+              {this.getAverageFileSize(feedSource.feedVersionSummaries)}
             </li>
           </ul>
         </Col>

--- a/lib/manager/components/ManagerHeader.js
+++ b/lib/manager/components/ManagerHeader.js
@@ -21,7 +21,6 @@ type Props = {
 
 export default class ManagerHeader extends Component<Props> {
   getAverageFileSize (feedVersionSummaries: ?Array<FeedVersionSummary>) {
-    // if (!feedVersionSummaries) return
     let sum = 0
     let avg
     if (feedVersionSummaries) {

--- a/lib/manager/components/transform/FeedTransformation.js
+++ b/lib/manager/components/transform/FeedTransformation.js
@@ -7,15 +7,15 @@ import Select from 'react-select'
 
 import {getGtfsSpec, getGtfsPlusSpec, isModuleEnabled} from '../../../common/util/config'
 import {getTransformationName, getTransformationPlaceholder} from '../../util/transform'
-import NormalizeField from './NormalizeField'
-import ReplaceFileFromString from './ReplaceFileFromString'
-import ReplaceFileFromVersion from './ReplaceFileFromVersion'
-
 import type {
   Feed,
   FeedTransformation as FeedTransformationType,
   ReactSelectOption
 } from '../../../types'
+
+import NormalizeField from './NormalizeField'
+import ReplaceFileFromString from './ReplaceFileFromString'
+import ReplaceFileFromVersion from './ReplaceFileFromVersion'
 
 type Props = {
   feedSource: Feed,
@@ -117,7 +117,7 @@ export default class FeedTransformation extends Component<Props, {errors: Array<
             onClick={this._onRemoveTransformation}>
             Delete step
           </Button>
-          Step {index + 1} - {getTransformationName(transformationType, transformation, feedSource.feedVersions)}
+          Step {index + 1} - {getTransformationName(transformationType, transformation, feedSource.feedVersionSummaries)}
         </h5>
         <div className='feed-transformation-body'>
           <Select

--- a/lib/manager/components/transform/ReplaceFileFromVersion.js
+++ b/lib/manager/components/transform/ReplaceFileFromVersion.js
@@ -15,23 +15,28 @@ export default class ReplaceFileFromVersion extends Component<TransformProps<{}>
 
   _onSelectVersion = (versionIndex: number) => {
     const {feedSource, onSave} = this.props
-    if (feedSource.feedVersions) {
-      const version = feedSource.feedVersions[versionIndex - 1]
+    if (feedSource.feedVersionSummaries) {
+      const version = feedSource.feedVersionSummaries[versionIndex - 1]
       onSave({sourceVersionId: version.id}, this.props.index)
     } else {
       console.warn('Feed source does not have list of feed versions')
     }
   }
 
-  _getValidationErrors (): Array<string> {
+  _findFeedVersion = () => {
     const { feedSource, transformation } = this.props
+    return feedSource.feedVersionSummaries &&
+      feedSource.feedVersionSummaries.find(v => v.id === transformation.sourceVersionId)
+  }
+
+  _getValidationErrors (): Array<string> {
+    const { feedSource } = this.props
     // Get selected version (if applicable).
-    const version = feedSource.feedVersions &&
-      feedSource.feedVersions.find(v => v.id === transformation.sourceVersionId)
+    const version = this._findFeedVersion()
     const issues: Array<string> = []
 
     // Only trigger validation issue if versions have been loaded.
-    if (!version && feedSource.feedVersions) {
+    if (!version && feedSource.feedVersionSummaries) {
       issues.push('Version must be defined')
     }
 
@@ -48,10 +53,9 @@ export default class ReplaceFileFromVersion extends Component<TransformProps<{}>
   }
 
   render () {
-    const {feedSource, transformation} = this.props
+    const {feedSource} = this.props
     // Get selected version (if applicable).
-    const version = feedSource.feedVersions &&
-      feedSource.feedVersions.find(v => v.id === transformation.sourceVersionId)
+    const version = this._findFeedVersion()
 
     return (
       <VersionSelectorDropdown

--- a/lib/manager/components/transform/ReplaceFileFromVersion.js
+++ b/lib/manager/components/transform/ReplaceFileFromVersion.js
@@ -3,7 +3,6 @@
 import React, { Component } from 'react'
 
 import VersionSelectorDropdown from '../version/VersionSelectorDropdown'
-
 import type { TransformProps } from '../../../types'
 
 /**
@@ -65,7 +64,7 @@ export default class ReplaceFileFromVersion extends Component<TransformProps<{}>
           : 'Select a source version'
         }
         version={version}
-        versions={feedSource.feedVersions}
+        versions={feedSource.feedVersionSummaries}
       />
     )
   }

--- a/lib/manager/components/version/FeedVersionDetails.js
+++ b/lib/manager/components/version/FeedVersionDetails.js
@@ -15,7 +15,7 @@ import bboxPoly from 'turf-bbox-polygon'
 import * as versionsActions from '../../actions/versions'
 import {getConfigProperty, isExtensionEnabled} from '../../../common/util/config'
 import {BLOCKING_ERROR_TYPES} from '../../util/version'
-import type {FeedVersion, GtfsPlusValidation, Bounds, Feed} from '../../../types'
+import type {FeedVersion, FeedVersionSummary, GtfsPlusValidation, Bounds, Feed} from '../../../types'
 import type {ManagerUserState} from '../../../types/reducers'
 
 import FeedVersionSpanChart from './FeedVersionSpanChart'
@@ -50,7 +50,7 @@ export default class FeedVersionDetails extends Component<Props> {
       !!(errorCounts.find(ec => BLOCKING_ERROR_TYPES.indexOf(ec.type) !== -1))
   }
 
-  _mergeItemFormatter = (v: FeedVersion, activeVersion: ?FeedVersion) => {
+  _mergeItemFormatter = (v: FeedVersionSummary, activeVersion: ?FeedVersionSummary) => {
     let name = v.name
     let disabled = false
     if (v.retrievalMethod === 'SERVICE_PERIOD_MERGE') {

--- a/lib/manager/components/version/FeedVersionDetails.js
+++ b/lib/manager/components/version/FeedVersionDetails.js
@@ -152,7 +152,7 @@ export default class FeedVersionDetails extends Component<Props> {
               title={<span><Icon type='code-fork' /> {mergeButtonLabel}</span>}
               itemFormatter={this._mergeItemFormatter}
               version={version}
-              versions={feedSource.feedVersions}
+              versions={feedSource.feedVersionSummaries}
             />
             <Button
               disabled={

--- a/lib/manager/components/version/FeedVersionNavigator.js
+++ b/lib/manager/components/version/FeedVersionNavigator.js
@@ -17,13 +17,13 @@ import * as snapshotActions from '../../../editor/actions/snapshots'
 import * as gtfsPlusActions from '../../../gtfsplus/actions/gtfsplus'
 import * as deploymentActions from '../../../manager/actions/deployments'
 import DeploymentPreviewButton from '../deployment/DeploymentPreviewButton'
+import type {Props as ContainerProps} from '../../containers/ActiveFeedVersionNavigator'
+import type {FeedVersion, FeedVersionSummary, GtfsPlusValidation, Note} from '../../../types'
+import type {GtfsState, ManagerUserState} from '../../../types/reducers'
+
 import FeedVersionViewer from './FeedVersionViewer'
 import VersionComparisonDropdown from './VersionComparisonDropdown'
 import VersionSelectorDropdown from './VersionSelectorDropdown'
-
-import type {Props as ContainerProps} from '../../containers/ActiveFeedVersionNavigator'
-import type {FeedVersion, GtfsPlusValidation, Note} from '../../../types'
-import type {GtfsState, ManagerUserState} from '../../../types/reducers'
 
 type Props = ContainerProps & {
   comparedVersion?: FeedVersion,
@@ -51,7 +51,8 @@ type Props = ContainerProps & {
   user: ManagerUserState,
   version: FeedVersion,
   versionIndexDoesNotExist: boolean,
-  versionSection: ?string
+  versionSection: ?string,
+  versionSummaries: Array<FeedVersionSummary>,
 }
 
 type State = {
@@ -162,7 +163,8 @@ export default class FeedVersionNavigator extends Component<Props, State> {
       sortedVersions,
       user,
       version,
-      versionSection
+      versionSection,
+      versionSummaries
     } = this.props
     // Grab the feed-source-specific deployment that is both actively deployed
     // and contains the selected version's GTFS.
@@ -173,7 +175,7 @@ export default class FeedVersionNavigator extends Component<Props, State> {
         d.deployedTo &&
         d.feedVersions.findIndex(v => v.id === version.id) !== -1
       )
-    const dropdownTitle = `${this.messages('version')} ${feedVersionIndex} ${this.messages('of')} ${sortedVersions.length}`
+    const dropdownTitle = `${this.messages('version')} ${feedVersionIndex} ${this.messages('of')} ${versionSummaries.length}`
 
     return (
       <div>
@@ -206,14 +208,14 @@ export default class FeedVersionNavigator extends Component<Props, State> {
                   {/* Previous Version Button */}
                   <Button
                     data-test-id='decrement-feed-version-button'
-                    disabled={!hasVersions || !sortedVersions[feedVersionIndex - 2]}
+                    disabled={!hasVersions || !versionSummaries[feedVersionIndex - 2]}
                     href='#'
                     onClick={this._decrementVersion}>
                     <Glyphicon glyph='arrow-left' />
                   </Button>
 
                   {/* Version Selector Dropdown */}
-                  {sortedVersions.length > 0 &&
+                  {versionSummaries.length > 0 &&
                     <VersionSelectorDropdown
                       dropdownProps={{
                         id: 'versionSelector',
@@ -222,12 +224,12 @@ export default class FeedVersionNavigator extends Component<Props, State> {
                       header='Select a version to view summary'
                       title={dropdownTitle}
                       version={version}
-                      versions={sortedVersions}
+                      versions={versionSummaries}
                     />
                   }
                   {/* Next Version Button */}
                   <Button href='#'
-                    disabled={!hasVersions || !sortedVersions[feedVersionIndex]}
+                    disabled={!hasVersions || !versionSummaries[feedVersionIndex]}
                     onClick={this._incrementVersion}>
                     <Glyphicon glyph='arrow-right' />
                   </Button>
@@ -344,7 +346,8 @@ export default class FeedVersionNavigator extends Component<Props, State> {
               user={user}
               version={this.props.version}
               versionSection={versionSection || null}
-              versions={sortedVersions} />
+              versions={sortedVersions}
+            />
           </Col>
         </Row>
       </div>

--- a/lib/manager/components/version/FeedVersionNavigator.js
+++ b/lib/manager/components/version/FeedVersionNavigator.js
@@ -242,7 +242,7 @@ export default class FeedVersionNavigator extends Component<Props, State> {
                     <VersionComparisonDropdown
                       comparedVersion={comparedVersion}
                       version={version}
-                      versions={feedSource.feedVersions}
+                      versions={feedSource.feedVersionSummaries}
                     />
                   </ButtonGroup>
                 }

--- a/lib/manager/components/version/FeedVersionNavigator.js
+++ b/lib/manager/components/version/FeedVersionNavigator.js
@@ -237,12 +237,13 @@ export default class FeedVersionNavigator extends Component<Props, State> {
               }
 
               <ButtonToolbar className='pull-right'>
-                {feedSource.feedVersions &&
+                {versionSummaries &&
                   <ButtonGroup>
                     <VersionComparisonDropdown
                       comparedVersion={comparedVersion}
+                      feedSource={feedSource}
                       version={version}
-                      versions={feedSource.feedVersionSummaries}
+                      versionSummaries={versionSummaries}
                     />
                   </ButtonGroup>
                 }

--- a/lib/manager/components/version/FeedVersionViewer.js
+++ b/lib/manager/components/version/FeedVersionViewer.js
@@ -42,7 +42,6 @@ export type Props = {
   editDisabled: ?boolean,
   exportVersionShapes: typeof versionsActions.exportVersionShapes,
   feedSource: Feed,
-  feedSource: Feed,
   feedVersionIndex: number,
   fetchGTFSEntities: typeof versionsActions.fetchGTFSEntities,
   fetchValidationErrors: typeof versionsActions.fetchValidationErrors,
@@ -77,7 +76,6 @@ export default class FeedVersionViewer extends Component<Props> {
       notesRequested,
       user,
       version,
-      versions,
       versionSection
     } = this.props
 
@@ -122,8 +120,9 @@ export default class FeedVersionViewer extends Component<Props> {
                 validationResult={version.validationResult} />
               : versionSection === 'gtfsplus' && isModuleEnabled('gtfsplus')
                 ? <ActiveGtfsPlusVersionSummary
-                  versions={versions}
-                  version={version} />
+                  version={version}
+                  versionSummaries={feedSource.feedVersionSummaries}
+                />
                 : versionSection === 'comments'
                   ? <NotesViewer
                     feedSource={feedSource}

--- a/lib/manager/components/version/VersionComparisonDropdown.js
+++ b/lib/manager/components/version/VersionComparisonDropdown.js
@@ -48,12 +48,11 @@ class VersionComparisonDropdown extends Component<Props> {
   render () {
     const {
       comparedVersion,
-      versionSummaries // FIXME prop drilling redundant with feedSource
+      versionSummaries
     } = this.props
-    let title = 'Compare versions'
-    if (comparedVersion) {
-      title = `Comparing to version ${comparedVersion.version}`
-    }
+    const title = comparedVersion
+      ? `Comparing to version ${comparedVersion.version}`
+      : 'Compare versions'
 
     return (
       <VersionSelectorDropdown

--- a/lib/manager/components/version/VersionComparisonDropdown.js
+++ b/lib/manager/components/version/VersionComparisonDropdown.js
@@ -5,16 +5,16 @@ import {MenuItem} from 'react-bootstrap'
 import {connect} from 'react-redux'
 
 import * as versionsActions from '../../actions/versions'
-import VersionSelectorDropdown, {DefaultItemFormatter} from './VersionSelectorDropdown'
-
-import type {FeedVersion} from '../../../types'
+import type {FeedVersion, FeedVersionSummary} from '../../../types'
 import type {AppState} from '../../../types/reducers'
+
+import VersionSelectorDropdown, {DefaultItemFormatter} from './VersionSelectorDropdown'
 
 type Props = {
   comparedVersion?: FeedVersion,
   setComparedVersion: typeof versionsActions.setComparedVersion,
   version: FeedVersion,
-  versions: Array<FeedVersion>
+  versions: Array<FeedVersionSummary>
 }
 
 /**
@@ -27,6 +27,7 @@ class VersionComparisonDropdown extends Component<Props> {
     const comparedVersionIndex = comparedVersion ? comparedVersion.version : -1
     // Note: index is 1-based (the menu item at index 0 is a caption).
     if (index !== comparedVersionIndex) {
+      // FIXME
       setComparedVersion(versions.find(v => v.version === index))
     }
   }
@@ -48,8 +49,8 @@ class VersionComparisonDropdown extends Component<Props> {
 
     // This custom formatter adds and hides the active version in the list to
     // preserve version indexes.
-    const itemFormatter = (itemVersion: FeedVersion, activeVersion: ?FeedVersion) => (
-      itemVersion === version
+    const itemFormatter = (itemVersion: FeedVersionSummary, activeVersion: ?FeedVersion) => (
+      itemVersion.id === version.id
         ? <MenuItem key={itemVersion.id} style={{display: 'none'}} />
         : DefaultItemFormatter(itemVersion, activeVersion)
     )

--- a/lib/manager/components/version/VersionComparisonDropdown.js
+++ b/lib/manager/components/version/VersionComparisonDropdown.js
@@ -5,16 +5,16 @@ import {MenuItem} from 'react-bootstrap'
 import {connect} from 'react-redux'
 
 import * as versionsActions from '../../actions/versions'
-import type {FeedVersion, FeedVersionSummary} from '../../../types'
-import type {AppState} from '../../../types/reducers'
+import type {Feed, FeedVersion, FeedVersionSummary} from '../../../types'
 
 import VersionSelectorDropdown, {DefaultItemFormatter} from './VersionSelectorDropdown'
 
 type Props = {
   comparedVersion?: FeedVersion,
+  feedSource: Feed,
   setComparedVersion: typeof versionsActions.setComparedVersion,
   version: FeedVersion,
-  versions: Array<FeedVersionSummary>
+  versionSummaries: Array<FeedVersionSummary>
 }
 
 /**
@@ -23,12 +23,11 @@ type Props = {
  */
 class VersionComparisonDropdown extends Component<Props> {
   _onSelectComparedVersion = (index: number) => {
-    const {comparedVersion, setComparedVersion, versions} = this.props
+    const {comparedVersion, feedSource, setComparedVersion} = this.props
     const comparedVersionIndex = comparedVersion ? comparedVersion.version : -1
     // Note: index is 1-based (the menu item at index 0 is a caption).
     if (index !== comparedVersionIndex) {
-      // FIXME
-      setComparedVersion(versions.find(v => v.version === index))
+      setComparedVersion(feedSource, index)
     }
   }
 
@@ -36,24 +35,25 @@ class VersionComparisonDropdown extends Component<Props> {
     this.props.setComparedVersion(null)
   }
 
+  /**
+   * This custom formatter adds and hides the active version in the list to
+   * preserve version indexes.
+   */
+  itemFormatter = (itemVersion: FeedVersionSummary, activeVersion: ?FeedVersion) => (
+    this.props.version && itemVersion.id === this.props.version.id
+      ? <MenuItem key={itemVersion.id} style={{display: 'none'}} />
+      : DefaultItemFormatter(itemVersion, activeVersion)
+  )
+
   render () {
     const {
       comparedVersion,
-      version,
-      versions
+      versionSummaries // FIXME prop drilling redundant with feedSource
     } = this.props
     let title = 'Compare versions'
     if (comparedVersion) {
       title = `Comparing to version ${comparedVersion.version}`
     }
-
-    // This custom formatter adds and hides the active version in the list to
-    // preserve version indexes.
-    const itemFormatter = (itemVersion: FeedVersionSummary, activeVersion: ?FeedVersion) => (
-      itemVersion.id === version.id
-        ? <MenuItem key={itemVersion.id} style={{display: 'none'}} />
-        : DefaultItemFormatter(itemVersion, activeVersion)
-    )
 
     return (
       <VersionSelectorDropdown
@@ -65,25 +65,21 @@ class VersionComparisonDropdown extends Component<Props> {
           onClick: this._onClearComparedVersion,
           text: 'Exit compare mode'
         }]}
-        header={versions.length < 2
+        header={versionSummaries.length < 2
           ? 'Load another version to enable comparison'
           : 'Select a version to compare with'
         }
-        itemFormatter={itemFormatter}
+        itemFormatter={this.itemFormatter}
         title={title}
         version={comparedVersion}
-        versions={versions}
+        versions={versionSummaries}
       />
     )
   }
-}
-
-const mapStateToProps = (state: AppState, ownProps: {}) => {
-  return {}
 }
 
 const mapDispatchToProps = {
   setComparedVersion: versionsActions.setComparedVersion
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(VersionComparisonDropdown)
+export default connect(null, mapDispatchToProps)(VersionComparisonDropdown)

--- a/lib/manager/components/version/VersionComparisonDropdown.js
+++ b/lib/manager/components/version/VersionComparisonDropdown.js
@@ -32,14 +32,14 @@ class VersionComparisonDropdown extends Component<Props> {
   }
 
   _onClearComparedVersion = () => {
-    this.props.setComparedVersion(null)
+    this.props.setComparedVersion(this.props.feedSource, -1)
   }
 
   /**
    * This custom formatter adds and hides the active version in the list to
    * preserve version indexes.
    */
-  itemFormatter = (itemVersion: FeedVersionSummary, activeVersion: ?FeedVersion) => (
+  itemFormatter = (itemVersion: FeedVersionSummary, activeVersion: ?FeedVersionSummary) => (
     this.props.version && itemVersion.id === this.props.version.id
       ? <MenuItem key={itemVersion.id} style={{display: 'none'}} />
       : DefaultItemFormatter(itemVersion, activeVersion)

--- a/lib/manager/components/version/VersionRetrievalBadge.js
+++ b/lib/manager/components/version/VersionRetrievalBadge.js
@@ -4,11 +4,11 @@ import Icon from '@conveyal/woonerf/components/icon'
 import React from 'react'
 
 import toSentenceCase from '../../../common/util/to-sentence-case'
-import type { FeedVersion, RetrievalMethod } from '../../../types'
+import type { FeedVersionSummary, RetrievalMethod } from '../../../types'
 
 type Props = {
   retrievalMethod?: RetrievalMethod,
-  version?: FeedVersion
+  version?: FeedVersionSummary
 }
 
 const iconForRetrievalMethod = (retrievalMethod: RetrievalMethod | 'UNKNOWN') => {

--- a/lib/manager/components/version/VersionSelectorDropdown.js
+++ b/lib/manager/components/version/VersionSelectorDropdown.js
@@ -2,7 +2,7 @@
 
 import Icon from '@conveyal/woonerf/components/icon'
 import * as React from 'react'
-import { Dropdown } from 'react-bootstrap'
+import { Dropdown, MenuItem as BsMenuItem } from 'react-bootstrap'
 
 import MenuItem from '../../../common/components/MenuItem'
 import type { FeedVersion, FeedVersionSummary } from '../../../types'
@@ -67,7 +67,7 @@ export default function VersionSelectorDropdown (props: Props) {
           ? versionsSorted.map((v, i) => itemFormatter(v, version))
           : <MenuItem disabled>No versions available</MenuItem>}
 
-        {extraOptions && <MenuItem divider />}
+        {extraOptions && <BsMenuItem divider />}
         {extraOptions && extraOptions.map((option, i) => (
           <MenuItem key={i} onClick={option.onClick}>{option.text}</MenuItem>
         ))}

--- a/lib/manager/components/version/VersionSelectorDropdown.js
+++ b/lib/manager/components/version/VersionSelectorDropdown.js
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { Dropdown, MenuItem as BsMenuItem } from 'react-bootstrap'
 
 import MenuItem from '../../../common/components/MenuItem'
-import type { FeedVersion, FeedVersionSummary } from '../../../types'
+import type { FeedVersionSummary } from '../../../types'
 
 import VersionRetrievalBadge from './VersionRetrievalBadge'
 
@@ -20,7 +20,7 @@ type Props = {
   versions: ?Array<FeedVersionSummary>
 }
 
-export const DefaultItemFormatter = (version: FeedVersionSummary, activeVersion: ?FeedVersion) => (
+export const DefaultItemFormatter = (version: FeedVersionSummary, activeVersion: ?FeedVersionSummary) => (
   <MenuItem
     eventKey={version.version}
     key={version.id}

--- a/lib/manager/components/version/VersionSelectorDropdown.js
+++ b/lib/manager/components/version/VersionSelectorDropdown.js
@@ -5,22 +5,22 @@ import * as React from 'react'
 import { Dropdown } from 'react-bootstrap'
 
 import MenuItem from '../../../common/components/MenuItem'
-import VersionRetrievalBadge from './VersionRetrievalBadge'
+import type { FeedVersion, FeedVersionSummary } from '../../../types'
 
-import type { FeedVersion } from '../../../types'
+import VersionRetrievalBadge from './VersionRetrievalBadge'
 
 type Props = {
   dropdownProps: any,
   extraOptions?: ?Array<{onClick: () => void, text: string}>,
   header?: string,
-  itemFormatter: (FeedVersion, ?FeedVersion) => React.Node,
+  itemFormatter: (FeedVersionSummary, ?FeedVersionSummary) => React.Node,
   title: React.Node,
   // Indicates which version is active in the feed version navigator.
-  version?: FeedVersion,
-  versions: ?Array<FeedVersion>
+  version?: FeedVersionSummary,
+  versions: ?Array<FeedVersionSummary>
 }
 
-export const DefaultItemFormatter = (version: FeedVersion, activeVersion: ?FeedVersion) => (
+export const DefaultItemFormatter = (version: FeedVersionSummary, activeVersion: ?FeedVersion) => (
   <MenuItem
     eventKey={version.version}
     key={version.id}

--- a/lib/manager/containers/ActiveFeedVersionNavigator.js
+++ b/lib/manager/containers/ActiveFeedVersionNavigator.js
@@ -23,7 +23,6 @@ import {createDeploymentFromFeedSource} from '../../manager/actions/deployments'
 import {loadFeedVersionForEditing} from '../../editor/actions/snapshots'
 import {downloadGtfsPlusFeed} from '../../gtfsplus/actions/gtfsplus'
 import {versionsLastUpdatedComparator} from '../util/version'
-
 import type {Feed, Project} from '../../types'
 import type {AppState, RouteParams} from '../../types/reducers'
 
@@ -41,26 +40,29 @@ export type Props = {
 const mapStateToProps = (state: AppState, ownProps: Props) => {
   let feedVersionIndex
   const {routeParams, feedSource} = ownProps
-  const {feedVersions} = feedSource
+  const {feedVersions, feedVersionSummaries} = feedSource
   const {feedVersionIndex: fvi, subpage} = routeParams
   const routeVersionIndex = parseInt(fvi, 10)
   const hasVersionIndex = typeof fvi !== 'undefined'
   let versionIndexDoesNotExist = false
-  if (feedSource && typeof feedVersions !== 'undefined') {
+  if (feedSource && typeof feedVersionSummaries !== 'undefined') {
     if ((hasVersionIndex && isNaN(routeVersionIndex)) ||
-        routeVersionIndex > feedVersions.length ||
+        routeVersionIndex > feedVersionSummaries.length ||
         routeVersionIndex < 0) {
       versionIndexDoesNotExist = true
     } else {
       feedVersionIndex = hasVersionIndex
         ? routeVersionIndex
-        : feedVersions.length
+        : feedVersionSummaries.length
     }
   }
   const {gtfs} = state
-  const hasVersions = feedVersions && feedVersions.length > 0
+  const hasVersions = feedVersionSummaries && feedVersionSummaries.length > 0
   const sortedVersions = (hasVersions && feedVersions)
     ? feedVersions.sort(versionsLastUpdatedComparator)
+    : []
+  const sortedSummaries = (hasVersions && feedVersionSummaries)
+    ? feedVersionSummaries.sort(versionsLastUpdatedComparator)
     : []
 
   let comparedVersion, version
@@ -88,7 +90,8 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
     version,
     comparedVersion,
     versionIndexDoesNotExist,
-    versionSection: subpage
+    versionSection: subpage,
+    versionSummaries: sortedSummaries
   }
 }
 

--- a/lib/manager/containers/ActiveFeedVersionNavigator.js
+++ b/lib/manager/containers/ActiveFeedVersionNavigator.js
@@ -76,7 +76,7 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
     version = sortedVersions[feedVersionIndex - 1]
 
     if (gtfs.filter.comparedVersion) {
-      comparedVersion = sortedVersions.find(feedVer => feedVer.id === gtfs.filter.comparedVersion)
+      comparedVersion = sortedVersions.find(feedVer => feedVer && feedVer.id === gtfs.filter.comparedVersion)
     }
   }
   // FIXME: prop drilling.

--- a/lib/manager/reducers/projects.js
+++ b/lib/manager/reducers/projects.js
@@ -224,7 +224,7 @@ const projects = (state: ProjectsState = defaultState, action: Action): Projects
       }
       return update(state, {
         all: {[projectIndex]: {feedSources: {[sourceIndex]: {$merge: {
-          feedVersions: versions.map(() => null), // versions.sort(versionSort), // TODO remove
+          feedVersions: versions.map(() => null),
           feedVersionSummaries: versions.sort(versionSort)
         }}}}}
       })
@@ -243,8 +243,7 @@ const projects = (state: ProjectsState = defaultState, action: Action): Projects
       return update(state, {
         all: {[projectIndex]: {feedSources: {[sourceIndex]: {
           feedVersions: updatedVersions
-        }}}},
-        isFetching: { $set: false }
+        }}}}
       })
     }
     case 'PUBLISHED_FEEDVERSION': {

--- a/lib/manager/reducers/projects.js
+++ b/lib/manager/reducers/projects.js
@@ -224,7 +224,7 @@ const projects = (state: ProjectsState = defaultState, action: Action): Projects
       }
       return update(state, {
         all: {[projectIndex]: {feedSources: {[sourceIndex]: {$merge: {
-          feedVersions: [], // versions.sort(versionSort), // TODO remove
+          feedVersions: versions.map(() => null), // versions.sort(versionSort), // TODO remove
           feedVersionSummaries: versions.sort(versionSort)
         }}}}}
       })

--- a/lib/manager/reducers/projects.js
+++ b/lib/manager/reducers/projects.js
@@ -224,7 +224,8 @@ const projects = (state: ProjectsState = defaultState, action: Action): Projects
       }
       return update(state, {
         all: {[projectIndex]: {feedSources: {[sourceIndex]: {$merge: {
-          feedVersions: versions.sort(versionSort)
+          feedVersions: [], // versions.sort(versionSort), // TODO remove
+          feedVersionSummaries: versions.sort(versionSort)
         }}}}}
       })
     }
@@ -242,7 +243,8 @@ const projects = (state: ProjectsState = defaultState, action: Action): Projects
       return update(state, {
         all: {[projectIndex]: {feedSources: {[sourceIndex]: {
           feedVersions: updatedVersions
-        }}}}
+        }}}},
+        isFetching: { $set: false }
       })
     }
     case 'PUBLISHED_FEEDVERSION': {

--- a/lib/manager/util/index.js
+++ b/lib/manager/util/index.js
@@ -382,10 +382,10 @@ export function getIndexesFromFeed ({
     return { projectIndex, sourceIndex, versionIndex: -2, errorIndex: -2 }
   }
   const feedSource = project.feedSources[sourceIndex]
-  if (!feedSource.feedVersions) {
+  if (!feedSource.feedVersionSummaries) {
     return { projectIndex, sourceIndex, versionIndex: -2, errorIndex: -2 }
   }
-  const versionIndex = feedSource.feedVersions.findIndex(v => v.id === feedVersionId)
+  const versionIndex = feedSource.feedVersionSummaries.findIndex(v => v.id === feedVersionId)
   if (!errorType || !feedSource.feedVersions || versionIndex < 0) {
     return { projectIndex, sourceIndex, versionIndex, errorIndex: -2 }
   }

--- a/lib/manager/util/transform.js
+++ b/lib/manager/util/transform.js
@@ -1,9 +1,8 @@
 // @flow
 import {getComponentMessages} from '../../common/util/config'
-
 import type {
   FeedTransformation,
-  FeedVersion,
+  FeedVersionSummary,
   Substitution
 } from '../../types'
 
@@ -15,7 +14,7 @@ import type {
 export function getTransformationName (
   type: string,
   transformation?: FeedTransformation,
-  versions?: Array<FeedVersion>
+  versionSummaries?: Array<FeedVersionSummary>
 ) {
   // Get the base component messages.
   const messages = getComponentMessages('FeedTransformationDescriptions')
@@ -44,7 +43,7 @@ export function getTransformationName (
         if (table) replacementText = `${table} ${messages(`general.table`)}`
         break
       case 'versionPlaceholder':
-        const version = versions && versions.find(v => v.id === sourceVersionId)
+        const version = versionSummaries && versionSummaries.find(v => v.id === sourceVersionId)
         if (version) replacementText = `${messages(`general.version`)} ${version.version}`
         break
       default:

--- a/lib/manager/util/version.js
+++ b/lib/manager/util/version.js
@@ -4,11 +4,11 @@ import moment from 'moment'
 import numeral from 'numeral'
 
 import { isExtensionEnabled } from '../../common/util/config'
-
 import type {
   Deployment,
   Feed,
   FeedVersion,
+  FeedVersionSummary,
   Project,
   SummarizedFeedVersion,
   ValidationResult,
@@ -182,7 +182,7 @@ export function getVersionValidationSummaryByFilterStrategy (
   }
 }
 
-export const versionsLastUpdatedComparator = (a: FeedVersion, b: FeedVersion) => {
+export const versionsLastUpdatedComparator = (a: FeedVersionSummary, b: FeedVersionSummary) => {
   return a.updated - b.updated
 }
 

--- a/lib/manager/util/version.js
+++ b/lib/manager/util/version.js
@@ -183,7 +183,7 @@ export function getVersionValidationSummaryByFilterStrategy (
 }
 
 export const versionsLastUpdatedComparator = (a: FeedVersionSummary, b: FeedVersionSummary) => {
-  return a.updated - b.updated
+  return a && b ? a.updated - b.updated : 0
 }
 
 /**

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -385,6 +385,7 @@ export type Feed = {
   editorNamespace: ?string,
   editorSnapshots?: Array<Snapshot>,
   externalProperties?: any, // TODO: add more exact type
+  feedVersionSummaries?: Array<FeedVersionSummary>,
   feedVersions?: Array<FeedVersion>,
   fetchFrequency?: FetchFrequency,
   fetchInterval?: number,
@@ -500,6 +501,17 @@ export type TableTransformResult = {
 export type FeedTransformResult = {
   tableTransformResults: Array<TableTransformResult>
 }
+
+// TODO: Refactor
+export type FeedVersionSummary = {|
+  dateCreated: number,
+  id: string,
+  lastUpdated: number,
+  name: string,
+  namespace: string,
+  retrievalMethod: ?RetrievalMethod,
+  version: number
+|}
 
 export type FeedVersion = {|
   dateCreated: number,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -502,45 +502,41 @@ export type FeedTransformResult = {
   tableTransformResults: Array<TableTransformResult>
 }
 
-// TODO: Refactor
-export type FeedVersionSummary = {|
+/**
+ * Subset of the attributes of a feed version,
+ * used when retrieveing all summaries for all feed versions in a feed source.
+ */
+export type FeedVersionSummary = {
   dateCreated: number,
+  fileSize: number,
   id: string,
   lastUpdated: number,
   name: string,
   namespace: string,
   retrievalMethod: ?RetrievalMethod,
+  updated: number,
   version: number
-|}
+}
 
-export type FeedVersion = {|
-  dateCreated: number,
+export type FeedVersion = FeedVersionSummary & {
   feedLoadResult: FeedLoadResult,
   feedSource: Feed,
   feedSourceId?: string,
   feedTransformResult?: FeedTransformResult,
-  fileSize: number,
   fileTimestamp: number,
-  id: string,
   isCreating?: boolean,
   isochrones?: any,
-  lastUpdated: number,
-  name: string,
-  namespace: string,
   nextVersionId: ?string,
   noteCount: number,
   notes: Array<Note>,
   originNamespace: ?string,
   previousVersionId: ?string,
   processedByExternalPublisher: ?number,
-  retrievalMethod: ?RetrievalMethod,
   sentToExternalPublisher: ?number,
-  updated: number,
   user: string,
   validationResult: ValidationResult,
-  validationSummary: ValidationSummary,
-  version: number
-|}
+  validationSummary: ValidationSummary
+}
 
 export type Label = {
   adminOnly: boolean,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -504,7 +504,7 @@ export type FeedTransformResult = {
 
 /**
  * Subset of the attributes of a feed version,
- * used when retrieveing all summaries for all feed versions in a feed source.
+ * used when retrieving all summaries for all feed versions in a feed source.
  */
 export type FeedVersionSummary = {
   dateCreated: number,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -513,6 +513,7 @@ export type FeedVersionSummary = {
   lastUpdated: number,
   name: string,
   namespace: string,
+  originNamespace: ?string,
   retrievalMethod: ?RetrievalMethod,
   updated: number,
   version: number
@@ -529,7 +530,6 @@ export type FeedVersion = FeedVersionSummary & {
   nextVersionId: ?string,
   noteCount: number,
   notes: Array<Note>,
-  originNamespace: ?string,
   previousVersionId: ?string,
   processedByExternalPublisher: ?number,
   sentToExternalPublisher: ?number,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Companion PR for https://github.com/ibi-group/datatools-server/pull/457.
Partial fix for https://github.com/ibi-group/datatools-server/issues/456.

Basically, the `VersionSelectorDropdown`, `ManagerHeader` and `ReplaceFileFromVersion` components, and related code are set to use the new field `Feed.feedVersionSummaries` which fetches summary data for all feed versions much faster than `Feed.feedVersions`. That field instead is populated on demand as the user browses feed versions.



