### PR TITLE
Fix undeletable patternstops

### DIFF
--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -227,7 +227,7 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
     const patternStops = clone(currentPatternStops)
     const {controlPoints, patternSegments} = getControlPoints(getState())
     const patternLine = lineString(coordinatesFromShapePoints(shapePoints))
-    const hasShapePoints = shapePoints && shapePoints.length >= 2
+    const hasShapePoints = shapePoints && shapePoints.length > 1
     const newStop = stopToPatternStop(
       stop,
       (typeof index === 'undefined' || index === null)

--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -227,7 +227,7 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
     const patternStops = clone(currentPatternStops)
     const {controlPoints, patternSegments} = getControlPoints(getState())
     const patternLine = lineString(coordinatesFromShapePoints(shapePoints))
-    const hasShapePoints = shapePoints && shapePoints.length > 2
+    const hasShapePoints = shapePoints && shapePoints.length >= 2
     const newStop = stopToPatternStop(
       stop,
       (typeof index === 'undefined' || index === null)


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

This PR resolves an issue where adding stops after a straight, two stop segment produced an undeletable patternStop. This behaviour can be seen [here](https://drive.google.com/file/d/1cs7zLb5BFY1040rpH3aahgokqcQs3Ahj/view?usp=sharing). The cause of the behaviour appears to have been a typo in the definition of `hasShapePoints` (other functions use the definition this PR introduces)