### PR TITLE
Fix editor lock (again)

### DIFF
--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -164,19 +164,17 @@ export function lockEditorFeedSource (feedId: string) {
 }
 
 /**
- * Stop job time function stored with timer ID stored in state.
- */
-function stopCurrentTimer (state: AppState) {
-  const {timer} = state.editor.data.lock
-  if (timer) clearInterval(timer)
-}
-
-/**
  * Stops the lock timer.
  */
 export function stopLockTimer () {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    stopCurrentTimer(getState())
+    const {timer} = getState().editor.data.lock
+    if (timer) {
+      clearInterval(timer)
+      console.log('editor timer cleared', timer)
+      // Remove timer id from redux state to avoid later interference with other timers.
+      dispatch(setEditorCheckIn({ timer: null }))
+    }
   }
 }
 
@@ -203,6 +201,8 @@ function maintainEditorLock (
       })
       .catch(err => {
         console.warn(err)
+        clearInterval(timer)
+        // dispatch(stopLockTimer())
         dispatch(removeEditorLock(feedId))
       })
   }
@@ -231,7 +231,7 @@ function startEditorLockMaintenance (
   feedId: string
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    stopCurrentTimer(getState())
+    dispatch(stopLockTimer())
 
     const timerFunction = () => dispatch(maintainEditorLock(sessionId, feedId))
     // Set time to check in every 10 seconds
@@ -284,7 +284,7 @@ export function removeEditorLock (
     const url = `/api/editor/secure/lock/${sessionId || 'dummy_value'}?feedId=${feedId}${overwrite ? '&overwrite=true' : ''}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => {
-        stopCurrentTimer(getState())
+        dispatch(stopLockTimer())
         dispatch(setEditorCheckIn({timer: null, sessionId: null, feedId: null}))
         return res.json()
       })

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -154,11 +154,17 @@ export default class GtfsEditor extends Component<Props, State> {
 
   componentCleanUp = () => {
     // When the user exits the editor, as a last-gasp action, remove the editor lock on the feed.
-    this.props.removeEditorLockLastGasp(this.props.feedSourceId)
+    const { feedSourceId, removeEditorLockLastGasp, stopLockTimer } = this.props
+    stopLockTimer()
+    removeEditorLockLastGasp(feedSourceId)
   }
 
   onFocus = () => {
-    this.props.checkLockStatus(this.props.feedSourceId)
+    const { checkLockStatus, feedSourceId, namespace } = this.props
+    if (namespace) {
+      // Only claim (back) an editor lock if an editor session (i.e. namespace) has been created.
+      checkLockStatus(feedSourceId)
+    }
   }
 
   onVisibilityChange = () => {
@@ -166,16 +172,21 @@ export default class GtfsEditor extends Component<Props, State> {
       errorStatus,
       feedSourceId,
       lockEditorFeedSource,
+      namespace,
       stopLockTimer
     } = this.props
     if (document.visibilityState === 'visible') {
-      // If the page is visible/activated again, resume lock check-in, unless a modal prompt is shown.
-      if (errorStatus.modal === undefined) {
+      // If the page is visible/activated again, resume lock check-in,
+      // unless a modal prompt is shown or no editor was loaded for this feed.
+      if (!errorStatus.modal && !!namespace) {
         lockEditorFeedSource(feedSourceId)
       }
     } else {
-      // When the user exits the editor (i.e. switches, closes, or reloads the tab/window, or navigates away),
+      // When the user exits the editor (i.e. switches, closes, or reloads the tab/window,
+      // or navigates away using the browser buttons),
       // stop the editor lock timer (don't remove the lock in case the page gets activated again).
+      // Note: this case does not cover the user navigating to other datatool views using regular links from the ui,
+      //   see componentWillUnmount for that.
       stopLockTimer()
     }
   }
@@ -233,7 +244,8 @@ export default class GtfsEditor extends Component<Props, State> {
       clearGtfsContent,
       feedSourceId,
       namespace,
-      removeEditorLock
+      removeEditorLock,
+      stopLockTimer
     } = this.props
     if (nextProps.feedSourceId !== feedSourceId) {
       // Clear GTFS content if feedSource changes (i.e., user switches feed sources).
@@ -242,10 +254,17 @@ export default class GtfsEditor extends Component<Props, State> {
       clearGtfsContent()
       // Re-establish lock for new feed source and fetch GTFS.
       this._refreshBaseEditorData(nextProps)
-    } else if (!nextProps.feedIsLocked && this.props.feedIsLocked) {
-      // If user clicked "Re-lock feed",
-      // re-establish lock for the feed source and fetch GTFS to resume editing.
-      this._refreshBaseEditorData(nextProps)
+    } else if (this.props.feedIsLocked && namespace && nextProps.namespace === namespace) {
+      // The actions below apply if content hasa been loaded into the GTFS editor.
+      if (!nextProps.feedIsLocked) {
+        // If user clicked "Re-lock feed",
+        // re-establish lock for the feed source and fetch GTFS to resume editing.
+        this._refreshBaseEditorData(nextProps)
+      } else {
+        // If the user dismissed the "Relock feed" dialog, stop the lock timer and leave the UI disabled.
+        // The "Relock feed" modal will reappear next time the user switches back to the tab.
+        stopLockTimer()
+      }
     }
     if (namespace && nextProps.namespace !== namespace) {
       // If the editor namespace changes (not simply from null), re-fetch the GTFS.

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -255,7 +255,7 @@ export default class GtfsEditor extends Component<Props, State> {
       // Re-establish lock for new feed source and fetch GTFS.
       this._refreshBaseEditorData(nextProps)
     } else if (this.props.feedIsLocked && namespace && nextProps.namespace === namespace) {
-      // The actions below apply if content hasa been loaded into the GTFS editor.
+      // The actions below apply if content has been loaded into the GTFS editor.
       if (!nextProps.feedIsLocked) {
         // If user clicked "Re-lock feed",
         // re-establish lock for the feed source and fetch GTFS to resume editing.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

Requires https://github.com/ibi-group/datatools-server/pull/477
Fix #175, Fix #179

Redo of #815. This PR improves the editor locking feature as follows, in both Chrome and Firefox:
- Clicking "Re-lock feed" immediately enables the GTFS editor without the need to reload the page (one fewer click than before).
- Reloading an active editor tab/window no longer triggers the re-lock notice.
- The re-lock notice appears immediately after switching focus to a tab that doesn’t own the editor lock.

Other behavior that #815 broke and I hope have handled this time:
- Starting the GTFS editor after loading the first zip/feed version should work as usual (e2e tests for initially loading the editor should pass).
- Using “back to feed” or “home” in the GTFS editor should not trigger the "Relock feed" prompt in the feed version manager, even if the lock was "stolen" by another editor.
- Closing the “relock feed” modal then clicking “relock feed” later (e.g. by reactivating the affected browser tab) should work correctly.
