### PR TITLE
style(Job Monitor Popover): Fix exception overflow, allow scrolling in CSS

### DIFF
--- a/lib/style.css
+++ b/lib/style.css
@@ -996,3 +996,8 @@ h4.line:after {
 .route-type-select .toggle.expanded::after {
   content: "\f068";
 }
+
+/* Datatools backend exception in popover overflows the container */
+.popover-content {
+  overflow-x: scroll;
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Previously, Datatools backend exceptions (if they occurred) would appear in the Job Monitor Popover overflowing the component's width (fake text in exception used for demonstration)
<img width="594" alt="image" src="https://user-images.githubusercontent.com/63798641/164079385-a8f8bd61-2f90-4d36-9513-2d976bde2cee.png">

In this PR, scrolling is added to prevent this behaviour: 
<img width="541" alt="image" src="https://user-images.githubusercontent.com/63798641/164079635-3688e837-e877-4ce0-a3f0-12b55663fd03.png">


