### PR TITLE
fix(TimetableHeader): separate offset input into two inputs

### DIFF
--- a/lib/editor/components/HourMinuteInput.js
+++ b/lib/editor/components/HourMinuteInput.js
@@ -1,12 +1,13 @@
 // @flow
 
-import React, {Component} from 'react'
+// $FlowFixMe Flow doesn't recognize react KeyboardEvent
+import React, {Component, KeyboardEvent } from 'react'
 import {FormControl} from 'react-bootstrap'
 
 type Props = {
   onChange: (number) => any,
   seconds: number,
-  style: {[string]: string | number}
+  style?: {[string]: string | number}
 }
 
 type State = {
@@ -17,15 +18,24 @@ type State = {
 export default class HourMinuteInput extends Component<Props, State> {
   state = {}
 
-  _onChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    const {id, value} = evt.target
-    // $FlowFixMe Using weird React types
-    const {data: key} = evt.nativeEvent
+  _onKeyDown = (evt: KeyboardEvent) => {
+    const {key} = evt
 
-    // Ignore non-number keystrokes
-    if (isNaN(parseInt(key))) {
+    // Move to minute field when colon is typed
+    if (key === ':') {
+      evt.preventDefault()
+      // $FlowFixMe this is a terrible hack, but unless we upgrade to react 17 and use modern refs, this is not possible otherwise
+      document.getElementById('minutes').select()
       return
     }
+
+    // Ignore non-number keystrokes
+    if (key !== 'Backspace' && key !== 'Tab' && isNaN(parseInt(key))) {
+      evt.preventDefault()
+    }
+  }
+  _onChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    const {id, value} = evt.target
 
     // Ignore calls to this method that somehow don't come from the two inputs below
     if (id !== 'hours' && id !== 'minutes') {
@@ -65,21 +75,24 @@ export default class HourMinuteInput extends Component<Props, State> {
         <FormControl
           {...otherProps}
           id='hours'
+          onKeyDown={this._onKeyDown}
           onChange={this._onChange}
           onFocus={this._onFocus}
           placeholder={'hh'}
-          style={style}
-          value={hours && hours < 10 ? `0${hours}` : hours || '00'}
+          style={{ width: '5.5ch', borderRight: 'none', ...style }}
+          value={hours && hours < 10 ? `0${hours}` : hours || null}
         />
-         :
+        <span style={{zIndex: 9, position: 'relative', left: -2.5, fontWeight: 900}}>:</span>
         <FormControl
           {...otherProps}
           id='minutes'
+          onKeyDown={this._onKeyDown}
           onChange={this._onChange}
           onFocus={this._onFocus}
           placeholder={'mm'}
-          style={style}
-          value={minutes && minutes < 10 ? `0${minutes}` : minutes || '00'}
+          ref={'minuteInput'}
+          style={{ width: '6.5ch', marginLeft: -5, borderLeft: 'none', ...style }}
+          value={minutes && minutes < 10 ? `0${minutes}` : minutes || null}
         />
       </span>
     )

--- a/lib/editor/components/HourMinuteInput.js
+++ b/lib/editor/components/HourMinuteInput.js
@@ -3,11 +3,6 @@
 import React, {Component} from 'react'
 import {FormControl} from 'react-bootstrap'
 
-import {
-  convertSecondsToHHMMString,
-  convertHHMMStringToSeconds
-} from '../../common/util/date-time'
-
 type Props = {
   onChange: (number) => any,
   seconds: number,
@@ -15,34 +10,74 @@ type Props = {
 }
 
 type State = {
-  string?: string
+  hours?: number,
+  minutes?: number
 }
 
 export default class HourMinuteInput extends Component<Props, State> {
   state = {}
 
   _onChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    const {onChange} = this.props
-    const {value} = evt.target
-    const seconds = convertHHMMStringToSeconds(value)
-    this.setState({string: value})
-    onChange && onChange(seconds)
+    const {id, value} = evt.target
+    const {data: key} = evt.nativeEvent
+
+    if (isNaN(parseInt(key))) {
+      return
+    }
+    if (id !== 'hours' && id !== 'minutes') {
+      return
+    }
+
+    this.setState({[id]: value}, this.handleChange)
   }
 
-  componentWillReceiveProps (nextProps: Props) {
-    this.setState({string: convertSecondsToHHMMString(nextProps.seconds)})
+  _onFocus = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    evt.target.select()
+  }
+
+  handleChange = () => {
+    const {onChange} = this.props
+
+    const {hours, minutes} = this.state
+    onChange && onChange(((hours || 0) * 3600) + ((minutes || 0) * 60))
+  }
+
+  componentDidUpdate (prevProps: Props) {
+    const {seconds} = this.props
+    if (seconds !== prevProps.seconds) {
+      const hours = Math.floor(seconds / 3600)
+      const minutes = Math.floor(seconds / 60 % 60)
+
+      this.setState({minutes, hours})
+    }
   }
 
   render () {
-    const {seconds, style, ...otherProps} = this.props
-    const {string} = this.state
+    const {seconds: initialSeconds, style, ...otherProps} = this.props
+    const {hours, minutes} = this.state
+
     return (
-      <FormControl
-        {...otherProps}
-        value={typeof string !== 'undefined' ? string : convertSecondsToHHMMString(seconds)}
-        placeholder={'hh:mm'}
-        style={style}
-        onChange={this._onChange} />
+      <span style={{display: 'flex', alignItems: 'baseline'}}>
+        <FormControl
+          {...otherProps}
+          id='hours'
+          onChange={this._onChange}
+          onFocus={this._onFocus}
+          placeholder={'hh'}
+          style={style}
+          value={hours && hours < 10 ? `0${hours}` : hours || '00'}
+        />
+         :
+        <FormControl
+          {...otherProps}
+          id='minutes'
+          onChange={this._onChange}
+          onFocus={this._onFocus}
+          placeholder={'mm'}
+          style={style}
+          value={minutes && minutes < 10 ? `0${minutes}` : minutes || '00'}
+        />
+      </span>
     )
   }
 }

--- a/lib/editor/components/HourMinuteInput.js
+++ b/lib/editor/components/HourMinuteInput.js
@@ -30,7 +30,7 @@ export default class HourMinuteInput extends Component<Props, State> {
     }
 
     // Ignore non-number keystrokes
-    if (key !== 'Backspace' && key !== 'Tab' && isNaN(parseInt(key))) {
+    if (key !== 'Backspace' && key !== 'Tab' && !key.includes('Arrow') && isNaN(parseInt(key))) {
       evt.preventDefault()
     }
   }
@@ -70,6 +70,8 @@ export default class HourMinuteInput extends Component<Props, State> {
     const {seconds: initialSeconds, style, ...otherProps} = this.props
     const {hours, minutes} = this.state
 
+    const defaultValue = !minutes && !hours ? '' : '00'
+
     return (
       <span style={{display: 'flex', alignItems: 'baseline'}}>
         <FormControl
@@ -80,7 +82,7 @@ export default class HourMinuteInput extends Component<Props, State> {
           onFocus={this._onFocus}
           placeholder={'hh'}
           style={{ width: '5.5ch', borderRight: 'none', ...style }}
-          value={hours && hours < 10 ? `0${hours}` : hours || null}
+          value={hours && hours < 10 ? `0${hours}` : hours || defaultValue}
         />
         <span style={{zIndex: 9, position: 'relative', left: -2.5, fontWeight: 900}}>:</span>
         <FormControl
@@ -91,8 +93,8 @@ export default class HourMinuteInput extends Component<Props, State> {
           onFocus={this._onFocus}
           placeholder={'mm'}
           ref={'minuteInput'}
-          style={{ width: '6.5ch', marginLeft: -5, borderLeft: 'none', ...style }}
-          value={minutes && minutes < 10 ? `0${minutes}` : minutes || null}
+          style={{ width: '6.5ch', marginLeft: -5, borderLeft: 'none', borderRadius: 0, ...style }}
+          value={minutes && minutes < 10 ? `0${minutes}` : minutes || defaultValue}
         />
       </span>
     )

--- a/lib/editor/components/HourMinuteInput.js
+++ b/lib/editor/components/HourMinuteInput.js
@@ -19,16 +19,20 @@ export default class HourMinuteInput extends Component<Props, State> {
 
   _onChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     const {id, value} = evt.target
+    // $FlowFixMe Using weird React types
     const {data: key} = evt.nativeEvent
 
+    // Ignore non-number keystrokes
     if (isNaN(parseInt(key))) {
       return
     }
+
+    // Ignore calls to this method that somehow don't come from the two inputs below
     if (id !== 'hours' && id !== 'minutes') {
       return
     }
 
-    this.setState({[id]: value}, this.handleChange)
+    this.setState({[id]: parseInt(value)}, this.handleChange)
   }
 
   _onFocus = (evt: SyntheticInputEvent<HTMLInputElement>) => {

--- a/lib/editor/components/HourMinuteInput.js
+++ b/lib/editor/components/HourMinuteInput.js
@@ -92,7 +92,6 @@ export default class HourMinuteInput extends Component<Props, State> {
           onChange={this._onChange}
           onFocus={this._onFocus}
           placeholder={'mm'}
-          ref={'minuteInput'}
           style={{ width: '6.5ch', marginLeft: -5, borderLeft: 'none', borderRadius: 0, ...style }}
           value={minutes && minutes < 10 ? `0${minutes}` : minutes || defaultValue}
         />

--- a/lib/editor/components/HourMinuteInput.js
+++ b/lib/editor/components/HourMinuteInput.js
@@ -1,7 +1,7 @@
 // @flow
 
 // $FlowFixMe Flow doesn't recognize react KeyboardEvent
-import React, {Component, KeyboardEvent } from 'react'
+import React, {Component, KeyboardEvent} from 'react'
 import {FormControl} from 'react-bootstrap'
 
 type Props = {

--- a/lib/editor/components/timetable/TimetableHeader.js
+++ b/lib/editor/components/timetable/TimetableHeader.js
@@ -21,14 +21,14 @@ import * as activeActions from '../../actions/active'
 import * as tripActions from '../../actions/trip'
 import OptionButton from '../../../common/components/OptionButton'
 import HourMinuteInput from '../HourMinuteInput'
-import CalendarSelect from './CalendarSelect'
-import RouteSelect from './RouteSelect'
-import PatternSelect from './PatternSelect'
 import {getTableById} from '../../util/gtfs'
-
 import type {TripValidationIssues} from '../../selectors/timetable'
 import type {Feed, GtfsRoute, Pattern, ServiceCalendar, TripCounts} from '../../../types'
 import type {EditorTables, TimetableState} from '../../../types/reducers'
+
+import PatternSelect from './PatternSelect'
+import RouteSelect from './RouteSelect'
+import CalendarSelect from './CalendarSelect'
 
 type Props = {
   activePattern: Pattern,
@@ -209,15 +209,15 @@ export default class TimetableHeader extends Component<Props> {
             <FormGroup
               className='pull-right'
               style={{
-                maxWidth: '100px',
+                maxWidth: '120px',
                 marginBottom: '0px',
                 marginRight: '18px',
-                minWidth: '50px'
+                minWidth: '60px'
               }}>
               <InputGroup>
                 <HourMinuteInput
                   bsSize='small'
-                  style={{width: '65px'}}
+                  style={{width: '5.5ch'}}
                   seconds={timetable.offset}
                   onChange={setOffset} />
                 <InputGroup.Button>

--- a/lib/editor/components/timetable/TimetableHeader.js
+++ b/lib/editor/components/timetable/TimetableHeader.js
@@ -217,7 +217,6 @@ export default class TimetableHeader extends Component<Props> {
               <InputGroup>
                 <HourMinuteInput
                   bsSize='small'
-                  style={{width: '5.5ch'}}
                   seconds={timetable.offset}
                   onChange={setOffset} />
                 <InputGroup.Button>


### PR DESCRIPTION
### Checklist

- [X] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [X] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [X] The description lists all applicable issues this PR seeks to resolve
- [X] The description lists any configuration setting(s) that differ from the default settings
- [X] All tests and CI builds passing

### Description

This PR refactors the offset input to be 2 separate textboxes. This removes the previous behavior in the unified textbox, which was seen by many to be confusing and complicated.

The input is now separated between hours and minutes.

<img width="233" alt="Screen Shot 2022-07-13 at 3 51 50 PM" src="https://user-images.githubusercontent.com/86619099/178750219-dd03df7d-94f4-4d25-8467-82461ffed6a8.png">

One piece of functionality I feel is missing is automatically moving to the minute input field, either after the user types a `:` or perhaps after they type two characters? Curious what others think about this.
