### PR TITLE
fix: correctly check for null bounds throughout deployment ui

### DIFF
--- a/lib/common/components/MapModal.js
+++ b/lib/common/components/MapModal.js
@@ -4,9 +4,9 @@ import React, {Component} from 'react'
 import {Modal, Button} from 'react-bootstrap'
 import {Map, Marker, TileLayer} from 'react-leaflet'
 
+import {boundsContainNaN} from '../../editor/util/map'
 import {defaultTileLayerProps} from '../util/maps'
 import type {LatLng} from '../../types'
-import { boundsContainNaN } from '../../editor/util/map'
 
 type Props = {
   body?: string,

--- a/lib/common/components/MapModal.js
+++ b/lib/common/components/MapModal.js
@@ -5,8 +5,8 @@ import {Modal, Button} from 'react-bootstrap'
 import {Map, Marker, TileLayer} from 'react-leaflet'
 
 import {defaultTileLayerProps} from '../util/maps'
-
 import type {LatLng} from '../../types'
+import { boundsContainNaN } from '../../editor/util/map'
 
 type Props = {
   body?: string,
@@ -100,14 +100,14 @@ export default class MapModal extends Component<Props, State> {
         </Header>
 
         <Body>
-          <Map
+          {!boundsContainNaN(bounds) && <Map
             ref='map'
             bounds={bounds}
             style={mapStyle}
             onClick={this.clickHandler}>
             <TileLayer {...defaultTileLayerProps()} />
             {marker}
-          </Map>
+          </Map>}
         </Body>
         <Footer>
           <Button onClick={this.ok}>OK</Button>

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -975,4 +975,8 @@ export function getDistanceScaleFactor (shapePoints: Array<ShapePoint>): number 
   return distScaleFactor
 }
 
-export const boundsContainNaN = (bounds) => bounds.flat().includes('NaN')
+// Our version of flow does not know about .flat(). Our options here are either
+// to upgrade the flow version, or to create a cusotm array type
+// The simplest is to simply declare
+// $FlowFixMe
+export const boundsContainNaN = (bounds: any) => bounds.flat().includes('NaN')

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -976,7 +976,7 @@ export function getDistanceScaleFactor (shapePoints: Array<ShapePoint>): number 
 }
 
 // Our version of flow does not know about .flat(). Our options here are either
-// to upgrade the flow version, or to create a cusotm array type
-// The simplest is to simply declare
+// to upgrade the flow version, or to create a custom array type
+// The simplest is to simply declare the following:
 // $FlowFixMe
 export const boundsContainNaN = (bounds: any) => bounds.flat().includes('NaN')

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -974,3 +974,5 @@ export function getDistanceScaleFactor (shapePoints: Array<ShapePoint>): number 
   }
   return distScaleFactor
 }
+
+export const boundsContainNaN = (bounds) => bounds.flat().includes('NaN')

--- a/lib/manager/components/deployment/DeploymentConfirmModal.js
+++ b/lib/manager/components/deployment/DeploymentConfirmModal.js
@@ -9,10 +9,10 @@ import area from '@turf/area'
 import * as deploymentActions from '../../actions/deployments'
 import {getComponentMessages} from '../../../common/util/config'
 import {defaultTileLayerProps} from '../../../common/util/maps'
+import {boundsContainNaN} from '../../../editor/util/map'
 import {getServerForId} from '../../util/deployment'
 import {getFeedNames, versionHasExpired} from '../../util/version'
 import type {Deployment, Project, SummarizedFeedVersion} from '../../../types'
