### PR TITLE
refactor(DeploymentViewer): remove test deployment restrictions

### DIFF
--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -197,18 +197,18 @@ export default class DeploymentViewer extends Component<Props, State> {
                 ? project.otpServers.map((server, i) => (
                   <MenuItem
                     data-test-id={`deploy-server-${i}-button`}
-                    // Disable server if the server is missing a name,
-                    // has neither an internal URL or s3 bucket name,
-                    // or has a load balancer target group set, but is
-                    // set for a test feed source (with a non-default router).
+                    // Disable server if the server is missing a name or
+                    // has neither an internal URL or s3 bucket name.
+                    // This used to check for test deployments (using the existence of deployment.feedSourceId)
+                    // to avoid deploying a test deployment to a "production" router, however now that there
+                    // is only one router (even for OTP1 instances) this functionality has been removed.
                     disabled={
                       deployJobs.length > 0 ||
                       !server.name ||
                       (
                         (!server.internalUrl || server.internalUrl.length === 0) &&
                         !server.s3Bucket
-                      ) ||
-                      (server.ec2Info && server.ec2Info.targetGroupArn && deployment.feedSourceId)
+                      )
                     }
                     eventKey={server.id}
                     key={server.id}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

As mentioned in the comment added in this PR, there used to be a restriction on "test" deployments (deployments with only one feed source) that they could only be deployed to non-default routers. Now that 100% of OTP routers are "default" this restriction causes more problems than it solves. 
