### PR TITLE
Fix validation result checks failing to display all validation results.

### DIFF
--- a/lib/manager/reducers/projects.js
+++ b/lib/manager/reducers/projects.js
@@ -277,7 +277,7 @@ const projects = (state: ProjectsState = defaultState, action: Action): Projects
         console.warn('Feedsource has no feed version')
         return state
       }
-      if (!action.payload || typeof action.payload.validationIssueCount !== 'number') return state
+      if (!action.payload || !action.payload.validationIssueCount) return state
       return update(state, {
         all: {[projectIndex]: {feedSources: {[sourceIndex]: {feedVersions: {
           [versionIndex]: {validationResult: {$merge: action.payload.validationIssueCount}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

The check from the previous fix was catching all feeds, rather than just ones w/o validation results because of an incorrect typing. This PR fixes that issue. 