### PR TITLE
fix(timetable): Allow offsetting by 24hrs or more

### DIFF
--- a/lib/editor/reducers/timetable.js
+++ b/lib/editor/reducers/timetable.js
@@ -7,7 +7,6 @@ import clone from 'lodash/cloneDeep'
 import { sortAndFilterTrips } from '../util'
 import { isTimeFormat } from '../util/timetable'
 import {resequenceStops} from '../util/map'
-
 import type {Action} from '../../types/actions'
 import type {TimetableState} from '../../types/reducers'
 
@@ -98,7 +97,8 @@ const timetable = (state: TimetableState = defaultState, action: Action): Timeta
           const path = `${action.payload.rowIndexes[i]}.${col.key}`
           if (isTimeFormat(col.type)) {
             const currentVal = objectPath.get(trips, path)
-            const value = currentVal + (action.payload.offset % 86399) // ensure seconds does not exceed 24 hours
+            // Arrival time can be > 24 hours for service day, so do not block offsetting by 24 hours.
+            const value = currentVal + action.payload.offset
             objectPath.set(trips, path, value)
           }
         }

--- a/lib/editor/reducers/timetable.js
+++ b/lib/editor/reducers/timetable.js
@@ -98,7 +98,8 @@ const timetable = (state: TimetableState = defaultState, action: Action): Timeta
           if (isTimeFormat(col.type)) {
             const currentVal = objectPath.get(trips, path)
             // Arrival time can be > 24 hours for service day, so do not block offsetting by 24 hours.
-            const value = currentVal + action.payload.offset
+            // Maintain empty cells (null) when offsetting.
+            const value = currentVal !== null ? currentVal + action.payload.offset : null
             objectPath.set(trips, path, value)
           }
         }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Currently in datatools, offsetting by a value of 24 hours or more in the timetable editor will result in an offset of that value modulus 86399 (1 second if offset is 24 hours). However, transit agencies will want to offset by 24 hours or greater for a trip that begins past midnight on the same service day as other trips. They currently use a workaround where the same result can be achieved by offsetting by 12h twice. This PR enables offsetting by 24 hours or more, to bring DT behaviour in line with service day offsets. 

**Tests will fail until https://github.com/ibi-group/datatools-ui/pull/777 is merged