### PR TITLE
Fix UI crash on empty validationResult for FeedVersion

### DIFF
--- a/lib/manager/components/version/FeedVersionDetails.js
+++ b/lib/manager/components/version/FeedVersionDetails.js
@@ -44,6 +44,7 @@ export default class FeedVersionDetails extends Component<Props> {
    * errors.
    */
   _checkBlockingIssue = (version: FeedVersion) => {
+    if (!version.validationResult) return false
     if (version.validationResult.fatalException) return true
     const errorCounts = version.validationResult.error_counts
     return errorCounts &&

--- a/lib/manager/components/version/FeedVersionViewer.js
+++ b/lib/manager/components/version/FeedVersionViewer.js
@@ -162,7 +162,7 @@ class VersionSectionSelector extends Component<SelectorProps> {
     // Determine the highest priority issue (which will determine the label
     // color).
     let highestPriority = 'UNKNOWN'
-    if (validationResult.error_counts) {
+    if (validationResult && validationResult.error_counts) {
       validationResult.error_counts.forEach(category => {
         const level = errorPriorityLevels[category.priority]
         if (level < errorPriorityLevels[highestPriority]) {

--- a/lib/manager/reducers/projects.js
+++ b/lib/manager/reducers/projects.js
@@ -277,6 +277,7 @@ const projects = (state: ProjectsState = defaultState, action: Action): Projects
         console.warn('Feedsource has no feed version')
         return state
       }
+      if (!action.payload || typeof action.payload.validationIssueCount !== 'number') return state
       return update(state, {
         all: {[projectIndex]: {feedSources: {[sourceIndex]: {feedVersions: {
           [versionIndex]: {validationResult: {$merge: action.payload.validationIssueCount}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Old datatools feeds may not contain a `validationResult` in the database and will not be able to display various information regarding validation. Rather than throwing errors w/ an empty validationResult we avoid behaviour that relies on it. The validation issues label will display "critical error" in the case of empty `validationResult`
