### PR TITLE
ci(e2e): Run e2e tests on dependabot PR branches.

### DIFF
--- a/scripts/check-if-e2e-should-run-on-ci.sh
+++ b/scripts/check-if-e2e-should-run-on-ci.sh
@@ -9,6 +9,12 @@ else
     echo "SHOULD_RUN_E2E=true" >> $GITHUB_ENV && export SHOULD_RUN_E2E=true
     echo 'Will run E2E tests because this is a commit to master or dev'
   fi
+  # Also run e2e tests on automatic dependabot PR branches to facilitate approval of security-related PRs.
+  # We check that the branch ref starts with "dependabot/" (refs are in the format "dependabot/<module>/<package-version>").
+  if [[ "$GITHUB_REPOSITORY" = "ibi-group/datatools-ui" ]] && [[ $GITHUB_REF_NAME = dependabot/* ]] && [[ "$GITHUB_REF_SLUG" = "master" || "$GITHUB_REF_SLUG" = "dev" || "$GITHUB_REF_SLUG" = "github-actions" ]]; then
+    echo "SHOULD_RUN_E2E=true" >> $GITHUB_ENV && export SHOULD_RUN_E2E=true
+    echo 'Will run E2E tests because this is an automatic dependabot PR to master or dev'
+  fi
 fi
 
 if [[ "$SHOULD_RUN_E2E" != "true" ]]; then


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [na] All tests and CI builds passing

### Description

This PR changes a condition so that e2e tests will be run for PRs created by dependabot.
This will facilitate accepting security-related PRs.
