### PR TITLE
feat: support multiple graphhopper instances based on bbox

### DIFF
--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -9,5 +9,14 @@ SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key
 # Optional override to use a custom service instead of the graphhopper.com hosted service.
 # GRAPH_HOPPER_URL: http://localhost:8989/
+# Optional overrides to use custom service or different api key for certain bounding boxes.
+GRAPH_HOPPER_ALTERNATES:
+  - URL: http://localhost:8989/
+    KEY: your-localhost-graph-hopper-key
+    BBOX:
+      - -170
+      - 6
+      - -46
+      - 83
 GOOGLE_ANALYTICS_TRACKING_ID: optional-ga-key
 # GRAPH_HOPPER_POINT_LIMIT: 10 # Defaults to 30

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -1,7 +1,7 @@
 // @flow
 
 import ll from '@conveyal/lonlat'
-import {divIcon} from 'leaflet'
+import {Bounds, divIcon} from 'leaflet'
 import clone from 'lodash/cloneDeep'
 import fetch from 'isomorphic-fetch'
 import distance from '@turf/distance'
@@ -44,14 +44,14 @@ type R5Response = {
   }>
 }
 
-export const coordIsOutOfBounds = (coords: LatLng, bounds: any) => {
+export const coordIsOutOfBounds = (coords: LatLng, bounds: Bounds) => {
   return coords.lat > bounds.getNorth() ||
     coords.lat < bounds.getSouth() ||
     bounds.lng > bounds.getEast() ||
     bounds.lng < bounds.getWest()
 }
-export const stopIsOutOfBounds = (stop: GtfsStop, bounds: any) => {
-  return coordIsOutOfBounds({lat: stop.stop_lat, lng: stop.stop_lon})
+export const stopIsOutOfBounds = (stop: GtfsStop, bounds: Bounds) => {
+  return coordIsOutOfBounds({lat: stop.stop_lat, lng: stop.stop_lon}, bounds)
 }
 
 export const getStopIcon = (

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -44,11 +44,14 @@ type R5Response = {
   }>
 }
 
+export const coordIsOutOfBounds = (coords: LatLng, bounds: any) => {
+  return coords.lat > bounds.getNorth() ||
+    coords.lat < bounds.getSouth() ||
+    bounds.lng > bounds.getEast() ||
+    bounds.lng < bounds.getWest()
+}
 export const stopIsOutOfBounds = (stop: GtfsStop, bounds: any) => {
-  return stop.stop_lat > bounds.getNorth() ||
-    stop.stop_lat < bounds.getSouth() ||
-    stop.stop_lon > bounds.getEast() ||
-    stop.stop_lon < bounds.getWest()
+  return coordIsOutOfBounds({lat: stop.stop_lat, lng: stop.stop_lon})
 }
 
 export const getStopIcon = (

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -1,11 +1,11 @@
 // @flow
 
-import fetch from 'isomorphic-fetch'
-import {decode as decodePolyline} from 'polyline'
 import {isEqual as coordinatesAreEqual} from '@conveyal/lonlat'
-import qs from 'qs'
-import lineString from 'turf-linestring'
+import fetch from 'isomorphic-fetch'
 import L from 'leaflet'
+import {decode as decodePolyline} from 'polyline'
+import lineString from 'turf-linestring'
+import qs from 'qs'
 
 // This can be used for logging line strings to geojson.io URLs for easy
 // debugging.
@@ -55,7 +55,7 @@ type GraphHopperResponse = {
   paths: Array<Path>
 }
 
-type GraphHopperAlternativeServer = {
+type GraphHopperAlternateServer = {
   BBOX: Array<number>,
   KEY?: string,
   URL?: string
@@ -221,7 +221,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
 
   if (process.env.GRAPH_HOPPER_ALTERNATES) {
     // $FlowFixMe This is a bit of a hack and now how env variables are supposed to work, but the yaml loader supports it.
-    const alternates: Array<GraphHopperAlternativeServer> = process.env.GRAPH_HOPPER_ALTERNATES
+    const alternates: Array<GraphHopperAlternateServer> = process.env.GRAPH_HOPPER_ALTERNATES
     alternates.forEach(alternative => {
       const {BBOX} = alternative
       if (BBOX.length !== 4) {

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -5,11 +5,13 @@ import {decode as decodePolyline} from 'polyline'
 import {isEqual as coordinatesAreEqual} from '@conveyal/lonlat'
 import qs from 'qs'
 import lineString from 'turf-linestring'
+import L from 'leaflet'
 
 // This can be used for logging line strings to geojson.io URLs for easy
 // debugging.
 // import {logCoordsToGeojsonio} from '../../editor/util/debug'
 
+import { coordIsOutOfBounds } from '../../editor/util/map'
 import type {
   Coordinates,
   LatLng
@@ -51,6 +53,12 @@ type GraphHopperResponse = {
     took: number
   },
   paths: Array<Path>
+}
+
+type GraphHopperAlternativeServer = {
+  BBOX: Array<number>,
+  KEY?: string,
+  URL?: string
 }
 
 /**
@@ -206,10 +214,45 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   if (!process.env.GRAPH_HOPPER_KEY) {
     throw new Error('GRAPH_HOPPER_KEY not set')
   }
+
   // Use custom url if it exists, otherwise default to the hosted service.
-  const GRAPH_HOPPER_URL = process.env.GRAPH_HOPPER_URL || 'https://graphhopper.com/api/1/'
+  let graphHopperUrl = process.env.GRAPH_HOPPER_URL || 'https://graphhopper.com/api/1/'
+  let graphHopperKey = process.env.GRAPH_HOPPER_KEY
+
+  if (process.env.GRAPH_HOPPER_ALTERNATES) {
+    // $FlowFixMe This is a bit of a hack and now how env variables are supposed to work, but the yaml loader supports it.
+    const alternates: Array<GraphHopperAlternativeServer> = process.env.GRAPH_HOPPER_ALTERNATES
+    alternates.forEach(alternative => {
+      const {BBOX} = alternative
+      if (BBOX.length !== 4) {
+        console.warn('Invalid BBOX for GRAPH_HOPPER_ALTERNATIVE')
+        return
+      }
+      if (!alternative.URL && !alternative.KEY) {
+        console.warn('No URL or key provided for alternative graphhopper server.')
+        return
+      }
+
+      if (
+        points.every(
+          (point) =>
+            !coordIsOutOfBounds(
+              point,
+              L.latLngBounds(
+                [alternative.BBOX[1], alternative.BBOX[0]],
+                [alternative.BBOX[3], alternative.BBOX[2]]
+              )
+            )
+        )
+      ) {
+        graphHopperUrl = alternative.URL
+        graphHopperKey = alternative.KEY ? alternative.KEY : null
+      }
+    })
+  }
+
   const params = {
-    key: process.env.GRAPH_HOPPER_KEY,
+    key: graphHopperKey,
     vehicle: 'car',
     debug: true,
     type: 'json'
@@ -217,7 +260,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   // Avoiding motorways requires a POST request with a formatted body
   const graphHopperRequest = avoidMotorways
-    ? fetch(`${GRAPH_HOPPER_URL}route?key=${params.key}`,
+    ? fetch(`${graphHopperUrl}route?key=${params.key}`,
       {
         body: JSON.stringify({
           'ch.disable': true,
@@ -237,7 +280,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
         },
         method: 'POST'
       })
-    : fetch(`${GRAPH_HOPPER_URL}route?${locations}&${qs.stringify(params)}`)
+    : fetch(`${graphHopperUrl}route?${locations}&${qs.stringify(params)}`)
 
   return graphHopperRequest.then(res => res.json())
 }

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -245,8 +245,12 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
             )
         )
       ) {
-        graphHopperUrl = alternative.URL
-        graphHopperKey = alternative.KEY ? alternative.KEY : null
+        if (alternative.URL) {
+          graphHopperUrl = alternative.URL
+        }
+        if (alternative.KEY) {
+          graphHopperKey = alternative.KEY
+        }
       }
     })
   }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR refactors valhalla to support multiple GraphHopper instances based on bounding box. All bounding boxes and servers are configurable via the environment config file.