### PR TITLE
fix(PatternStopCard): Fix 0 value continuous pickup/dropoff being displayed as '1'

### DIFF
--- a/lib/editor/components/pattern/PatternStopCard.js
+++ b/lib/editor/components/pattern/PatternStopCard.js
@@ -424,7 +424,7 @@ class PatternStopContents extends Component<Props, State> {
               selectType='continuousPickup'
               shouldHaveDisabledOption
               title='Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path.'
-              value={patternStop.continuousPickup || 1}
+              value={(patternStop.continuousPickup || patternStop.continuousPickup === 0) ? patternStop.continuousPickup : 1}
             />
           </Col>
           <Col xs={6}>
@@ -435,7 +435,7 @@ class PatternStopContents extends Component<Props, State> {
               selectType='continuousDropOff'
               shouldHaveDisabledOption
               title='Indicates whether a rider can alight from the transit vehicle at any point along the vehicle’s travel path.'
-              value={patternStop.continuousDropOff || 1}
+              value={(patternStop.continuousDropOff || patternStop.continuousDropOff === 0) ? patternStop.continuousDropOff : 1}
             />
           </Col>
         </Row>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR updates a bug that was missed earlier where a continuous pickup or dropoff value set to 0 will be displayed as 1 (the default value) bc of a misused logical `or` expression. The pickup/dropoff value of 0 should evaluate to true in this context (since it means 0 - Available) and if undefined or null, etc. it should evaluate to the default (1 - Not available). 