### PR TITLE
fix: correct coordIsOutOfBounds behavior

### DIFF
--- a/lib/common/util/__tests__/map.js
+++ b/lib/common/util/__tests__/map.js
@@ -19,7 +19,7 @@ describe('lib > common > util > map', () => {
       expect(coordIsOutOfBounds(SOMEWHERE_IN_CANADA, NULL_BOUNDS)).toEqual(true)
       expect(coordIsOutOfBounds(NULL_ISLAND, NULL_BOUNDS)).toEqual(true)
     })
-    it('should correctly handle either argument being null', () => {
+    it('should correctly handle null/undefined arguments', () => {
       // $FlowFixMe this is a test
       expect(coordIsOutOfBounds(undefined, APPROX_NORTH_AMERICA_BOUNDS)).toEqual(true)
       // $FlowFixMe this is a test

--- a/lib/common/util/__tests__/map.js
+++ b/lib/common/util/__tests__/map.js
@@ -6,18 +6,28 @@ import { coordIsOutOfBounds } from '../../../editor/util/map'
 
 describe('lib > common > util > map', () => {
   describe('> coordIsOutOfBounds', () => {
-    const APPROX_NORTH_AMERICA_BOUNDS = L.latLngBounds([-170.15625, 6.315299, -46.40625, 83.440326])
-    const NULL_BOUNDS = L.latLngBounds([1, 1, 1, 1])
+    const APPROX_NORTH_AMERICA_BOUNDS = L.latLngBounds([6.315299, -170.15625], [ 83.440326, -46.40625 ])
+    const NULL_BOUNDS = L.latLngBounds([0, 0], [0, 0])
     const SOMEWHERE_IN_CANADA = {lat: 60.064840, lng: -99.492188}
     const NULL_ISLAND = {lat: 0, lng: 0}
 
     it('should correctly determine if a coordinate is outside set bounds', () => {
-      expect(coordIsOutOfBounds(SOMEWHERE_IN_CANADA, APPROX_NORTH_AMERICA_BOUNDS)).toEqual(true)
-      expect(coordIsOutOfBounds(NULL_ISLAND, APPROX_NORTH_AMERICA_BOUNDS)).toEqual(false)
+      expect(coordIsOutOfBounds(SOMEWHERE_IN_CANADA, APPROX_NORTH_AMERICA_BOUNDS)).toEqual(false)
+      expect(coordIsOutOfBounds(NULL_ISLAND, APPROX_NORTH_AMERICA_BOUNDS)).toEqual(true)
     })
-    it('should correctly determine no coordinates to be within an infinitely small set of bounds', () => {
-      expect(coordIsOutOfBounds(SOMEWHERE_IN_CANADA, NULL_BOUNDS)).toEqual(false)
-      expect(coordIsOutOfBounds(NULL_ISLAND, NULL_BOUNDS)).toEqual(false)
+    it('should correctly determine handle strange bounds', () => {
+      expect(coordIsOutOfBounds(SOMEWHERE_IN_CANADA, NULL_BOUNDS)).toEqual(true)
+      expect(coordIsOutOfBounds(NULL_ISLAND, NULL_BOUNDS)).toEqual(true)
+    })
+    it('should correctly handle either argument being null', () => {
+      // $FlowFixMe this is a test
+      expect(coordIsOutOfBounds(undefined, APPROX_NORTH_AMERICA_BOUNDS)).toEqual(true)
+      // $FlowFixMe this is a test
+      expect(coordIsOutOfBounds(SOMEWHERE_IN_CANADA, undefined)).toEqual(true)
+      // $FlowFixMe this is a test
+      expect(coordIsOutOfBounds(undefined, undefined)).toEqual(true)
+      // $FlowFixMe this is a test
+      expect(coordIsOutOfBounds()).toEqual(true)
     })
   })
 })

--- a/lib/common/util/__tests__/map.js
+++ b/lib/common/util/__tests__/map.js
@@ -1,0 +1,23 @@
+// @flow
+
+import L from 'leaflet'
+
+import { coordIsOutOfBounds } from '../../../editor/util/map'
+
+describe('lib > common > util > map', () => {
+  describe('> coordIsOutOfBounds', () => {
+    const APPROX_NORTH_AMERICA_BOUNDS = L.latLngBounds([-170.15625, 6.315299, -46.40625, 83.440326])
+    const NULL_BOUNDS = L.latLngBounds([1, 1, 1, 1])
+    const SOMEWHERE_IN_CANADA = {lat: 60.064840, lng: -99.492188}
+    const NULL_ISLAND = {lat: 0, lng: 0}
+
+    it('should correctly determine if a coordinate is outside set bounds', () => {
+      expect(coordIsOutOfBounds(SOMEWHERE_IN_CANADA, APPROX_NORTH_AMERICA_BOUNDS)).toEqual(true)
+      expect(coordIsOutOfBounds(NULL_ISLAND, APPROX_NORTH_AMERICA_BOUNDS)).toEqual(false)
+    })
+    it('should correctly determine no coordinates to be within an infinitely small set of bounds', () => {
+      expect(coordIsOutOfBounds(SOMEWHERE_IN_CANADA, NULL_BOUNDS)).toEqual(false)
+      expect(coordIsOutOfBounds(NULL_ISLAND, NULL_BOUNDS)).toEqual(false)
+    })
+  })
+})

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -45,6 +45,8 @@ type R5Response = {
 }
 
 export const coordIsOutOfBounds = (coords: LatLng, bounds: Bounds) => {
+  if (!coords || !coords.lat || !coords.lng || !bounds) return true
+
   return coords.lat > bounds.getNorth() ||
     coords.lat < bounds.getSouth() ||
     coords.lng > bounds.getEast() ||

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -47,8 +47,8 @@ type R5Response = {
 export const coordIsOutOfBounds = (coords: LatLng, bounds: Bounds) => {
   return coords.lat > bounds.getNorth() ||
     coords.lat < bounds.getSouth() ||
-    bounds.lng > bounds.getEast() ||
-    bounds.lng < bounds.getWest()
+    coords.lng > bounds.getEast() ||
+    coords.lng < bounds.getWest()
 }
 export const stopIsOutOfBounds = (stop: GtfsStop, bounds: Bounds) => {
   return coordIsOutOfBounds({lat: stop.stop_lat, lng: stop.stop_lon}, bounds)


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

#808 contained a bug that prevented it from working properly. As a result, a valid configuration would sometimes route graphhopper requests to the wrong server. This PR fixes this bug.

I've done some testing and it looks like this closes #825, but I would appreciate some verification of this