### PR TITLE
feat(Deployment): Add shapefile export for deployments

### DIFF
--- a/lib/manager/actions/deployments.js
+++ b/lib/manager/actions/deployments.js
@@ -6,10 +6,10 @@ import { createAction, type ActionType } from 'redux-actions'
 
 import { createVoidPayloadAction, postFormData, secureFetch } from '../../common/actions'
 import fileDownload from '../../common/util/file-download'
-import type {Deployment, Feed, SummarizedFeedVersion} from '../../types'
+import type {Deployment, Feed, ShapefileExportType, SummarizedFeedVersion} from '../../types'
 import type {dispatchFn, getStateFn} from '../../types/reducers'
 
-import { startJobMonitor } from './status'
+import { handleJobResponse, startJobMonitor } from './status'
 import { receiveProject } from './projects'
 
 const DEPLOYMENT_URL = `/api/manager/secure/deployments`
@@ -185,6 +185,16 @@ export function downloadDeployment (deployment: Deployment) {
     return dispatch(secureFetch(`${DEPLOYMENT_URL}/${deployment.id}/download`))
       .then(response => response.blob())
       .then(blob => fileDownload(blob, zipName, 'application/zip'))
+  }
+}
+
+export function downloadDeploymentShapes (deployment: Deployment, type: ShapefileExportType) {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    const url = `${DEPLOYMENT_URL}/${deployment.id}/shapes?type=${type}`
+    return dispatch(secureFetch(url, 'post'))
+      .then(res => {
+        dispatch(handleJobResponse(res, 'Error exporting GIS'))
+      })
   }
 }
 

--- a/lib/manager/actions/status.js
+++ b/lib/manager/actions/status.js
@@ -282,6 +282,10 @@ export function handleFinishedJob (job: ServerJob) {
         // download via S3 (it never uploads the file to S3).
         window.location.assign(`${API_PREFIX}downloadshapes/${job.jobId}`)
         break
+      case 'EXPORT_DEPLOYMENT_GIS':
+        // Download shapefiles for deployment. See note above about temporary files.
+        window.location.assign(`${API_PREFIX}downloadshapes/${job.jobId}`)
+        break
       case 'EXPORT_SNAPSHOT_TO_GTFS':
         if (job.parentJobId) {
           console.log('Not downloading snapshot GTFS. Export job part of feed version creation.')
@@ -326,8 +330,12 @@ export function handleJobResponse (response: Response, message: string) {
         : response.json()
       return dispatch(setErrorMessage(props))
     } else {
-      // Resulting JSON contains message and job ID wich which to monitor job.
+      response.json().then((data) => {
+        console.log(data)
+      })
+      // Resulting JSON contains message and job ID with which to monitor job.
       const json: {jobId: number, message: string} = (response.json(): any)
+
       dispatch(startJobMonitor())
       // Return json with job ID in case it is needed upstream
       return json

--- a/lib/manager/actions/status.js
+++ b/lib/manager/actions/status.js
@@ -330,9 +330,6 @@ export function handleJobResponse (response: Response, message: string) {
         : response.json()
       return dispatch(setErrorMessage(props))
     } else {
-      response.json().then((data) => {
-        console.log(data)
-      })
       // Resulting JSON contains message and job ID with which to monitor job.
       const json: {jobId: number, message: string} = (response.json(): any)
 

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -169,15 +169,14 @@ export default class DeploymentViewer extends Component<Props, State> {
               <span><Glyphicon glyph='download' /> {this.messages('download')}</span>
             </Button>
             <DropdownButton
-              // bsSize={size}
               id='shp-export'
+              onSelect={this._onClickDownloadShapes}
               title={
                 <span>
                   <Icon type='file-zip-o' />
                   <span className='hidden-xs'> Export (.shp)</span>
                 </span>
-              }
-              onSelect={this._onClickDownloadShapes}>
+              }>
               <MenuItem eventKey='STOPS'><Icon type='map-marker' /> Stops</MenuItem>
               <MenuItem eventKey='ROUTES'><Icon type='ellipsis-h' /> Routes</MenuItem>
             </DropdownButton>

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -34,6 +34,7 @@ import {getServerDeployedTo} from '../../util/deployment'
 import type {Props as ContainerProps} from '../../containers/ActiveDeploymentViewer'
 import type {
   ServerJob,
+  ShapefileExportType,
   SummarizedFeedVersion
 } from '../../../types'
 import type {ManagerUserState} from '../../../types/reducers'
@@ -50,6 +51,7 @@ type Props = ContainerProps & {
   deployToTarget: typeof deploymentActions.deployToTarget,
   downloadBuildArtifact: typeof deploymentActions.downloadBuildArtifact,
   downloadDeployment: typeof deploymentActions.downloadDeployment,
+  downloadDeploymentShapes: typeof deploymentActions.downloadDeploymentShapes,
   fetchDeployment: typeof deploymentActions.fetchDeployment,
   incrementAllVersionsToLatest: typeof deploymentActions.incrementAllVersionsToLatest,
   terminateEC2InstanceForDeployment: typeof deploymentActions.terminateEC2InstanceForDeployment,
@@ -114,6 +116,8 @@ export default class DeploymentViewer extends Component<Props, State> {
 
   _onClickDownload = () => this.props.downloadDeployment(this.props.deployment)
 
+  _onClickDownloadShapes = (type: ShapefileExportType) => this.props.downloadDeploymentShapes(this.props.deployment, type)
+
   _onCloseModal = () => this.setState({target: null})
 
   _onSelectTarget = (target: string) => this.setState({target})
@@ -164,6 +168,19 @@ export default class DeploymentViewer extends Component<Props, State> {
               onClick={this._onClickDownload}>
               <span><Glyphicon glyph='download' /> {this.messages('download')}</span>
             </Button>
+            <DropdownButton
+              // bsSize={size}
+              id='shp-export'
+              title={
+                <span>
+                  <Icon type='file-zip-o' />
+                  <span className='hidden-xs'> Export (.shp)</span>
+                </span>
+              }
+              onSelect={this._onClickDownloadShapes}>
+              <MenuItem eventKey='STOPS'><Icon type='map-marker' /> Stops</MenuItem>
+              <MenuItem eventKey='ROUTES'><Icon type='ellipsis-h' /> Routes</MenuItem>
+            </DropdownButton>
             <DropdownButton
               bsStyle='primary'
               id='deploy-server-dropdown'

--- a/lib/manager/containers/ActiveDeploymentViewer.js
+++ b/lib/manager/containers/ActiveDeploymentViewer.js
@@ -7,13 +7,13 @@ import {
   deployToTarget,
   downloadBuildArtifact,
   downloadDeployment,
+  downloadDeploymentShapes,
   fetchDeployment,
   incrementAllVersionsToLatest,
   terminateEC2InstanceForDeployment,
   updateDeployment
 } from '../actions/deployments'
 import DeploymentViewer from '../components/deployment/DeploymentViewer'
-
 import type {Deployment, Feed, Project} from '../../types'
 import type {AppState} from '../../types/reducers'
 
@@ -38,6 +38,7 @@ const mapDispatchToProps = {
   deployToTarget,
   downloadBuildArtifact,
   downloadDeployment,
+  downloadDeploymentShapes,
   fetchDeployment,
   incrementAllVersionsToLatest,
   terminateEC2InstanceForDeployment,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds a button to export shapefiles for a given deployment based on the new endpoint created in this [server PR](https://github.com/ibi-group/datatools-server/pull/470). 

BLOCKED BY https://github.com/ibi-group/datatools-server/pull/470
