### PR TITLE
Hide routes already in use in route selector in GTFS+ route_attributes editor.

### DIFF
--- a/gtfsplus.yml
+++ b/gtfsplus.yml
@@ -347,7 +347,7 @@
   fields:
     - name: route_id
       required: true
-      inputType: GTFS_ROUTE
+      inputType: GTFS_ROUTE_NOT_ADDED
       columnWidth: 4
       helpContent: From GTFS routes.txt file. This is necessary to maintain relationship between routes in this file and routes in the standard GTFS routes.txt file.
     - name: category

--- a/lib/gtfs/components/gtfs-search.js
+++ b/lib/gtfs/components/gtfs-search.js
@@ -7,7 +7,6 @@ import {Async} from 'react-select'
 
 import {getRouteName} from '../../editor/util/gtfs'
 import {searchEntitiesWithString} from '../util'
-
 import type {Feed, GtfsRoute, GtfsStop, User} from '../../types'
 import type {AppState} from '../../types/reducers'
 
@@ -21,6 +20,7 @@ export type GtfsOption = {
 
 type Props = {
   entities: Array<string>,
+  excludedEntityIds: Array<string>,
   feeds: Array<Feed>,
   filterByRoute?: GtfsRoute,
   filterByStop?: GtfsStop,
@@ -109,7 +109,16 @@ class GtfsSearch extends Component<Props, State> {
    * @param  {String} input text string to search
    */
   _loadOptions = (input: string) => {
-    const {entities, feeds, filterByRoute, filterByStop, namespace, user} = this.props
+    const {
+      entities,
+      excludedEntityIds,
+      feeds,
+      filterByRoute,
+      filterByStop,
+      namespace,
+      user,
+      value: currentOption
+    } = this.props
     // $FlowFixMe kind of cryptic error, ignoring for now
     let queries = []
     if (namespace) {
@@ -142,7 +151,16 @@ class GtfsSearch extends Component<Props, State> {
             // Entities must be mapped to options here in order to make use of
             // feed references.
             stops && stopOptions.push(...stops.map(s => _entityToOption(s, feed)))
-            routes && routeOptions.push(...routes.map(r => _entityToOption(r, feed)))
+            routes && routeOptions.push(
+              ...routes
+                // Remove specified entity ids (route ids in this case) to exclude, except the current value.
+                .filter(route =>
+                  !excludedEntityIds.includes(route.route_id) ||
+                  // (Extended type checks are for flow validation.)
+                  (route.route_id === (typeof currentOption === 'object' ? currentOption && currentOption.value : currentOption))
+                )
+                .map(r => _entityToOption(r, feed))
+            )
           } else {
             const feedName = feed ? feed.name : responseNamespace
             console.warn(`Could not search GTFS entities (query: "${input}") for ${feedName}`, results)

--- a/lib/gtfs/util/index.js
+++ b/lib/gtfs/util/index.js
@@ -6,7 +6,6 @@ import {GTFS_GRAPHQL_PREFIX} from '../../common/constants'
 import {getGtfsSpec} from '../../common/util/config'
 import {routeSearch, stopSearch} from '../util/graphql'
 import {getHeaders} from '../../common/util/util'
-
 import type {GtfsRoute, GtfsStop, User} from '../../types'
 
 export function getEntityIdField (type: string): string {
@@ -229,6 +228,8 @@ export function searchEntitiesWithString (
   const includeStopSubQuery = !!filterByRoute
   // Build routes/stops query based on entities searching and whether we're
   // filtering by a specific route or stop ID.
+  // FIXME: Removed the hardcoded limit of 30 on the route search so it works with the GTFS_ROUTE_NOT_ADDED field,
+  // but does removing that negatively affect anything else?
   const body = JSON.stringify({
     query: `
 query (
@@ -239,7 +240,7 @@ query (
 ) {
   feed(namespace: $namespace) {
     ${queryForRoutes && includeRouteSubQuery ? stopSearch(true, 30) : ''}
-    ${queryForRoutes && !includeRouteSubQuery ? routeSearch(false, 30) : ''}
+    ${queryForRoutes && !includeRouteSubQuery ? routeSearch(false) : ''}
     ${queryForStops && includeStopSubQuery ? routeSearch(true, 30) : ''}
     ${queryForStops && !includeStopSubQuery ? stopSearch(false, 30) : ''}
   }

--- a/lib/gtfsplus/components/GtfsPlusField.js
+++ b/lib/gtfsplus/components/GtfsPlusField.js
@@ -42,7 +42,14 @@ export default class GtfsPlusField extends Component<Props> {
   }
 
   render () {
-    const {currentValue, data: rowData, feedVersionSummary, field, getGtfsEntity, rows} = this.props
+    const {
+      currentValue,
+      data: rowData,
+      feedVersionSummary,
+      field,
+      getGtfsEntity,
+      tableData
+    } = this.props
     const namespace = feedVersionSummary && feedVersionSummary.namespace
     switch (field.inputType) {
       case 'TEXT':
@@ -108,9 +115,9 @@ export default class GtfsPlusField extends Component<Props> {
           : null
 
         // If this field is of type GTFS_ROUTE_NOT_ADDED, only display in the dropdown route ids
-        // that are not already used as route_id in other rows in the table.
-        const excludedEntityIds = field.inputType === 'GTFS_ROUTE_NOT_ADDED'
-          ? rows.map(row => row.route_id)
+        // that are not already used as route_id in other rows in the entire table.
+        const excludedEntityIds = field.inputType === 'GTFS_ROUTE_NOT_ADDED' && tableData
+          ? tableData.route_attributes.map(row => row.route_id)
           : []
 
         return (

--- a/lib/gtfsplus/components/GtfsPlusField.js
+++ b/lib/gtfsplus/components/GtfsPlusField.js
@@ -42,7 +42,7 @@ export default class GtfsPlusField extends Component<Props> {
   }
 
   render () {
-    const {currentValue, data: rowData, feedVersionSummary, field, getGtfsEntity} = this.props
+    const {currentValue, data: rowData, feedVersionSummary, field, getGtfsEntity, rows} = this.props
     const namespace = feedVersionSummary && feedVersionSummary.namespace
     switch (field.inputType) {
       case 'TEXT':
@@ -98,6 +98,7 @@ export default class GtfsPlusField extends Component<Props> {
           </FormControl>
         )
       case 'GTFS_ROUTE':
+      case 'GTFS_ROUTE_NOT_ADDED':
         const routeEntity = ((getGtfsEntity('route', currentValue): any): GtfsRoute)
         const routeValue = routeEntity
           ? {
@@ -106,16 +107,24 @@ export default class GtfsPlusField extends Component<Props> {
           }
           : null
 
+        // If this field is of type GTFS_ROUTE_NOT_ADDED, only display in the dropdown route ids
+        // that are not already used as route_id in other rows in the table.
+        const excludedEntityIds = field.inputType === 'GTFS_ROUTE_NOT_ADDED'
+          ? rows.map(row => row.route_id)
+          : []
+
         return (
           <GtfsSearch
-            feeds={[]}
-            namespace={namespace}
-            limit={100}
-            entities={['routes']}
-            minimumInput={1}
             clearable={false}
+            entities={['routes']}
+            excludedEntityIds={excludedEntityIds}
+            feeds={[]}
+            limit={100}
+            minimumInput={1}
+            namespace={namespace}
             onChange={this._onChangeRoute}
-            value={routeValue} />
+            value={routeValue}
+          />
         )
       case 'GTFS_STOP':
         const stopEntity = ((getGtfsEntity('stop', currentValue): any): GtfsStop)


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This client-requested improvement PR changes the route selector in the GTFS+ route attributes so that only the routes not in use (plus the current route) are shown in the selector drop-down. Routes that appear in other rows of the tables are not shown in the drop-down. (Does not include validation of cases where the same route_id appears in multiple entries in this table).
