### PR TITLE
Fix GTFS editor lock (again)

### DIFF
--- a/lib/common/components/StatusModal.js
+++ b/lib/common/components/StatusModal.js
@@ -6,7 +6,6 @@ import {Modal, Button} from 'react-bootstrap'
 import Login from '../containers/Login'
 import * as statusActions from '../../manager/actions/status'
 import * as editorActions from '../../editor/actions/editor'
-
 import type {Props as ContainerProps} from '../containers/CurrentStatusModal'
 import type {ModalStatus} from '../../types/reducers'
 
@@ -65,17 +64,13 @@ export default class StatusModal extends Component<Props, State> {
   }
 
   _handleReLock = () => {
+    // Close modal before executing actions.
+    this.close()
     // Calling removeEditorLock with null feedId will use current editor
     // feedSourceId found in store.
     this.props.removeEditorLock(null, true)
       .then((success) => {
-        if (success) {
-          this.setState({
-            action: 'RELOAD',
-            title: 'Success!',
-            body: 'Reload page to begin editing.'
-          })
-        } else {
+        if (!success) {
           this.setState({
             title: 'Attempt to take over editing failed!',
             disabled: true,

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -164,35 +164,57 @@ export function lockEditorFeedSource (feedId: string) {
 }
 
 /**
- * Stop job time function stored with timer ID stored in state.
+ * Stops the lock timer.
  */
-function stopCurrentTimer (state: AppState) {
-  // FIXME
-  const {timer} = state.editor.data.lock
-  if (timer) clearInterval(timer)
+export function stopLockTimer () {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    const {timer} = getState().editor.data.lock
+    if (timer) {
+      clearInterval(timer)
+      // Remove timer id from redux state to avoid later interference with other timers.
+      dispatch(setEditorCheckIn({ timer: null }))
+    }
+  }
 }
 
 /**
- * HTTP call to .
+ * HTTP call to the feed lock endpoint.
  */
 function maintainEditorLock (
   sessionId: string,
-  feedId: string
+  feedId: string,
+  timer?: IntervalID
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     const url = `/api/editor/secure/lock/${sessionId}?feedId=${feedId}`
-    if (!document.hidden) {
-      // Only maintain lock if browser tab is active
-      return dispatch(secureFetch(url, 'put', undefined, undefined, undefined, 'RE_LOCK'))
-        .then(response => response.json())
-        .then(json => {
-          if (json.code >= 400) dispatch(removeEditorLock(feedId))
-          else dispatch(setEditorCheckIn({timestamp: moment().format()}))
-        })
-        .catch(err => {
-          console.warn(err)
-          dispatch(removeEditorLock(feedId))
-        })
+    // Note: this action is called only when the browser tab/window is visible.
+    return dispatch(secureFetch(url, 'put', undefined, undefined, undefined, 'RE_LOCK'))
+      .then(response => response.json())
+      .then(json => {
+        if (json.code >= 400) dispatch(removeEditorLock(feedId))
+        else {
+          const timestamp = moment().format()
+          if (timer) dispatch(setEditorCheckIn({feedId, sessionId, timer, timestamp}))
+          else dispatch(setEditorCheckIn({timestamp}))
+        }
+      })
+      .catch(err => {
+        console.warn(err)
+        if (timer) clearInterval(timer)
+        dispatch(removeEditorLock(feedId))
+      })
+  }
+}
+
+/**
+ * Performs a spot check of the editor lock status (i.e. attempts to maintain the lock)
+ * outside of the timer set in startEditorLockMaintenance.
+ */
+export function checkLockStatus (feedId: string) {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    const {sessionId} = getState().editor.data.lock
+    if (sessionId) {
+      dispatch(maintainEditorLock(sessionId, feedId))
     }
   }
 }
@@ -207,21 +229,34 @@ function startEditorLockMaintenance (
   feedId: string
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    stopCurrentTimer(getState())
+    dispatch(stopLockTimer())
 
     const timerFunction = () => dispatch(maintainEditorLock(sessionId, feedId))
-    // make an initial call right now
-    timerFunction()
     // Set time to check in every 10 seconds
     const timer = setInterval(timerFunction, 10000)
-    // FIXME: Timer needs updating every maintain editor lock call.
-    dispatch(setEditorCheckIn({timer, sessionId, feedId, timestamp: moment().format()}))
+
+    // Make an initial call right now specifying the timer id.
+    dispatch(maintainEditorLock(sessionId, feedId, timer))
   }
 }
 
+function getFeedIdFromStateOrUrl (state: AppState) {
+  let feedId = state.editor.data.active.feedSourceId
+  // If no feed id was found in the lock state, attempt to retrieve it from the editor URL.
+  if (!feedId) {
+    const { locationBeforeTransitions = {} } = state.routing
+    const { pathname = '' } = locationBeforeTransitions
+    const pathParts = pathname.split('/')
+    if (pathParts[1] === 'feed' && pathParts[3] === 'edit') {
+      // This will apply for URLs of the form '/feed/xxxxx/edit'
+      feedId = pathParts[2]
+    }
+  }
+  return feedId
+}
+
 /**
- * Remove current editor lock on feed. This should be called when the GTFS Editor
- * unmounts or the browser tab closes.
+ * Remove current editor lock on feed.
  */
 export function removeEditorLock (
   feedId: ?string,
@@ -230,9 +265,10 @@ export function removeEditorLock (
 ): any {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     if (!feedId) {
-      // If no feed ID is provided, default to the feed ID in the store.
-      feedId = getState().editor.data.active.feedSourceId
+      // If no feed ID is provided, default to the feed ID in the store/URL.
+      feedId = getFeedIdFromStateOrUrl(getState())
     }
+
     const {sessionId} = getState().editor.data.lock
     if (!feedId) {
       console.warn('Feed source ID is undefined! Skipping attempt to remove editor lock.')
@@ -246,7 +282,7 @@ export function removeEditorLock (
     const url = `/api/editor/secure/lock/${sessionId || 'dummy_value'}?feedId=${feedId}${overwrite ? '&overwrite=true' : ''}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => {
-        stopCurrentTimer(getState())
+        dispatch(stopLockTimer())
         dispatch(setEditorCheckIn({timer: null, sessionId: null, feedId: null}))
         return res.json()
       })
@@ -270,6 +306,23 @@ export function removeEditorLock (
           dispatch(clearGtfsContent())
         }
       })
+  }
+}
+
+/**
+ * Remove current editor lock on feed. This should be called as a last-gasp request
+ * when the GTFS Editor unmounts or the browser tab closes.
+ */
+export function removeEditorLockLastGasp (
+  feedId: string
+) {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    const {sessionId} = getState().editor.data.lock
+    // Send beacon (last-gasp) call to remove editor lock.
+    console.log(`removing lock for feed ${feedId}, session ${sessionId || '(undefined)'}`)
+    const url = `/api/editor/deletelock/${sessionId || 'dummy_value'}?feedId=${feedId}`
+    // $FlowFixMe - Assume navigator.sendBeacon is implemented.
+    navigator.sendBeacon(url)
   }
 }
 

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -14,18 +14,12 @@ import ConfirmModal from '../../common/components/ConfirmModal'
 import Title from '../../common/components/Title'
 import CurrentStatusModal from '../../common/containers/CurrentStatusModal'
 import * as userActions from '../../manager/actions/user'
-import EditorMap from './map/EditorMap'
-import EditorHelpModal from './EditorHelpModal'
-import EditorSidebar from './EditorSidebar'
 import ActiveEntityList from '../containers/ActiveEntityList'
-import EntityDetails from './EntityDetails'
 import ActiveTimetableEditor from '../containers/ActiveTimetableEditor'
 import ActiveFeedInfoPanel from '../containers/ActiveFeedInfoPanel'
-
 import {getConfigProperty} from '../../common/util/config'
 import {getEntityName, getTableById} from '../util/gtfs'
 import {GTFS_ICONS} from '../util/ui'
-
 import type {Props as ContainerProps} from '../containers/ActiveGtfsEditor'
 import type {
   ControlPoint,
@@ -43,9 +37,15 @@ import type {
   EditorStatus,
   EditorTables,
   ManagerUserState,
-  MapState
+  MapState,
+  StatusState
 } from '../../types/reducers'
 import type {EditorValidationIssue} from '../util/validation'
+
+import EntityDetails from './EntityDetails'
+import EditorSidebar from './EditorSidebar'
+import EditorHelpModal from './EditorHelpModal'
+import EditorMap from './map/EditorMap'
 
 type Props = ContainerProps & {
   activeComponent: string,
@@ -59,6 +59,7 @@ type Props = ContainerProps & {
   addStopAtInterval: typeof stopStrategiesActions.addStopAtIntersection,
   addStopAtPoint: typeof stopStrategiesActions.addStopAtPoint,
   addStopToPattern: typeof stopStrategiesActions.addStopToPattern,
+  checkLockStatus: typeof editorActions.checkLockStatus,
   clearGtfsContent: typeof activeActions.clearGtfsContent,
   cloneGtfsEntity: typeof editorActions.cloneGtfsEntity,
   constructControlPoint: typeof mapActions.constructControlPoint,
@@ -70,6 +71,7 @@ type Props = ContainerProps & {
   editSettings: EditSettingsState,
   entities: Array<Entity>,
   entityEdited: boolean,
+  errorStatus: StatusState,
   feedInfo: FeedInfo,
   feedIsLocked: boolean,
   feedSource: Feed,
@@ -82,6 +84,7 @@ type Props = ContainerProps & {
   hasRoutes: boolean,
   hideTutorial: boolean,
   loadFeedVersionForEditing: typeof snapshotActions.loadFeedVersionForEditing,
+  lockEditorFeedSource: typeof editorActions.lockEditorFeedSource,
   mapState: MapState,
   namespace: string,
   newGtfsEntity: typeof editorActions.newGtfsEntity,
@@ -94,6 +97,7 @@ type Props = ContainerProps & {
   refreshBaseEditorData: typeof activeActions.refreshBaseEditorData,
   removeControlPoint: typeof mapActions.removeControlPoint,
   removeEditorLock: typeof editorActions.removeEditorLock,
+  removeEditorLockLastGasp: typeof editorActions.removeEditorLockLastGasp,
   removeStopFromPattern: typeof stopStrategiesActions.removeStopFromPattern,
   resetActiveGtfsEntity: typeof activeActions.resetActiveGtfsEntity,
   saveActiveGtfsEntity: typeof activeActions.saveActiveGtfsEntity,
@@ -104,6 +108,7 @@ type Props = ContainerProps & {
   showConfirmModal: ({body: string, onConfirm: () => void, title: string}) => void,
   sidebarExpanded: boolean,
   status: EditorStatus,
+  stopLockTimer: typeof editorActions.stopLockTimer,
   subComponent: string,
   subEntity: number,
   subEntityId: number,
@@ -126,6 +131,13 @@ type State = {
   activeTableId: ?string
 }
 
+/**
+ * Figures out the correct event name to use.
+ */
+function getNormalizedEvent (eventName: string) {
+  return window.attachEvent ? `on${eventName}` : eventName
+}
+
 export default class GtfsEditor extends Component<Props, State> {
   componentWillMount () {
     this.setState({
@@ -141,25 +153,65 @@ export default class GtfsEditor extends Component<Props, State> {
   }
 
   componentCleanUp = () => {
-    // When the user exits the editor, remove the lock on the editor feed resource.
-    this.props.removeEditorLock(this.props.feedSourceId)
+    // When the user exits the editor, as a last-gasp action, remove the editor lock on the feed.
+    const { feedSourceId, removeEditorLockLastGasp, stopLockTimer } = this.props
+    stopLockTimer()
+    removeEditorLockLastGasp(feedSourceId)
+  }
+
+  onFocus = () => {
+    const { checkLockStatus, feedSourceId, namespace } = this.props
+    if (namespace) {
+      // Only claim (back) an editor lock if an editor session (i.e. namespace) has been created.
+      checkLockStatus(feedSourceId)
+    }
+  }
+
+  onVisibilityChange = () => {
+    const {
+      errorStatus,
+      feedSourceId,
+      lockEditorFeedSource,
+      namespace,
+      stopLockTimer
+    } = this.props
+    if (document.visibilityState === 'visible') {
+      // If the page is visible/activated again, resume lock check-in,
+      // unless a modal prompt is shown or no editor was loaded for this feed.
+      if (!errorStatus.modal && !!namespace) {
+        lockEditorFeedSource(feedSourceId)
+      }
+    } else {
+      // When the user exits the editor (i.e. switches, closes, or reloads the tab/window,
+      // or navigates away using the browser buttons),
+      // stop the editor lock timer (don't remove the lock in case the page gets activated again).
+      // Note: this case does not cover the user navigating to other datatool views using regular links from the ui,
+      //   see componentWillUnmount for that.
+      stopLockTimer()
+    }
   }
 
   componentDidMount () {
-    // If the browser window/tab is closed, the componnent does not have a chance
+    // If the browser window/tab is closed, the component does not have a chance
     // to run componentWillUnmount. This event listener runs clean up in those
     // cases.
-    const unloadEvent = window.attachEvent ? 'onbeforeunload' : 'beforeunload'
-    window.addEventListener(unloadEvent, this.componentCleanUp)
+    window.addEventListener(getNormalizedEvent('pagehide'), this.componentCleanUp)
+
+    // Listen to the window focus event so we can check for things like editor lock status right away.
+    window.addEventListener(getNormalizedEvent('focus'), this.onFocus)
+
+    // Listen to the page visibilityChange event so we can check for things like editor lock status
+    // or pause/resume lock timers right away.
+    window.addEventListener(getNormalizedEvent('visibilitychange'), this.onVisibilityChange)
   }
 
   componentWillUnmount () {
     // Run component clean-up
-    // console.log('componnent is unmounting')
     this.componentCleanUp()
-    // And remove the event handler for normal unmounting
-    const unloadEvent = window.attachEvent ? 'onbeforeunload' : 'beforeunload'
-    window.removeEventListener(unloadEvent, this.componentCleanUp)
+    // And remove the event handlers for normal unmounting
+    window.removeEventListener(getNormalizedEvent('pagehide'), this.componentCleanUp)
+    window.removeEventListener(getNormalizedEvent('focus'), this.onFocus)
+    window.removeEventListener(getNormalizedEvent('visibilitychange'), this.onVisibilityChange)
   }
 
   componentDidUpdate (prevProps: Props) {
@@ -192,7 +244,8 @@ export default class GtfsEditor extends Component<Props, State> {
       clearGtfsContent,
       feedSourceId,
       namespace,
-      removeEditorLock
+      removeEditorLock,
+      stopLockTimer
     } = this.props
     if (nextProps.feedSourceId !== feedSourceId) {
       // Clear GTFS content if feedSource changes (i.e., user switches feed sources).
@@ -201,6 +254,17 @@ export default class GtfsEditor extends Component<Props, State> {
       clearGtfsContent()
       // Re-establish lock for new feed source and fetch GTFS.
       this._refreshBaseEditorData(nextProps)
+    } else if (this.props.feedIsLocked && namespace && nextProps.namespace === namespace) {
+      // The actions below apply if content has been loaded into the GTFS editor.
+      if (!nextProps.feedIsLocked) {
+        // If user clicked "Re-lock feed",
+        // re-establish lock for the feed source and fetch GTFS to resume editing.
+        this._refreshBaseEditorData(nextProps)
+      } else {
+        // If the user dismissed the "Relock feed" dialog, stop the lock timer and leave the UI disabled.
+        // The "Relock feed" modal will reappear next time the user switches back to the tab.
+        stopLockTimer()
+      }
     }
     if (namespace && nextProps.namespace !== namespace) {
       // If the editor namespace changes (not simply from null), re-fetch the GTFS.

--- a/lib/editor/containers/ActiveGtfsEditor.js
+++ b/lib/editor/containers/ActiveGtfsEditor.js
@@ -38,17 +38,20 @@ import {
   updateEditSetting
 } from '../actions/active'
 import {
+  checkLockStatus,
   cloneGtfsEntity,
+  lockEditorFeedSource,
   newGtfsEntity,
   newGtfsEntities,
   removeEditorLock,
+  removeEditorLockLastGasp,
+  stopLockTimer,
   uploadBrandingAsset
 } from '../actions/editor'
 import {createSnapshot, loadFeedVersionForEditing} from '../actions/snapshots'
 import {findProjectByFeedSource} from '../../manager/util'
 import {getActivePatternStops, getControlPoints, getValidationErrors} from '../selectors'
 import {getTableById, getIdsFromParams} from '../util/gtfs'
-
 import type {AppState, RouterProps} from '../../types/reducers'
 
 export type Props = RouterProps
@@ -87,6 +90,7 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
   // console.log(activeEntityId, activeEntity, active, active.entity)
   const validationErrors = getValidationErrors(state)
   const user = state.user
+  const errorStatus = state.status
 
   // find the containing project
   const project = findProjectByFeedSource(state.projects.all, feedSourceId)
@@ -110,6 +114,7 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
     editSettings,
     entities,
     entityEdited,
+    errorStatus,
     feedInfo,
     feedIsLocked,
     feedSource,
@@ -141,6 +146,7 @@ const mapDispatchToProps = {
   addStopAtInterval,
   addStopAtPoint,
   addStopToPattern,
+  checkLockStatus,
   clearGtfsContent,
   cloneGtfsEntity,
   constructControlPoint,
@@ -152,11 +158,13 @@ const mapDispatchToProps = {
   handleControlPointDragEnd,
   handleControlPointDragStart,
   loadFeedVersionForEditing,
+  lockEditorFeedSource,
   newGtfsEntities,
   newGtfsEntity,
   refreshBaseEditorData,
   removeControlPoint,
   removeEditorLock,
+  removeEditorLockLastGasp,
   removeStopFromPattern,
   resetActiveGtfsEntity,
   saveActiveGtfsEntity,
@@ -164,6 +172,7 @@ const mapDispatchToProps = {
   setActiveGtfsEntity,
   setActivePatternSegment,
   setActiveStop,
+  stopLockTimer,
   undoActiveTripPatternEdits,
   updateActiveGtfsEntity,
   updateEditSetting,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Requires https://github.com/ibi-group/datatools-server/pull/477
Fix #175, Fix #179

Redo of #815. To see the diff between #815 and this one, see https://github.com/ibi-group/datatools-ui/compare/fix-editor-lock...fix-editor-lock-2 (in that view, ignore files not changed by this PR).

This PR improves the editor locking feature as follows, in both Chrome and Firefox:
- Clicking "Re-lock feed" immediately enables the GTFS editor without the need to reload the page (one fewer click than before).
- Reloading an active editor tab/window no longer triggers the re-lock notice.
- The re-lock notice appears immediately after switching focus to a tab that doesn’t own the editor lock.

Other behavior that #815 broke and I hope have handled this time:
- Starting the GTFS editor after loading the first zip/feed version should work as usual (e2e tests for initially loading the editor should pass).
- Using “back to feed” or “home” in the GTFS editor should not trigger the "Relock feed" prompt in the feed version manager, even if the lock was "stolen" by another editor.
- Closing the “relock feed” modal then clicking “relock feed” later (e.g. by reactivating the affected browser tab) should work correctly.