-import { boundsContainNaN } from '../../../editor/util/map'
 
 type Props = {
   deployToTarget: typeof deploymentActions.deployToTarget,

--- a/lib/manager/components/deployment/DeploymentConfirmModal.js
+++ b/lib/manager/components/deployment/DeploymentConfirmModal.js
@@ -3,16 +3,16 @@
 import React, {Component, type Node} from 'react'
 import {Alert as BootstrapAlert, Button, Glyphicon, Modal} from 'react-bootstrap'
 import {Map, TileLayer, Rectangle} from 'react-leaflet'
+import polygon from 'turf-polygon'
+import area from '@turf/area'
 
 import * as deploymentActions from '../../actions/deployments'
 import {getComponentMessages} from '../../../common/util/config'
 import {defaultTileLayerProps} from '../../../common/util/maps'
 import {getServerForId} from '../../util/deployment'
 import {getFeedNames, versionHasExpired} from '../../util/version'
-import polygon from 'turf-polygon'
-import area from '@turf/area'
-
 import type {Deployment, Project, SummarizedFeedVersion} from '../../../types'
+import { boundsContainNaN } from '../../../editor/util/map'
 
 type Props = {
   deployToTarget: typeof deploymentActions.deployToTarget,
@@ -90,7 +90,7 @@ export default class DeploymentConfirmModal extends Component<Props, State> {
             <li>Build config: {deployment.customBuildConfig ? 'custom' : 'default'}</li>
             <li>Router config: {deployment.customRouterConfig ? 'custom' : 'default'}</li>
           </ul>
-          <Map
+          {!boundsContainNaN(bounds) && <Map
             ref='map'
             bounds={bounds}
             scrollWheelZoom={false}
@@ -101,7 +101,7 @@ export default class DeploymentConfirmModal extends Component<Props, State> {
                 bounds={bounds}
                 fillOpacity={0} />
             }
-          </Map>
+          </Map>}
           {isMissingFeeds &&
             <DeploymentConfirmModalAlert
               type='danger'

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -38,6 +38,7 @@ import type {
   SummarizedFeedVersion
 } from '../../../types'
 import type {ManagerUserState} from '../../../types/reducers'
+import { boundsContainNaN } from '../../../editor/util/map'
 
 import CurrentDeploymentPanel from './CurrentDeploymentPanel'
 import DeploymentConfigurationsPanel from './DeploymentConfigurationsPanel'
@@ -255,7 +256,7 @@ export default class DeploymentViewer extends Component<Props, State> {
     // datatools server. The bounds will then include NaN. Since there is nothing to
     // represent, we should render nothing.
     // $FlowFixMe flow array method list is outdated
-    if (bounds.flat().includes('NaN')) return null
+    if (boundsContainNaN(bounds)) return null
     return (
       <Map
         ref='map'

--- a/lib/manager/components/deployment/DeploymentViewer.js
+++ b/lib/manager/components/deployment/DeploymentViewer.js
@@ -30,6 +30,7 @@ import {getComponentMessages, getConfigProperty} from '../../../common/util/conf
 import {formatTimestamp, fromNow} from '../../../common/util/date-time'
 import {defaultTileLayerProps} from '../../../common/util/maps'
 import { versionsSorter } from '../../../common/util/util'
+import {boundsContainNaN} from '../../../editor/util/map'
 import {getServerDeployedTo} from '../../util/deployment'
 import type {Props as ContainerProps} from '../../containers/ActiveDeploymentViewer'
 import type {
@@ -38,7 +39,6 @@ import type {
   SummarizedFeedVersion
 } from '../../../types'
 import type {ManagerUserState} from '../../../types/reducers'
-import { boundsContainNaN } from '../../../editor/util/map'
 
 import CurrentDeploymentPanel from './CurrentDeploymentPanel'
 import DeploymentConfigurationsPanel from './DeploymentConfigurationsPanel'
@@ -255,7 +255,6 @@ export default class DeploymentViewer extends Component<Props, State> {
     // Flex V2 routes may have no stops and therefore have no bounds detected by
     // datatools server. The bounds will then include NaN. Since there is nothing to
     // represent, we should render nothing.
-    // $FlowFixMe flow array method list is outdated
     if (boundsContainNaN(bounds)) return null
     return (
       <Map


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

#830 did an insufficient job at correctly checking all bounds in all maps that could be displayed in the process of deploying a feed. This PR checks for null bounds in the remaining places.
