### PR TITLE
Fix GTFS editor lock

### DIFF
--- a/lib/common/components/StatusModal.js
+++ b/lib/common/components/StatusModal.js
@@ -6,7 +6,6 @@ import {Modal, Button} from 'react-bootstrap'
 import Login from '../containers/Login'
 import * as statusActions from '../../manager/actions/status'
 import * as editorActions from '../../editor/actions/editor'
-
 import type {Props as ContainerProps} from '../containers/CurrentStatusModal'
 import type {ModalStatus} from '../../types/reducers'
 
@@ -71,9 +70,13 @@ export default class StatusModal extends Component<Props, State> {
       .then((success) => {
         if (success) {
           this.setState({
-            action: 'RELOAD',
-            title: 'Success!',
-            body: 'Reload page to begin editing.'
+            // action: 'RELOAD',
+            // title: 'Success!',
+            // body: 'Reload page to begin editing.'
+            action: '',
+            body: '',
+            showModal: false,
+            title: ''
           })
         } else {
           this.setState({

--- a/lib/common/components/StatusModal.js
+++ b/lib/common/components/StatusModal.js
@@ -124,7 +124,6 @@ export default class StatusModal extends Component<Props, State> {
           Re-lock feed
         </Button>
       case 'RELOAD':
-        // TODO: See if this state is still needed.
         return <Button
           bsStyle='success'
           disabled={disabled}

--- a/lib/common/components/StatusModal.js
+++ b/lib/common/components/StatusModal.js
@@ -64,21 +64,13 @@ export default class StatusModal extends Component<Props, State> {
   }
 
   _handleReLock = () => {
+    // Close modal before executing actions.
+    this.close()
     // Calling removeEditorLock with null feedId will use current editor
     // feedSourceId found in store.
     this.props.removeEditorLock(null, true)
       .then((success) => {
-        if (success) {
-          this.setState({
-            // action: 'RELOAD',
-            // title: 'Success!',
-            // body: 'Reload page to begin editing.'
-            action: '',
-            body: '',
-            showModal: false,
-            title: ''
-          })
-        } else {
+        if (!success) {
           this.setState({
             title: 'Attempt to take over editing failed!',
             disabled: true,
@@ -132,6 +124,7 @@ export default class StatusModal extends Component<Props, State> {
           Re-lock feed
         </Button>
       case 'RELOAD':
+        // TODO: See if this state is still needed.
         return <Button
           bsStyle='success'
           disabled={disabled}

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -173,6 +173,15 @@ function stopCurrentTimer (state: AppState) {
 }
 
 /**
+ * Stops the lock timer.
+ */
+export function stopLockTimer () {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    stopCurrentTimer(getState())
+  }
+}
+
+/**
  * HTTP call to the feed lock endpoint.
  */
 function maintainEditorLock (
@@ -181,19 +190,17 @@ function maintainEditorLock (
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     const url = `/api/editor/secure/lock/${sessionId}?feedId=${feedId}`
-    if (!document.hidden) {
-      // Only maintain lock if browser tab is active
-      return dispatch(secureFetch(url, 'put', undefined, undefined, undefined, 'RE_LOCK'))
-        .then(response => response.json())
-        .then(json => {
-          if (json.code >= 400) dispatch(removeEditorLock(feedId))
-          else dispatch(setEditorCheckIn({timestamp: moment().format()}))
-        })
-        .catch(err => {
-          console.warn(err)
-          dispatch(removeEditorLock(feedId))
-        })
-    }
+    // Note: this action is called only when the browser tab/window is visible.
+    return dispatch(secureFetch(url, 'put', undefined, undefined, undefined, 'RE_LOCK'))
+      .then(response => response.json())
+      .then(json => {
+        if (json.code >= 400) dispatch(removeEditorLock(feedId))
+        else dispatch(setEditorCheckIn({timestamp: moment().format()}))
+      })
+      .catch(err => {
+        console.warn(err)
+        dispatch(removeEditorLock(feedId))
+      })
   }
 }
 

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -233,6 +233,19 @@ export function removeEditorLock (
       // If no feed ID is provided, default to the feed ID in the store.
       feedId = getState().editor.data.active.feedSourceId
     }
+
+    if (!feedId) {
+      // TODO: Extract method.
+      // If still no feed id was found, attempt to retrieve it from the editor URL
+      const { locationBeforeTransitions = {} } = getState().routing
+      const { pathname = '' } = locationBeforeTransitions
+      const pathParts = pathname.split('/')
+      if (pathParts[1] === 'feed' && pathParts[3] === 'edit') {
+        // This will apply for URLs that begin with '/feed/xxxxx/edit'
+        feedId = pathParts[2]
+      }
+    }
+
     const {sessionId} = getState().editor.data.lock
     if (!feedId) {
       console.warn('Feed source ID is undefined! Skipping attempt to remove editor lock.')

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -232,6 +232,26 @@ function startEditorLockMaintenance (
   }
 }
 
+function getFeedIdFromStateOrUrl (state: AppState) {
+  let feedId
+  if (!feedId) {
+    // If no feed ID is provided, default to the feed ID in the store.
+    feedId = state.editor.data.active.feedSourceId
+  }
+
+  if (!feedId) {
+    // If still no feed id was found, attempt to retrieve it from the editor URL
+    const { locationBeforeTransitions = {} } = state.routing
+    const { pathname = '' } = locationBeforeTransitions
+    const pathParts = pathname.split('/')
+    if (pathParts[1] === 'feed' && pathParts[3] === 'edit') {
+      // This will apply for URLs that begin with '/feed/xxxxx/edit'
+      feedId = pathParts[2]
+    }
+  }
+  return feedId
+}
+
 /**
  * Remove current editor lock on feed. This should be called when the GTFS Editor
  * unmounts or the browser tab closes.
@@ -243,20 +263,8 @@ export function removeEditorLock (
 ): any {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     if (!feedId) {
-      // If no feed ID is provided, default to the feed ID in the store.
-      feedId = getState().editor.data.active.feedSourceId
-    }
-
-    if (!feedId) {
-      // TODO: Extract method.
-      // If still no feed id was found, attempt to retrieve it from the editor URL
-      const { locationBeforeTransitions = {} } = getState().routing
-      const { pathname = '' } = locationBeforeTransitions
-      const pathParts = pathname.split('/')
-      if (pathParts[1] === 'feed' && pathParts[3] === 'edit') {
-        // This will apply for URLs that begin with '/feed/xxxxx/edit'
-        feedId = pathParts[2]
-      }
+      // If no feed ID is provided, default to the feed ID in the store/URL.
+      feedId = getFeedIdFromStateOrUrl(getState())
     }
 
     const {sessionId} = getState().editor.data.lock
@@ -308,20 +316,8 @@ export function removeEditorLockBeacon (
 ): any {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     if (!feedId) {
-      // If no feed ID is provided, default to the feed ID in the store.
-      feedId = getState().editor.data.active.feedSourceId
-    }
-
-    if (!feedId) {
-      // TODO: Extract method.
-      // If still no feed id was found, attempt to retrieve it from the editor URL
-      const { locationBeforeTransitions = {} } = getState().routing
-      const { pathname = '' } = locationBeforeTransitions
-      const pathParts = pathname.split('/')
-      if (pathParts[1] === 'feed' && pathParts[3] === 'edit') {
-        // This will apply for URLs that begin with '/feed/xxxxx/edit'
-        feedId = pathParts[2]
-      }
+      // If no feed ID is provided, default to the feed ID in the store/URL.
+      feedId = getFeedIdFromStateOrUrl(getState())
     }
 
     const {sessionId} = getState().editor.data.lock
@@ -331,12 +327,10 @@ export function removeEditorLockBeacon (
       return
     }
     console.log(`removing lock for feed ${feedId}, session ${sessionId || '(undefined)'}`)
-    // If sessionId is missing and overwrite is true, the server will
-    // overwrite whatever session was currently running for the feed ID with a
-    // new session.
-    const url = `/api/editor/deletelock/${sessionId || 'dummy_value'}?feedId=${feedId}`
-    // (Weird checks below are needed by flow)
-    if (navigator !== undefined && navigator.sendBeacon !== undefined) {
+    // Send beacon (last-gasp) call to remove editor lock.
+    // (checks for undefined below are needed by flow)
+    if (navigator.sendBeacon !== undefined) {
+      const url = `/api/editor/deletelock/${sessionId || 'dummy_value'}?feedId=${feedId}`
       navigator.sendBeacon(url)
     }
   }

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -173,7 +173,7 @@ function stopCurrentTimer (state: AppState) {
 }
 
 /**
- * HTTP call to .
+ * HTTP call to the feed lock endpoint.
  */
 function maintainEditorLock (
   sessionId: string,
@@ -193,6 +193,19 @@ function maintainEditorLock (
           console.warn(err)
           dispatch(removeEditorLock(feedId))
         })
+    }
+  }
+}
+
+/**
+ * Performs a spot check of the editor lock status (i.e. attempts to maintain the lock)
+ * outside of the timer set in startEditorLockMaintenance.
+ */
+export function checkLockStatus (feedId: string) {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    const {sessionId} = getState().editor.data.lock
+    if (sessionId) {
+      dispatch(maintainEditorLock(sessionId, feedId))
     }
   }
 }

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -186,7 +186,8 @@ export function stopLockTimer () {
  */
 function maintainEditorLock (
   sessionId: string,
-  feedId: string
+  feedId: string,
+  timer?: IntervalID
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     const url = `/api/editor/secure/lock/${sessionId}?feedId=${feedId}`
@@ -195,7 +196,11 @@ function maintainEditorLock (
       .then(response => response.json())
       .then(json => {
         if (json.code >= 400) dispatch(removeEditorLock(feedId))
-        else dispatch(setEditorCheckIn({timestamp: moment().format()}))
+        else {
+          const timestamp = moment().format()
+          if (timer) dispatch(setEditorCheckIn({feedId, sessionId, timer, timestamp}))
+          else dispatch(setEditorCheckIn({timestamp}))
+        }
       })
       .catch(err => {
         console.warn(err)
@@ -230,12 +235,11 @@ function startEditorLockMaintenance (
     stopCurrentTimer(getState())
 
     const timerFunction = () => dispatch(maintainEditorLock(sessionId, feedId))
-    // make an initial call right now
-    timerFunction()
     // Set time to check in every 10 seconds
     const timer = setInterval(timerFunction, 10000)
-    // FIXME: Timer needs updating every maintain editor lock call.
-    dispatch(setEditorCheckIn({timer, sessionId, feedId, timestamp: moment().format()}))
+
+    // Make an initial call right now specifying the timer id.
+    dispatch(maintainEditorLock(sessionId, feedId, timer))
   }
 }
 

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -322,7 +322,7 @@ export function removeEditorLock (
  * Remove current editor lock on feed. This should be called when the GTFS Editor
  * unmounts or the browser tab closes.
  */
-export function removeEditorLockBeacon (
+export function sendRemoveEditorLockBeacon (
   feedId: ?string
 ): any {
   return function (dispatch: dispatchFn, getState: getStateFn) {

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -299,6 +299,49 @@ export function removeEditorLock (
   }
 }
 
+/**
+ * Remove current editor lock on feed. This should be called when the GTFS Editor
+ * unmounts or the browser tab closes.
+ */
+export function removeEditorLockBeacon (
+  feedId: ?string
+): any {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    if (!feedId) {
+      // If no feed ID is provided, default to the feed ID in the store.
+      feedId = getState().editor.data.active.feedSourceId
+    }
+
+    if (!feedId) {
+      // TODO: Extract method.
+      // If still no feed id was found, attempt to retrieve it from the editor URL
+      const { locationBeforeTransitions = {} } = getState().routing
+      const { pathname = '' } = locationBeforeTransitions
+      const pathParts = pathname.split('/')
+      if (pathParts[1] === 'feed' && pathParts[3] === 'edit') {
+        // This will apply for URLs that begin with '/feed/xxxxx/edit'
+        feedId = pathParts[2]
+      }
+    }
+
+    const {sessionId} = getState().editor.data.lock
+    if (!feedId) {
+      console.warn('Feed source ID is undefined! Skipping attempt to remove editor lock.')
+      // FIXME: Don't let feed ID become undefined!
+      return
+    }
+    console.log(`removing lock for feed ${feedId}, session ${sessionId || '(undefined)'}`)
+    // If sessionId is missing and overwrite is true, the server will
+    // overwrite whatever session was currently running for the feed ID with a
+    // new session.
+    const url = `/api/editor/deletelock/${sessionId || 'dummy_value'}?feedId=${feedId}`
+    // (Weird checks below are needed by flow)
+    if (navigator !== undefined && navigator.sendBeacon !== undefined) {
+      navigator.sendBeacon(url)
+    }
+  }
+}
+
 export function newGtfsEntities (
   feedSourceId: string,
   component: string,

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -167,7 +167,6 @@ export function lockEditorFeedSource (feedId: string) {
  * Stop job time function stored with timer ID stored in state.
  */
 function stopCurrentTimer (state: AppState) {
-  // FIXME
   const {timer} = state.editor.data.lock
   if (timer) clearInterval(timer)
 }
@@ -244,19 +243,14 @@ function startEditorLockMaintenance (
 }
 
 function getFeedIdFromStateOrUrl (state: AppState) {
-  let feedId
+  let feedId = state.editor.data.active.feedSourceId
+  // If no feed id was found in the lock state, attempt to retrieve it from the editor URL.
   if (!feedId) {
-    // If no feed ID is provided, default to the feed ID in the store.
-    feedId = state.editor.data.active.feedSourceId
-  }
-
-  if (!feedId) {
-    // If still no feed id was found, attempt to retrieve it from the editor URL
     const { locationBeforeTransitions = {} } = state.routing
     const { pathname = '' } = locationBeforeTransitions
     const pathParts = pathname.split('/')
     if (pathParts[1] === 'feed' && pathParts[3] === 'edit') {
-      // This will apply for URLs that begin with '/feed/xxxxx/edit'
+      // This will apply for URLs of the form '/feed/xxxxx/edit'
       feedId = pathParts[2]
     }
   }
@@ -264,8 +258,7 @@ function getFeedIdFromStateOrUrl (state: AppState) {
 }
 
 /**
- * Remove current editor lock on feed. This should be called when the GTFS Editor
- * unmounts or the browser tab closes.
+ * Remove current editor lock on feed.
  */
 export function removeEditorLock (
   feedId: ?string,
@@ -319,24 +312,14 @@ export function removeEditorLock (
 }
 
 /**
- * Remove current editor lock on feed. This should be called when the GTFS Editor
- * unmounts or the browser tab closes.
+ * Remove current editor lock on feed. This should be called as a last-gasp request
+ * when the GTFS Editor unmounts or the browser tab closes.
  */
 export function removeEditorLockLastGasp (
-  feedId: ?string
-): any {
+  feedId: string
+) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    if (!feedId) {
-      // If no feed ID is provided, default to the feed ID in the store/URL.
-      feedId = getFeedIdFromStateOrUrl(getState())
-    }
-
     const {sessionId} = getState().editor.data.lock
-    if (!feedId) {
-      console.warn('Feed source ID is undefined! Skipping attempt to remove editor lock.')
-      // FIXME: Don't let feed ID become undefined!
-      return
-    }
     // Send beacon (last-gasp) call to remove editor lock.
     console.log(`removing lock for feed ${feedId}, session ${sessionId || '(undefined)'}`)
     const url = `/api/editor/deletelock/${sessionId || 'dummy_value'}?feedId=${feedId}`

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -322,7 +322,7 @@ export function removeEditorLock (
  * Remove current editor lock on feed. This should be called when the GTFS Editor
  * unmounts or the browser tab closes.
  */
-export function sendRemoveEditorLockBeacon (
+export function removeEditorLockLastGasp (
   feedId: ?string
 ): any {
   return function (dispatch: dispatchFn, getState: getStateFn) {
@@ -337,13 +337,11 @@ export function sendRemoveEditorLockBeacon (
       // FIXME: Don't let feed ID become undefined!
       return
     }
-    console.log(`removing lock for feed ${feedId}, session ${sessionId || '(undefined)'}`)
     // Send beacon (last-gasp) call to remove editor lock.
-    // (checks for undefined below are needed by flow)
-    if (navigator.sendBeacon !== undefined) {
-      const url = `/api/editor/deletelock/${sessionId || 'dummy_value'}?feedId=${feedId}`
-      navigator.sendBeacon(url)
-    }
+    console.log(`removing lock for feed ${feedId}, session ${sessionId || '(undefined)'}`)
+    const url = `/api/editor/deletelock/${sessionId || 'dummy_value'}?feedId=${feedId}`
+    // $FlowFixMe - Assume navigator.sendBeacon is implemented.
+    navigator.sendBeacon(url)
   }
 }
 

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -82,6 +82,7 @@ type Props = ContainerProps & {
   hasRoutes: boolean,
   hideTutorial: boolean,
   loadFeedVersionForEditing: typeof snapshotActions.loadFeedVersionForEditing,
+  lockEditorFeedSource: typeof editorActions.lockEditorFeedSource,
   mapState: MapState,
   namespace: string,
   newGtfsEntity: typeof editorActions.newGtfsEntity,
@@ -105,6 +106,7 @@ type Props = ContainerProps & {
   showConfirmModal: ({body: string, onConfirm: () => void, title: string}) => void,
   sidebarExpanded: boolean,
   status: EditorStatus,
+  stopLockTimer: typeof editorActions.stopLockTimer,
   subComponent: string,
   subEntity: number,
   subEntityId: number,
@@ -150,6 +152,19 @@ export default class GtfsEditor extends Component<Props, State> {
     this.props.checkLockStatus(this.props.feedSourceId)
   }
 
+  onVisibilityChange = () => {
+    // When the user exits the editor (i.e. switches tab, closes tab or window, navigates away, or refreshes the page),
+    // remove the lock on the editor feed resource.
+    if (document.visibilityState === 'visible') {
+      // If the page is visible/activated again, resume lock checkin.
+      this.props.lockEditorFeedSource(this.props.feedSourceId)
+    } else {
+      // When the user exits the editor, stop the editor check-in requests
+      // (does not remove the editor lock in case the page gets activated again).
+      this.props.stopLockTimer()
+    }
+  }
+
   componentDidMount () {
     // If the browser window/tab is closed, the component does not have a chance
     // to run componentWillUnmount. This event listener runs clean up in those
@@ -160,6 +175,11 @@ export default class GtfsEditor extends Component<Props, State> {
     // Listen to the window focus event so we can check for things like editor lock status right away.
     const focusEvent = window.attachEvent ? 'onfocus' : 'focus'
     window.addEventListener(focusEvent, this.onFocus)
+
+    // Listen to the page visibilityChange event so we can check for things like editor lock status
+    // or pause/resume lock pings right away.
+    const visibilityChangeEvent = window.attachEvent ? 'onvisibilitychange' : 'visibilitychange'
+    window.addEventListener(visibilityChangeEvent, this.onVisibilityChange)
   }
 
   componentWillUnmount () {
@@ -171,6 +191,9 @@ export default class GtfsEditor extends Component<Props, State> {
 
     const focusEvent = window.attachEvent ? 'onfocus' : 'focus'
     window.removeEventListener(focusEvent, this.onFocus)
+
+    const visibilityChangeEvent = window.attachEvent ? 'onvisibilitychange' : 'visibilitychange'
+    window.removeEventListener(visibilityChangeEvent, this.onVisibilityChange)
   }
 
   componentDidUpdate (prevProps: Props) {

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -97,10 +97,10 @@ type Props = ContainerProps & {
   refreshBaseEditorData: typeof activeActions.refreshBaseEditorData,
   removeControlPoint: typeof mapActions.removeControlPoint,
   removeEditorLock: typeof editorActions.removeEditorLock,
+  removeEditorLockLastGasp: typeof editorActions.removeEditorLockLastGasp,
   removeStopFromPattern: typeof stopStrategiesActions.removeStopFromPattern,
   resetActiveGtfsEntity: typeof activeActions.resetActiveGtfsEntity,
   saveActiveGtfsEntity: typeof activeActions.saveActiveGtfsEntity,
-  sendRemoveEditorLockBeacon: typeof editorActions.sendRemoveEditorLockBeacon,
   setActiveEntity: typeof activeActions.setActiveEntity,
   setActiveGtfsEntity: typeof activeActions.setActiveGtfsEntity,
   setActivePatternSegment: typeof tripPatternActions.setActivePatternSegment,
@@ -153,8 +153,8 @@ export default class GtfsEditor extends Component<Props, State> {
   }
 
   componentCleanUp = () => {
-    // When the user exits the editor, remove the lock on the editor feed resource.
-    this.props.sendRemoveEditorLockBeacon(this.props.feedSourceId)
+    // When the user exits the editor, as a last-gasp action, remove the editor lock on the feed.
+    this.props.removeEditorLockLastGasp(this.props.feedSourceId)
   }
 
   onFocus = () => {
@@ -168,16 +168,14 @@ export default class GtfsEditor extends Component<Props, State> {
       lockEditorFeedSource,
       stopLockTimer
     } = this.props
-    // When the user exits the editor (i.e. switches tab, closes tab or window, navigates away, or refreshes the page),
-    // remove the lock on the editor feed resource.
     if (document.visibilityState === 'visible') {
-      // If the page is visible/activated again, resume lock checkin, unless showing a RE_LOCK prompt.
+      // If the page is visible/activated again, resume lock check-in, unless a modal prompt is shown.
       if (errorStatus.modal === undefined) {
         lockEditorFeedSource(feedSourceId)
       }
     } else {
-      // When the user exits the editor, stop the editor check-in requests
-      // (does not remove the editor lock in case the page gets activated again).
+      // When the user exits the editor (i.e. switches, closes, or reloads the tab/window, or navigates away),
+      // stop the editor lock timer (don't remove the lock in case the page gets activated again).
       stopLockTimer()
     }
   }

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -94,6 +94,7 @@ type Props = ContainerProps & {
   refreshBaseEditorData: typeof activeActions.refreshBaseEditorData,
   removeControlPoint: typeof mapActions.removeControlPoint,
   removeEditorLock: typeof editorActions.removeEditorLock,
+  removeEditorLockBeacon: typeof editorActions.removeEditorLockBeacon,
   removeStopFromPattern: typeof stopStrategiesActions.removeStopFromPattern,
   resetActiveGtfsEntity: typeof activeActions.resetActiveGtfsEntity,
   saveActiveGtfsEntity: typeof activeActions.saveActiveGtfsEntity,
@@ -142,7 +143,7 @@ export default class GtfsEditor extends Component<Props, State> {
 
   componentCleanUp = () => {
     // When the user exits the editor, remove the lock on the editor feed resource.
-    this.props.removeEditorLock(this.props.feedSourceId)
+    this.props.removeEditorLockBeacon(this.props.feedSourceId)
   }
 
   onFocus = () => {
@@ -153,7 +154,7 @@ export default class GtfsEditor extends Component<Props, State> {
     // If the browser window/tab is closed, the component does not have a chance
     // to run componentWillUnmount. This event listener runs clean up in those
     // cases.
-    const unloadEvent = window.attachEvent ? 'onbeforeunload' : 'beforeunload'
+    const unloadEvent = window.attachEvent ? 'onpagehide' : 'pagehide'
     window.addEventListener(unloadEvent, this.componentCleanUp)
 
     // Listen to the window focus event so we can check for things like editor lock status right away.
@@ -165,7 +166,7 @@ export default class GtfsEditor extends Component<Props, State> {
     // Run component clean-up
     this.componentCleanUp()
     // And remove the event handler for normal unmounting
-    const unloadEvent = window.attachEvent ? 'onbeforeunload' : 'beforeunload'
+    const unloadEvent = window.attachEvent ? 'onpagehide' : 'pagehide'
     window.removeEventListener(unloadEvent, this.componentCleanUp)
 
     const focusEvent = window.attachEvent ? 'onfocus' : 'focus'

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -97,10 +97,10 @@ type Props = ContainerProps & {
   refreshBaseEditorData: typeof activeActions.refreshBaseEditorData,
   removeControlPoint: typeof mapActions.removeControlPoint,
   removeEditorLock: typeof editorActions.removeEditorLock,
-  removeEditorLockBeacon: typeof editorActions.removeEditorLockBeacon,
   removeStopFromPattern: typeof stopStrategiesActions.removeStopFromPattern,
   resetActiveGtfsEntity: typeof activeActions.resetActiveGtfsEntity,
   saveActiveGtfsEntity: typeof activeActions.saveActiveGtfsEntity,
+  sendRemoveEditorLockBeacon: typeof editorActions.sendRemoveEditorLockBeacon,
   setActiveEntity: typeof activeActions.setActiveEntity,
   setActiveGtfsEntity: typeof activeActions.setActiveGtfsEntity,
   setActivePatternSegment: typeof tripPatternActions.setActivePatternSegment,
@@ -131,6 +131,13 @@ type State = {
   activeTableId: ?string
 }
 
+/**
+ * Figures out the correct event name to use.
+ */
+function getNormalizedEvent (eventName: string) {
+  return window.attachEvent ? `on${eventName}` : eventName
+}
+
 export default class GtfsEditor extends Component<Props, State> {
   componentWillMount () {
     this.setState({
@@ -147,7 +154,7 @@ export default class GtfsEditor extends Component<Props, State> {
 
   componentCleanUp = () => {
     // When the user exits the editor, remove the lock on the editor feed resource.
-    this.props.removeEditorLockBeacon(this.props.feedSourceId)
+    this.props.sendRemoveEditorLockBeacon(this.props.feedSourceId)
   }
 
   onFocus = () => {
@@ -179,31 +186,23 @@ export default class GtfsEditor extends Component<Props, State> {
     // If the browser window/tab is closed, the component does not have a chance
     // to run componentWillUnmount. This event listener runs clean up in those
     // cases.
-    const unloadEvent = window.attachEvent ? 'onpagehide' : 'pagehide'
-    window.addEventListener(unloadEvent, this.componentCleanUp)
+    window.addEventListener(getNormalizedEvent('pagehide'), this.componentCleanUp)
 
     // Listen to the window focus event so we can check for things like editor lock status right away.
-    const focusEvent = window.attachEvent ? 'onfocus' : 'focus'
-    window.addEventListener(focusEvent, this.onFocus)
+    window.addEventListener(getNormalizedEvent('focus'), this.onFocus)
 
     // Listen to the page visibilityChange event so we can check for things like editor lock status
-    // or pause/resume lock pings right away.
-    const visibilityChangeEvent = window.attachEvent ? 'onvisibilitychange' : 'visibilitychange'
-    window.addEventListener(visibilityChangeEvent, this.onVisibilityChange)
+    // or pause/resume lock timers right away.
+    window.addEventListener(getNormalizedEvent('visibilitychange'), this.onVisibilityChange)
   }
 
   componentWillUnmount () {
     // Run component clean-up
     this.componentCleanUp()
-    // And remove the event handler for normal unmounting
-    const unloadEvent = window.attachEvent ? 'onpagehide' : 'pagehide'
-    window.removeEventListener(unloadEvent, this.componentCleanUp)
-
-    const focusEvent = window.attachEvent ? 'onfocus' : 'focus'
-    window.removeEventListener(focusEvent, this.onFocus)
-
-    const visibilityChangeEvent = window.attachEvent ? 'onvisibilitychange' : 'visibilitychange'
-    window.removeEventListener(visibilityChangeEvent, this.onVisibilityChange)
+    // And remove the event handlers for normal unmounting
+    window.removeEventListener(getNormalizedEvent('pagehide'), this.componentCleanUp)
+    window.removeEventListener(getNormalizedEvent('focus'), this.onFocus)
+    window.removeEventListener(getNormalizedEvent('visibilitychange'), this.onVisibilityChange)
   }
 
   componentDidUpdate (prevProps: Props) {

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -58,6 +58,7 @@ type Props = ContainerProps & {
   addStopAtInterval: typeof stopStrategiesActions.addStopAtIntersection,
   addStopAtPoint: typeof stopStrategiesActions.addStopAtPoint,
   addStopToPattern: typeof stopStrategiesActions.addStopToPattern,
+  checkLockStatus: typeof editorActions.checkLockStatus,
   clearGtfsContent: typeof activeActions.clearGtfsContent,
   cloneGtfsEntity: typeof editorActions.cloneGtfsEntity,
   constructControlPoint: typeof mapActions.constructControlPoint,
@@ -144,12 +145,20 @@ export default class GtfsEditor extends Component<Props, State> {
     this.props.removeEditorLock(this.props.feedSourceId)
   }
 
+  onFocus = () => {
+    console.log('Window onfocus')
+    this.props.checkLockStatus(this.props.feedSourceId)
+  }
+
   componentDidMount () {
     // If the browser window/tab is closed, the componnent does not have a chance
     // to run componentWillUnmount. This event listener runs clean up in those
     // cases.
     const unloadEvent = window.attachEvent ? 'onbeforeunload' : 'beforeunload'
     window.addEventListener(unloadEvent, this.componentCleanUp)
+
+    const focusEvent = window.attachEvent ? 'onfocus' : 'focus'
+    window.addEventListener(focusEvent, this.onFocus)
   }
 
   componentWillUnmount () {
@@ -159,6 +168,9 @@ export default class GtfsEditor extends Component<Props, State> {
     // And remove the event handler for normal unmounting
     const unloadEvent = window.attachEvent ? 'onbeforeunload' : 'beforeunload'
     window.removeEventListener(unloadEvent, this.componentCleanUp)
+
+    const focusEvent = window.attachEvent ? 'onfocus' : 'focus'
+    window.removeEventListener(focusEvent, this.onFocus)
   }
 
   componentDidUpdate (prevProps: Props) {
@@ -201,8 +213,8 @@ export default class GtfsEditor extends Component<Props, State> {
       // Re-establish lock for new feed source and fetch GTFS.
       this._refreshBaseEditorData(nextProps)
     } else if (!nextProps.feedIsLocked && this.props.feedIsLocked) {
-      //
-      // Re-establish lock for the feed source and fetch GTFS.
+      // If user clicked "Re-lock feed",
+      // re-establish lock for the feed source and fetch GTFS to resume editing.
       this._refreshBaseEditorData(nextProps)
     }
     if (namespace && nextProps.namespace !== namespace) {

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -37,7 +37,8 @@ import type {
   EditorStatus,
   EditorTables,
   ManagerUserState,
-  MapState
+  MapState,
+  StatusState
 } from '../../types/reducers'
 import type {EditorValidationIssue} from '../util/validation'
 
@@ -70,6 +71,7 @@ type Props = ContainerProps & {
   editSettings: EditSettingsState,
   entities: Array<Entity>,
   entityEdited: boolean,
+  errorStatus: StatusState,
   feedInfo: FeedInfo,
   feedIsLocked: boolean,
   feedSource: Feed,
@@ -153,15 +155,23 @@ export default class GtfsEditor extends Component<Props, State> {
   }
 
   onVisibilityChange = () => {
+    const {
+      errorStatus,
+      feedSourceId,
+      lockEditorFeedSource,
+      stopLockTimer
+    } = this.props
     // When the user exits the editor (i.e. switches tab, closes tab or window, navigates away, or refreshes the page),
     // remove the lock on the editor feed resource.
     if (document.visibilityState === 'visible') {
-      // If the page is visible/activated again, resume lock checkin.
-      this.props.lockEditorFeedSource(this.props.feedSourceId)
+      // If the page is visible/activated again, resume lock checkin, unless showing a RE_LOCK prompt.
+      if (errorStatus.modal === undefined) {
+        lockEditorFeedSource(feedSourceId)
+      }
     } else {
       // When the user exits the editor, stop the editor check-in requests
       // (does not remove the editor lock in case the page gets activated again).
-      this.props.stopLockTimer()
+      stopLockTimer()
     }
   }
 

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -14,18 +14,12 @@ import ConfirmModal from '../../common/components/ConfirmModal'
 import Title from '../../common/components/Title'
 import CurrentStatusModal from '../../common/containers/CurrentStatusModal'
 import * as userActions from '../../manager/actions/user'
-import EditorMap from './map/EditorMap'
-import EditorHelpModal from './EditorHelpModal'
-import EditorSidebar from './EditorSidebar'
 import ActiveEntityList from '../containers/ActiveEntityList'
-import EntityDetails from './EntityDetails'
 import ActiveTimetableEditor from '../containers/ActiveTimetableEditor'
 import ActiveFeedInfoPanel from '../containers/ActiveFeedInfoPanel'
-
 import {getConfigProperty} from '../../common/util/config'
 import {getEntityName, getTableById} from '../util/gtfs'
 import {GTFS_ICONS} from '../util/ui'
-
 import type {Props as ContainerProps} from '../containers/ActiveGtfsEditor'
 import type {
   ControlPoint,
@@ -46,6 +40,11 @@ import type {
   MapState
 } from '../../types/reducers'
 import type {EditorValidationIssue} from '../util/validation'
+
+import EntityDetails from './EntityDetails'
+import EditorSidebar from './EditorSidebar'
+import EditorHelpModal from './EditorHelpModal'
+import EditorMap from './map/EditorMap'
 
 type Props = ContainerProps & {
   activeComponent: string,
@@ -200,6 +199,10 @@ export default class GtfsEditor extends Component<Props, State> {
       removeEditorLock(feedSourceId, false)
       clearGtfsContent()
       // Re-establish lock for new feed source and fetch GTFS.
+      this._refreshBaseEditorData(nextProps)
+    } else if (!nextProps.feedIsLocked && this.props.feedIsLocked) {
+      //
+      // Re-establish lock for the feed source and fetch GTFS.
       this._refreshBaseEditorData(nextProps)
     }
     if (namespace && nextProps.namespace !== namespace) {

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -146,24 +146,23 @@ export default class GtfsEditor extends Component<Props, State> {
   }
 
   onFocus = () => {
-    console.log('Window onfocus')
     this.props.checkLockStatus(this.props.feedSourceId)
   }
 
   componentDidMount () {
-    // If the browser window/tab is closed, the componnent does not have a chance
+    // If the browser window/tab is closed, the component does not have a chance
     // to run componentWillUnmount. This event listener runs clean up in those
     // cases.
     const unloadEvent = window.attachEvent ? 'onbeforeunload' : 'beforeunload'
     window.addEventListener(unloadEvent, this.componentCleanUp)
 
+    // Listen to the window focus event so we can check for things like editor lock status right away.
     const focusEvent = window.attachEvent ? 'onfocus' : 'focus'
     window.addEventListener(focusEvent, this.onFocus)
   }
 
   componentWillUnmount () {
     // Run component clean-up
-    // console.log('componnent is unmounting')
     this.componentCleanUp()
     // And remove the event handler for normal unmounting
     const unloadEvent = window.attachEvent ? 'onbeforeunload' : 'beforeunload'

--- a/lib/editor/containers/ActiveGtfsEditor.js
+++ b/lib/editor/containers/ActiveGtfsEditor.js
@@ -38,6 +38,7 @@ import {
   updateEditSetting
 } from '../actions/active'
 import {
+  checkLockStatus,
   cloneGtfsEntity,
   newGtfsEntity,
   newGtfsEntities,
@@ -48,7 +49,6 @@ import {createSnapshot, loadFeedVersionForEditing} from '../actions/snapshots'
 import {findProjectByFeedSource} from '../../manager/util'
 import {getActivePatternStops, getControlPoints, getValidationErrors} from '../selectors'
 import {getTableById, getIdsFromParams} from '../util/gtfs'
-
 import type {AppState, RouterProps} from '../../types/reducers'
 
 export type Props = RouterProps
@@ -141,6 +141,7 @@ const mapDispatchToProps = {
   addStopAtInterval,
   addStopAtPoint,
   addStopToPattern,
+  checkLockStatus,
   clearGtfsContent,
   cloneGtfsEntity,
   constructControlPoint,

--- a/lib/editor/containers/ActiveGtfsEditor.js
+++ b/lib/editor/containers/ActiveGtfsEditor.js
@@ -44,7 +44,7 @@ import {
   newGtfsEntity,
   newGtfsEntities,
   removeEditorLock,
-  sendRemoveEditorLockBeacon,
+  removeEditorLockLastGasp,
   stopLockTimer,
   uploadBrandingAsset
 } from '../actions/editor'
@@ -164,7 +164,7 @@ const mapDispatchToProps = {
   refreshBaseEditorData,
   removeControlPoint,
   removeEditorLock,
-  sendRemoveEditorLockBeacon,
+  removeEditorLockLastGasp,
   removeStopFromPattern,
   resetActiveGtfsEntity,
   saveActiveGtfsEntity,

--- a/lib/editor/containers/ActiveGtfsEditor.js
+++ b/lib/editor/containers/ActiveGtfsEditor.js
@@ -44,7 +44,7 @@ import {
   newGtfsEntity,
   newGtfsEntities,
   removeEditorLock,
-  removeEditorLockBeacon,
+  sendRemoveEditorLockBeacon,
   stopLockTimer,
   uploadBrandingAsset
 } from '../actions/editor'
@@ -164,7 +164,7 @@ const mapDispatchToProps = {
   refreshBaseEditorData,
   removeControlPoint,
   removeEditorLock,
-  removeEditorLockBeacon,
+  sendRemoveEditorLockBeacon,
   removeStopFromPattern,
   resetActiveGtfsEntity,
   saveActiveGtfsEntity,

--- a/lib/editor/containers/ActiveGtfsEditor.js
+++ b/lib/editor/containers/ActiveGtfsEditor.js
@@ -43,6 +43,7 @@ import {
   newGtfsEntity,
   newGtfsEntities,
   removeEditorLock,
+  removeEditorLockBeacon,
   uploadBrandingAsset
 } from '../actions/editor'
 import {createSnapshot, loadFeedVersionForEditing} from '../actions/snapshots'
@@ -158,6 +159,7 @@ const mapDispatchToProps = {
   refreshBaseEditorData,
   removeControlPoint,
   removeEditorLock,
+  removeEditorLockBeacon,
   removeStopFromPattern,
   resetActiveGtfsEntity,
   saveActiveGtfsEntity,

--- a/lib/editor/containers/ActiveGtfsEditor.js
+++ b/lib/editor/containers/ActiveGtfsEditor.js
@@ -90,6 +90,7 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
   // console.log(activeEntityId, activeEntity, active, active.entity)
   const validationErrors = getValidationErrors(state)
   const user = state.user
+  const errorStatus = state.status
 
   // find the containing project
   const project = findProjectByFeedSource(state.projects.all, feedSourceId)
@@ -113,6 +114,7 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
     editSettings,
     entities,
     entityEdited,
+    errorStatus,
     feedInfo,
     feedIsLocked,
     feedSource,

--- a/lib/editor/containers/ActiveGtfsEditor.js
+++ b/lib/editor/containers/ActiveGtfsEditor.js
@@ -40,10 +40,12 @@ import {
 import {
   checkLockStatus,
   cloneGtfsEntity,
+  lockEditorFeedSource,
   newGtfsEntity,
   newGtfsEntities,
   removeEditorLock,
   removeEditorLockBeacon,
+  stopLockTimer,
   uploadBrandingAsset
 } from '../actions/editor'
 import {createSnapshot, loadFeedVersionForEditing} from '../actions/snapshots'
@@ -154,6 +156,7 @@ const mapDispatchToProps = {
   handleControlPointDragEnd,
   handleControlPointDragStart,
   loadFeedVersionForEditing,
+  lockEditorFeedSource,
   newGtfsEntities,
   newGtfsEntity,
   refreshBaseEditorData,
@@ -167,6 +170,7 @@ const mapDispatchToProps = {
   setActiveGtfsEntity,
   setActivePatternSegment,
   setActiveStop,
+  stopLockTimer,
   undoActiveTripPatternEdits,
   updateActiveGtfsEntity,
   updateEditSetting,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Requires https://github.com/ibi-group/datatools-server/pull/477
Fix #175, Fix #179

This PR improves the editor locking feature as follows, in both Chrome and Firefox:
- Clicking "Re-lock feed" immediately enables the GTFS editor without the need to reload the page (one fewer click than before).
- Reloading an active editor tab/window no longer triggers the re-lock notice.
- The re-lock notice appears immediately after switching focus to a tab that doesn’t own the editor lock.

