### PR TITLE
test(e2e): Fix running e2e tests on dependabot PRs and on push to dev/master

### DIFF
--- a/scripts/check-if-e2e-should-run-on-ci.sh
+++ b/scripts/check-if-e2e-should-run-on-ci.sh
@@ -1,19 +1,21 @@
 # Since the e2e tests take a while to run and it could present an inconvenience
-# to be making sure the e2e tests work on every single PR, only run the e2e
-# tests on CI for PRs to master or on commits directly to dev or master
+# to be making sure the e2e tests work on every single PR, only run the e2e tests on CI selectively.
+
+# Run e2e tests on PRs to master
 if [[ "$GITHUB_BASE_REF_SLUG" = "master" ]]; then
   echo "SHOULD_RUN_E2E=true" >> $GITHUB_ENV && export SHOULD_RUN_E2E=true
   echo 'Will run E2E tests because this is a PR to master'
-else
-  if [[ "$GITHUB_REPOSITORY" = "ibi-group/datatools-server" ]] && [[ "$GITHUB_REF_SLUG" = "master" || "$GITHUB_REF_SLUG" = "dev" || "$GITHUB_REF_SLUG" = "github-actions" ]]; then
+elif [[ "$GITHUB_REPOSITORY" = "ibi-group/datatools-ui" ]]; then
+  # Run e2e tests on pushes to dev and master (and for checkout branches from github actions too).
+  if [[ "$GITHUB_REF_SLUG" = "master" || "$GITHUB_REF_SLUG" = "dev" || "$GITHUB_REF_SLUG" = "github-actions" ]]; then
     echo "SHOULD_RUN_E2E=true" >> $GITHUB_ENV && export SHOULD_RUN_E2E=true
     echo 'Will run E2E tests because this is a commit to master or dev'
   fi
-  # Also run e2e tests on automatic dependabot PR branches to facilitate approval of security-related PRs.
+  # Also run e2e tests on automatic dependabot PR branches to dev to facilitate approval of security-related PRs.
   # We check that the branch ref starts with "dependabot/" (refs are in the format "dependabot/<module>/<package-version>").
-  if [[ "$GITHUB_REPOSITORY" = "ibi-group/datatools-ui" ]] && [[ $GITHUB_REF_NAME = dependabot/* ]] && [[ "$GITHUB_REF_SLUG" = "master" || "$GITHUB_REF_SLUG" = "dev" || "$GITHUB_REF_SLUG" = "github-actions" ]]; then
+  if [[ $GITHUB_REF_NAME = dependabot/* ]] && [[ "$GITHUB_BASE_REF_SLUG" = "dev" ]]; then
     echo "SHOULD_RUN_E2E=true" >> $GITHUB_ENV && export SHOULD_RUN_E2E=true
-    echo 'Will run E2E tests because this is an automatic dependabot PR to master or dev'
+    echo 'Will run E2E tests because this is an automatic dependabot PR to dev'
   fi
 fi
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

#806 did not end up resulting in automatic triggering of e2e tests for dependabot, so this PR tries to fix that 🫰.
PR also (temporarily) reinstates running e2e tests on pushes to master and dev.
