### PR TITLE
test(e2e): Ensure no character is skipped when typing new project name

### DIFF
--- a/__tests__/end-to-end.js
+++ b/__tests__/end-to-end.js
@@ -770,6 +770,7 @@ async function getAllElements (selector: string) {
  */
 async function type (selector: string, text: string) {
   log.info(`typing text: "${text}" into selector: ${selector}`)
+  await page.focus(selector)
   await page.type(selector, text)
 }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

On the second e2e test pass of creating a new project, some characters of the project name are typed but were not inserted into the input field, causing the "should delete a project" test to fail. This PR attempts to fix that. 

