### PR TITLE
Fix feed source name editing

### DIFF
--- a/lib/manager/components/GeneralSettings.js
+++ b/lib/manager/components/GeneralSettings.js
@@ -40,9 +40,11 @@ type State = {
 export default class GeneralSettings extends Component<Props, State> {
   state = {}
 
-  _onChange = ({target}: SyntheticInputEvent<HTMLInputElement>) => {
+  _onChange = ({target}: SyntheticInputEvent<HTMLInputElement>, key: 'name' | 'url') => {
+    let value
     // Change empty string to null to avoid setting URL to empty string value.
-    const value = target.value === '' ? null : target.value.trim()
+    if (key === 'url') value = target.value === '' ? null : target.value.trim()
+    else value = target.value
     this.setState({[target.name]: value})
   }
 
@@ -130,7 +132,7 @@ export default class GeneralSettings extends Component<Props, State> {
                     value={this._getFormValue('name')}
                     name={'name'}
                     disabled={disabled}
-                    onChange={this._onChange} />
+                    onChange={(e) => this._onChange(e, 'name')} />
                   <InputGroup.Button>
                     <Button
                       // disable if no change or no value (name is required).
@@ -164,7 +166,7 @@ export default class GeneralSettings extends Component<Props, State> {
                   <FormControl
                     disabled={disabled}
                     name={'url'}
-                    onChange={this._onChange}
+                    onChange={(e) => this._onChange(e, 'url')}
                     value={this._getFormValue('url')}
                   />
                   <InputGroup.Button>

--- a/lib/manager/components/GeneralSettings.js
+++ b/lib/manager/components/GeneralSettings.js
@@ -40,11 +40,10 @@ type State = {
 export default class GeneralSettings extends Component<Props, State> {
   state = {}
 
-  _onChange = ({target}: SyntheticInputEvent<HTMLInputElement>, key: 'name' | 'url') => {
-    let value
+  _onChange = ({target}: SyntheticInputEvent<HTMLInputElement>) => {
     // Change empty string to null to avoid setting URL to empty string value.
-    if (key === 'url') value = target.value === '' ? null : target.value.trim()
-    else value = target.value
+    let value = target.value || null
+    if (target.name === 'url' && value) value = value.trim()
     this.setState({[target.name]: value})
   }
 
@@ -132,7 +131,7 @@ export default class GeneralSettings extends Component<Props, State> {
                     value={this._getFormValue('name')}
                     name={'name'}
                     disabled={disabled}
-                    onChange={(e) => this._onChange(e, 'name')} />
+                    onChange={this._onChange} />
                   <InputGroup.Button>
                     <Button
                       // disable if no change or no value (name is required).
@@ -166,7 +165,7 @@ export default class GeneralSettings extends Component<Props, State> {
                   <FormControl
                     disabled={disabled}
                     name={'url'}
-                    onChange={(e) => this._onChange(e, 'url')}
+                    onChange={this._onChange}
                     value={this._getFormValue('url')}
                   />
                   <InputGroup.Button>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Currently, when editing the name of a feed source, beginning additions to the name with spaces will cause the spaces to be trimmed as soon as they are entered. This PR resolves that issue.
