### PR TITLE
(Flex): Don't send pattern stop defaults to pattern locations

### DIFF
--- a/lib/editor/actions/active.js
+++ b/lib/editor/actions/active.js
@@ -396,8 +396,8 @@ export function saveEntity (
     // Add default vals for component
     const defaults = {}
     if (component === 'route') {
-      defaults.continuous_pickup = 1 // Default value for no continuous pickup
-      defaults.continuous_drop_off = 1 // Default value for no continuous drop off
+      defaults.continuous_pickup = null // Default value for no continuous pickup
+      defaults.continuous_drop_off = null // Default value for no continuous drop off
     } else if (component === 'feedinfo') {
       defaults.default_lang = ''
       defaults.feed_contact_url = ''

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -63,7 +63,7 @@ function getCloneProps (entityId: number, component: string, state: AppState) {
       }
       const pattern = active.entity.tripPatterns.find(tp => tp.id === entityId)
       const newPatternId = generateUID()
-      const newShapeId = generateUID()
+      const newShapeId = pattern.patternStops.length > 0 ? generateUID() : null
       return {
         ...pattern,
         // Overwrite existing name 'X' with 'X copy'

--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -247,7 +247,10 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop | GtfsLocatio
         : index
     )
 
-    if (patternHaltIsStop(newStop)) patternStops.push(patternHaltIsStop(newStop))
+    if (patternHaltIsStop(newStop)) {
+      patternStops.push(patternHaltIsStop(newStop))
+      pattern.shapeId = generateUID()
+    }
     if (patternHaltIsLocation(newStop)) patternLocations.push(patternHaltIsLocation(newStop))
 
     if (typeof index === 'undefined' || index === null || index === patternHalts.length) {

--- a/lib/editor/actions/trip.js
+++ b/lib/editor/actions/trip.js
@@ -171,8 +171,8 @@ export function saveTripsForCalendar (
       // Add default value to continuous pickup if not provided
       // Editing continuous pickup/drop off is not currently supported in the schedule editor
       const defaults = {
-        continuous_pickup: 1,
-        continuous_drop_off: 1
+        continuous_pickup: null,
+        continuous_drop_off: null
       }
       tripCopy.stop_times = tripCopy.stop_times.map((stopTime, index) => {
         return {...defaults, ...(stopTime: any)}

--- a/lib/editor/actions/tripPattern.js
+++ b/lib/editor/actions/tripPattern.js
@@ -216,7 +216,8 @@ export function saveTripPattern (feedId: ?string, tripPattern: Pattern) {
       // If trip pattern has no shape ID (e.g., if the pattern was imported
       // without shapes) but it does have shape points, generate a new shape ID
       // and assign shape points to the new ID.
-      const shapeId = generateUID()
+      // This should only happen if stops are present. A location-only pattern should have no shape id
+      const shapeId = tripPattern.patternStops.length > 0 ? generateUID() : null
       tripPattern.shapeId = shapeId
       tripPattern.shapePoints = tripPattern.shapePoints.map(sp => ({...sp, shapeId}))
     }

--- a/lib/editor/components/pattern/PatternStopCard.js
+++ b/lib/editor/components/pattern/PatternStopCard.js
@@ -580,7 +580,6 @@ class PatternStopContents extends Component<Props, State> {
             </FormGroup>
           </Col>
         </Row>
-        {pickupDropOffRow}
         <Row>
           <Col xs={6}>
             <FormGroup controlId='meanDurationFactor'>

--- a/lib/editor/components/pattern/TripPatternListControls.js
+++ b/lib/editor/components/pattern/TripPatternListControls.js
@@ -56,7 +56,7 @@ export default class TripPatternListControls extends Component<Props> {
       name: 'New Pattern',
       // FIXME should we be using some other method to generate ID?
       patternId: generateUID(),
-      shapeId: generateUID(),
+      shapeId: null,
       useFrequency: 0,
       shapePoints: [],
       id: ENTITY.NEW_ID

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -772,8 +772,8 @@ export function stopToPatternStop (
 ): PatternStop | PatternLocation {
   if (stop.hasOwnProperty('location_id')) {
     return {
-      continuousDropOff: 1,
-      continuousPickup: 1,
+      continuousDropOff: null,
+      continuousPickup: null,
       dropOffBookingRuleId: null,
       dropOffType: 0,
       flexDefaultTravelTime: 0,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -583,8 +583,8 @@ export type GeoJsonFeatureCollection = {
 }
 
 export type PatternStop = {
-  continuousDropOff: number,
-  continuousPickup: number,
+  continuousDropOff: number | null,
+  continuousPickup: number | null,
   cpIndex?: number,
   defaultDwellTime: number,
   defaultTravelTime: number,
@@ -601,8 +601,8 @@ export type PatternStop = {
   timepoint: ?number
 }
 export type PatternLocation = {
-  continuousDropOff?: number,
-  continuousPickup?: number,
+  continuousDropOff?: number | null,
+  continuousPickup?: number | null,
   dropOffBookingRuleId?: ?string,
   dropOffType?: number,
   flexDefaultTravelTime: number,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -625,7 +625,7 @@ export type ShapePoint = {
   id?: number,
   pointType: $Values<typeof POINT_TYPE>,
   shapeDistTraveled: number,
-  shapeId?: string,
+  shapeId?: string | null,
   shapePtLat: number,
   shapePtLon: number,
   shapePtSequence: number


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Pattern locations CAN have a shape id, pickup type, and drop-off type, however when they have these it can have unintended consequences. Therefore we no longer ship default values for this (and in some cases shipping invalid default values)

As part of this, it is no longer possible to set a pickup or drop-off type for a location. This has to be done via booking rules, which is best practice anyway.