### PR TITLE
Editor lock param

### DIFF
--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -31,6 +31,8 @@ import type {
 
 import {clearGtfsContent, saveActiveGtfsEntity, setActiveGtfsEntity} from './active'
 
+const LOCK_API_PATH = '/api/editor/secure/lock'
+
 export const updateEntitySort = createAction('UPDATE_ENTITY_SORT')
 
 const createGtfsEntity = createAction(
@@ -144,7 +146,7 @@ export function lockEditorFeedSource (feedId: string) {
         return Promise.resolve(true)
       }
     }
-    const url = `/api/editor/secure/lock?feedId=${feedId}`
+    const url = `${LOCK_API_PATH}?feedId=${feedId}`
     return dispatch(secureFetch(url, 'post', undefined, undefined, undefined, 'RE_LOCK'))
       .then(res => res.json())
       .then(json => {
@@ -186,7 +188,7 @@ function maintainEditorLock (
   timer?: IntervalID
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    const url = `/api/editor/secure/lock/${sessionId}?feedId=${feedId}`
+    const url = `${LOCK_API_PATH}/${sessionId}?feedId=${feedId}`
     // Note: this action is called only when the browser tab/window is visible.
     return dispatch(secureFetch(url, 'put', undefined, undefined, undefined, 'RE_LOCK'))
       .then(response => response.json())
@@ -279,7 +281,7 @@ export function removeEditorLock (
     // If sessionId is missing and overwrite is true, the server will
     // overwrite whatever session was currently running for the feed ID with a
     // new session.
-    const url = `/api/editor/secure/lock/${sessionId || 'dummy_value'}?feedId=${feedId}${overwrite ? '&overwrite=true' : ''}`
+    const url = `${LOCK_API_PATH}/${sessionId || 'dummy_value'}?feedId=${feedId}${overwrite ? '&overwrite=true' : ''}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => {
         dispatch(stopLockTimer())

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -32,6 +32,8 @@ import type {
 import {clearGtfsContent, saveActiveGtfsEntity, setActiveGtfsEntity} from './active'
 
 const LOCK_API_PATH = '/api/editor/secure/lock'
+/** Identifies what is being locked. */
+const GTFS_EDITOR_LOCK = 'gtfs-editor'
 
 export const updateEntitySort = createAction('UPDATE_ENTITY_SORT')
 
@@ -146,7 +148,7 @@ export function lockEditorFeedSource (feedId: string) {
         return Promise.resolve(true)
       }
     }
-    const url = `${LOCK_API_PATH}?feedId=${feedId}`
+    const url = `${LOCK_API_PATH}?feedId=${feedId}&item=${GTFS_EDITOR_LOCK}`
     return dispatch(secureFetch(url, 'post', undefined, undefined, undefined, 'RE_LOCK'))
       .then(res => res.json())
       .then(json => {
@@ -188,7 +190,7 @@ function maintainEditorLock (
   timer?: IntervalID
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    const url = `${LOCK_API_PATH}/${sessionId}?feedId=${feedId}`
+    const url = `${LOCK_API_PATH}/${sessionId}?feedId=${feedId}&item=${GTFS_EDITOR_LOCK}`
     // Note: this action is called only when the browser tab/window is visible.
     return dispatch(secureFetch(url, 'put', undefined, undefined, undefined, 'RE_LOCK'))
       .then(response => response.json())
@@ -281,7 +283,7 @@ export function removeEditorLock (
     // If sessionId is missing and overwrite is true, the server will
     // overwrite whatever session was currently running for the feed ID with a
     // new session.
-    const url = `${LOCK_API_PATH}/${sessionId || 'dummy_value'}?feedId=${feedId}${overwrite ? '&overwrite=true' : ''}`
+    const url = `${LOCK_API_PATH}/${sessionId || 'dummy_value'}?feedId=${feedId}&item=${GTFS_EDITOR_LOCK}${overwrite ? '&overwrite=true' : ''}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => {
         dispatch(stopLockTimer())

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -324,7 +324,7 @@ export function removeEditorLockLastGasp (
     const {sessionId} = getState().editor.data.lock
     // Send beacon (last-gasp) call to remove editor lock.
     console.log(`removing lock for feed ${feedId}, session ${sessionId || '(undefined)'}`)
-    const url = `/api/editor/deletelock/${sessionId || 'dummy_value'}?feedId=${feedId}`
+    const url = `/api/editor/deletelock/${sessionId || 'dummy_value'}?feedId=${feedId}&item=${GTFS_EDITOR_LOCK}`
     // $FlowFixMe - Assume navigator.sendBeacon is implemented.
     navigator.sendBeacon(url)
   }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR works with and without https://github.com/ibi-group/datatools-server/pull/479, and ~the two can be merged independently.~  EDIT: this PR can be merged independently of the backend one.

This refactor PR simply passes an `item` parameter to the editor lock endpoints. Right now, the `item` parameter is hardcoded to be `gtfs-editor`, although this can/will be changed in the future to accommodate the GTFS+ editor.
