### PR TITLE
Remove router override for ELB preview

### DIFF
--- a/lib/manager/components/deployment/DeploymentPreviewButton.js
+++ b/lib/manager/components/deployment/DeploymentPreviewButton.js
@@ -68,7 +68,7 @@ export default class DeploymentPreviewButton extends Component<Props> {
         }
         z--
       }
-      href += `#start/${lat}/${lon}/${z}/${deployment.routerId || 'default'}`
+      href += `#start/${lat}/${lon}/${z}/${(deployment.ec2Instances.length === 0 && deployment.routerId) || 'default'}`
     }
     return (
       <OverlayTrigger

--- a/lib/manager/components/deployment/DeploymentPreviewButton.js
+++ b/lib/manager/components/deployment/DeploymentPreviewButton.js
@@ -68,7 +68,7 @@ export default class DeploymentPreviewButton extends Component<Props> {
         }
         z--
       }
-      href += `#start/${lat}/${lon}/${z}/${(deployment.ec2Instances.length === 0 && deployment.routerId) || 'default'}`
+      href += `#start/${lat}/${lon}/${z}/${(deployment.ec2Instances && deployment.ec2Instances.length === 0 && deployment.routerId) || 'default'}`
     }
     return (
       <OverlayTrigger


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Previously, when using a build over wire server the `Preview` button would attach a router name to the URL. However, with an ELB server only the default router is used and thus the router name in the URL causes issues with the preview. This PR removes that router name from the URL in the case that we're using an ELB server
