### PR TITLE
Remove underscore in No Service exception option

### DIFF
--- a/lib/editor/components/ScheduleExceptionForm.js
+++ b/lib/editor/components/ScheduleExceptionForm.js
@@ -85,18 +85,14 @@ export default class ScheduleExceptionForm extends Component<Props> {
   }
 
   _renderExceptionExemplars (exemplar: string, value: number): string {
-    let exemplarText = ''
     switch (value) {
       case EXCEPTION_EXEMPLARS.SWAP:
-        exemplarText = 'Swap, add, or remove'
-        break
+        return 'Swap, add, or remove'
       case EXCEPTION_EXEMPLARS.NO_SERVICE:
-        exemplarText = toSentenceCase(exemplar.replace('_', ' '))
-        break
+        return toSentenceCase(exemplar.replace('_', ' '))
       default:
-        exemplarText = toSentenceCase(exemplar)
+        return toSentenceCase(exemplar)
     }
-    return exemplarText
   }
 
   _checkValidation = (id: string) => this.props.validationErrors

--- a/lib/editor/components/ScheduleExceptionForm.js
+++ b/lib/editor/components/ScheduleExceptionForm.js
@@ -13,13 +13,13 @@ import Select from 'react-select'
 
 import {updateActiveGtfsEntity} from '../actions/active'
 import toSentenceCase from '../../common/util/to-sentence-case'
-import ExceptionDate from './ExceptionDate'
 import {EXCEPTION_EXEMPLARS} from '../util'
 import {getTableById} from '../util/gtfs'
-
 import type {ServiceCalendar, ScheduleException} from '../../types'
 import type {EditorTables} from '../../types/reducers'
 import type {EditorValidationIssue} from '../util/validation'
+
+import ExceptionDate from './ExceptionDate'
 
 type Props = {
   activeComponent: string,
@@ -84,6 +84,22 @@ export default class ScheduleExceptionForm extends Component<Props> {
     })
   }
 
+  _renderExceptionExemplars (exemplar: string, value: number): string {
+    let exemplarText = ''
+    switch (value) {
+      case EXCEPTION_EXEMPLARS.SWAP:
+        exemplarText = 'Swap, add, or remove'
+        break
+      case EXCEPTION_EXEMPLARS.NO_SERVICE:
+        const a = exemplar.replace('_', ' ')
+        exemplarText = toSentenceCase(a)
+        break
+      default:
+        exemplarText = toSentenceCase(exemplar)
+    }
+    return exemplarText
+  }
+
   _checkValidation = (id: string) => this.props.validationErrors
     .find(e => e.field === id)
     ? 'error'
@@ -142,9 +158,7 @@ export default class ScheduleExceptionForm extends Component<Props> {
                     <option
                       value={value}
                       key={value}>
-                      {value === EXCEPTION_EXEMPLARS.SWAP
-                        ? 'Swap, add, or remove'
-                        : toSentenceCase(exemplar)}
+                      {this._renderExceptionExemplars(exemplar, value)}
                     </option>
                   )
                 })

--- a/lib/editor/components/ScheduleExceptionForm.js
+++ b/lib/editor/components/ScheduleExceptionForm.js
@@ -91,8 +91,7 @@ export default class ScheduleExceptionForm extends Component<Props> {
         exemplarText = 'Swap, add, or remove'
         break
       case EXCEPTION_EXEMPLARS.NO_SERVICE:
-        const a = exemplar.replace('_', ' ')
-        exemplarText = toSentenceCase(a)
+        exemplarText = toSentenceCase(exemplar.replace('_', ' '))
         break
       default:
         exemplarText = toSentenceCase(exemplar)


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Previously, the "No Service" exception option had an underscore included in the display text. This is removed with this PR, and the exception text generation moved to its own method. 

![image](https://user-images.githubusercontent.com/63798641/175353092-3e98cede-2735-40cb-8901-77323949f874.png)
