### PR TITLE
fix(DeploymentViewer): avoid crash when deploying feed with no bounds

### DIFF
--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -251,6 +251,9 @@ export default class DeploymentViewer extends Component<Props, State> {
     const boundsTooLarge = east - west > BOUNDS_LIMIT || north - south > BOUNDS_LIMIT
     const bounds = this._getBounds()
 
+    // Flex V2 routes may have no stops and therefore have no bounds detected by
+    // datatools server. The bounds will then include NaN. Since there is nothing to
+    // represent, we should render nothing.
     // $FlowFixMe flow array method list is outdated
     if (bounds.flat().includes('NaN')) return null
     return (

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -251,6 +251,8 @@ export default class DeploymentViewer extends Component<Props, State> {
     const boundsTooLarge = east - west > BOUNDS_LIMIT || north - south > BOUNDS_LIMIT
     const bounds = this._getBounds()
 
+    // $FlowFixMe flow array method list is outdated
+    if (bounds.flat().includes('NaN')) return null
     return (
       <Map
         ref='map'


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes a small bug where a feed with bounds that datatools can't understand (for example a flex feed in the non-flex version of datatools) would cause the entire deployments page to crash.
