### PR TITLE
Add German translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 ----------------------
+## Next
+ * Support German language and add initial translations.
+## Former
  * Fix timetable previous stop time checks from checking text columns.
  * Add feature allowing routing to avoid highways.
  * Support Polish language and add initial translations.

--- a/docs/dev/localization.md
+++ b/docs/dev/localization.md
@@ -19,7 +19,7 @@ To internationalize components not yet translated, perform the following steps:
 	* assign getComponentMessages('<ComponentName>') to a component properties `messages`
 	* extract not yet translated messages from component files to `i18n/english.yml` and replace their original text by this.messages('<key>')
 	* in case the original message was haad some dynamic parts, you should create placeholders (using `%placeholder%` and use replace to substitute that string with the intended value). Note that numic parameters should be converted to strings.
-* When done, add the new message keys to the existing translation files, e.g. using [yq](https://mikefarah.gitbook.io/yq/v/v2.x/), like e.g. `yq merge i18n/german.yml i18n/english.yml | sponge i18n/german.yml`. Note: Besides merging the missing keys, yq has some reformatting/reordering side effects.
+* When done, add the new message keys to the existing translation files, e.g. using [yq](https://mikefarah.gitbook.io/yq/v/v2.x/), like e.g. `yq merge i18n/german.yml i18n/english.yml | sponge i18n/german.yml`. Note: Besides merging the missing keys, yq has some reformatting/reordering side effects, i.e. messages surrounded by brackets need to be quoted, otherwise they are converted to nested arrays.
 * Periodically, and especially before commiting, run `yarn run lint-messages` or `yarn run test` to be sure all tests are still running. 
 
 Note: console log messages are not intended to be localized

--- a/docs/dev/localization.md
+++ b/docs/dev/localization.md
@@ -1,0 +1,34 @@
+# Localization
+
+## Adding translations for a new language
+To add support for a new language, you need to perform the following steps:
+
+1. Create a new language file in folder `i18`, e.g. by copying the `english.yml`.
+2. In the newly created `<new language>.yml`, adapt the first two lines: `_id` should conform to the ISO 639 language code, `_name` to the localized language name.
+3. In `lib/common/util/config.js`, add the import of the new language file at the mark  `// Add additional language files here.` Mind to add an `// $FlowFixMe` hint before the new line to make the linter happy
+4. Translate all messages in the `<new language>.yml` file. Note, that names surrounded by percent characters (`%`) denote parameters and must not be translated.
+5. Add a new line to the CHANGELOG, e.g. `Add support for <new language>`
+5. Before commiting, run `yarn run lint-messages` or `yarn run test`
+
+
+## Internationalizing components
+To internationalize components not yet translated, perform the following steps:
+
+* For components not yet translated:
+	* import getComponentMessages from common/util.config
+	* assign getComponentMessages('<ComponentName>') to a component properties `messages`
+	* extract not yet translated messages from component files to `i18n/english.yml` and replace their original text by this.messages('<key>')
+	* in case the original message was haad some dynamic parts, you should create placeholders (using `%placeholder%` and use replace to substitute that string with the intended value). Note that numic parameters should be converted to strings.
+* When done, add the new message keys to the existing translation files, e.g. using [yq](https://mikefarah.gitbook.io/yq/v/v2.x/), like e.g. `yq merge i18n/german.yml i18n/english.yml | sponge i18n/german.yml`. Note: Besides merging the missing keys, yq has some reformatting/reordering side effects.
+* Periodically, and especially before commiting, run `yarn run lint-messages` or `yarn run test` to be sure all tests are still running. 
+
+Note: console log messages are not intended to be localized
+
+### Open issues
+There are a few sections, which are not yet prepared for i18n and will not adapt to the user's locale:
+* The alerts module (`lib/alerts/**`) is not yet fully internationalized
+* A couple of messages (i.e. job names and status) are generated server-side and are not internationalized yet.
+* Time and date formatting performed by the moment javascript lib are not locale aware
+* Some messages from the react-bootstrap table component, e.g. `Showing row x-y of z`.
+* GTFS-related field names and descriptions defined in GTFS.yml
+

--- a/docs/dev/localization.md
+++ b/docs/dev/localization.md
@@ -7,18 +7,18 @@ To add support for a new language, you need to perform the following steps:
 2. In the newly created `<new language>.yml`, adapt the first two lines: `_id` should conform to the ISO 639 language code, `_name` to the localized language name.
 3. In `lib/common/util/config.js`, add the import of the new language file at the mark  `// Add additional language files here.` Mind to add an `// $FlowFixMe` hint before the new line to make the linter happy
 4. Translate all messages in the `<new language>.yml` file. Note, that names surrounded by percent characters (`%`) denote parameters and must not be translated.
-5. Add a new line to the CHANGELOG, e.g. `Add support for <new language>`
-5. Before commiting, run `yarn run lint-messages` or `yarn run test`
+5. Add a new line to the CHANGELOG, e.g. `Add support for <new language>`.
+5. Before commiting, run `yarn run lint-messages` or `yarn run test`.
 
 
 ## Internationalizing components
 To internationalize components not yet translated, perform the following steps:
 
 * For components not yet translated:
-	* import getComponentMessages from common/util.config
+	* import getComponentMessages from common/util.config.
 	* assign getComponentMessages('<ComponentName>') to a component properties `messages`
-	* extract not yet translated messages from component files to `i18n/english.yml` and replace their original text by this.messages('<key>')
-	* in case the original message was haad some dynamic parts, you should create placeholders (using `%placeholder%` and use replace to substitute that string with the intended value). Note that numic parameters should be converted to strings.
+	* extract not yet translated messages from component files to `i18n/english.yml` and replace their original text by this.messages('<key>').
+	* in case the original message contains dynamic parts, you should create placeholders (e.g. `%placeholder%`, and replacing that string with the intended value after calling `this.messages('<key>')`). Note that numeric parameters should be converted to strings.
 * When done, add the new message keys to the existing translation files, e.g. using [yq](https://mikefarah.gitbook.io/yq/v/v2.x/), like e.g. `yq merge i18n/german.yml i18n/english.yml | sponge i18n/german.yml`. Note: Besides merging the missing keys, yq has some reformatting/reordering side effects, i.e. messages surrounded by brackets need to be quoted, otherwise they are converted to nested arrays.
 * Periodically, and especially before commiting, run `yarn run lint-messages` or `yarn run test` to be sure all tests are still running. 
 
@@ -26,9 +26,9 @@ Note: console log messages are not intended to be localized
 
 ### Open issues
 There are a few sections, which are not yet prepared for i18n and will not adapt to the user's locale:
-* The alerts module (`lib/alerts/**`) is not yet fully internationalized
+* The alerts module (`lib/alerts/**`) is not yet fully internationalized.
 * A couple of messages (i.e. job names and status) are generated server-side and are not internationalized yet.
-* Time and date formatting performed by the moment javascript lib are not locale aware
+* Time and date formatting performed by the moment javascript lib are not locale aware.
 * Some messages from the react-bootstrap table component, e.g. `Showing row x-y of z`.
-* GTFS-related field names and descriptions defined in GTFS.yml
+* GTFS-related field names and descriptions defined in GTFS.yml.
 

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -357,7 +357,7 @@ components:
   FeedSourceAttributes:
     lastUpdated: Updated
   FeedSourcePanel:
-    chooseProject: [choose project]
+    chooseProject: '[choose project]'
     chooseProjectToView: Choose a project to view feeds
     createOne: Create one.
     filters:

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1,12 +1,73 @@
 _id: en-US
 _name: English
 components:
+  Actions:
+    error: Error making %method% request to %url%
+    errorGraphQL: Error fetching GTFS entities via GraphQL
+    errorWithStatus: Error (%status%) making %method% request to %url%
+    networkError: Network error (%status%)!\n\n(%method% request on %url%)
+    noFile: No file to upload!
+  AdminPage:
+    applicationLogs: Application logs
+    backToDashboard: Back to dashboard
+    deploymentServers: Deployment servers
+    noAccess: You do not have sufficient user privileges to access this area.
+    organizations: Organizations
+    title: Administration
+    userManagement: User Management
+  ApplicationStatusView:
+    columns:
+      id: ID
+      name: Name
+      path: Path
+      status: Status
+      time: Time
+      user: User
+    lastApiRequests: Last API requests by User
+    lastUpdatedAt: last updated at
+    noDataText: No active jobs in progress.
+    refresh: Refresh
+    unauthenticated: (unauthenticated)
+    userLogs: User Authentication Logs
+    serverJobs: Active Server Jobs
+    viewUserLogs: View user logs on Auth0.com
+    actions: Actions
+    name: Name
+    feed:
+      isPublic: Is Public
+      lastFetched: Last Time Data Fetched from Feed URL
+      lastUpdated: Last Updated
+      filterByLabels: Filter feeds by labels
+    latestValidation:
+      endDate: 'Latest Version: End Date'
+      errorCount: 'Latest Version: Number of Issues'
+      startDate: 'Latest Version: Start Date'
+      stopTimesCount: 'Latest Version: Number of Stop Times'
+      tripCount: 'Latest Version: Number of Trips'
+      stopCount: 'Latest Version: Number of Stops'
+      routeCount: 'Latest Version: Number of Routes'
+    sortBy: Sort By
+    url: 'Feed download URL'
+  Brand:
+    dataTools: Data Tools 
   Breadcrumbs:
     deployments: Deployments
     projects: Projects
     root: Explore
+  ConfirmModal:
+    cancel: Cancel
+    ok: OK
+  CreateProject:
+    new: Create New Project
   CreateUser:
     new: Create User
+    title: Create User
+    email: 
+      label: Email Address
+      placeholder: Enter email
+    password:
+      label: Password
+      placeholder: Enter password for new user
   CreateSnapshotModal:
     cancel: Cancel
     description: >-
@@ -182,8 +243,25 @@ components:
       testDeployment: Test?
       name: Name
     title: Deployments
+  EC2InstanceCard:
+    aws: AWS
+    confirmTermination: 'Are you sure you want to terminate this EC2 instance? This action cannot be undone and will remove this instance from the load balancer.'
+    log: log
+    notApplicable: 'N/A'
+    noPublicIP: No public IP
+    status:
+      booting: 'Booting up.'
+      terminated: Terminated.
+      terminatedAt: 'Terminated %moment%'
+      running: Running as server.
+    terminate: Terminate instance
+    view: View deployment
+  EditableTextField:
+    invalidInput: Must provide a valid input.
+    none: (none)
   EditorFeedSourcePanel:
     active: Active
+    availableSnapshots: Available snapshots
     confirmDelete: This will permanently delete this snapshot. Any data saved here cannot be recovered. Are you sure you want to continue?
     confirmLoad: 'This will override all active GTFS Editor data for this Feed Source with the data from this version. If there is unsaved work in the Editor you want to keep, you must snapshot the current Editor data first. Are you sure you want to continue?'
     created: created
@@ -191,6 +269,7 @@ components:
     date: Date
     delete: Delete
     download: Download
+    editFeed: Edit feed
     feed: Feed
     help:
       body:
@@ -207,35 +286,106 @@ components:
     publish: Publish
     restore: Restore
     snapshot: snapshot
+    snapshotLatest: Take snapshot of latest changes
     title: Snapshots
     version: Version
+  EditorInput:
+    daysOfService: Days of service
+    dropImage: Drop %activeComponent% image here, or click to select image to upload.
+    optional: (optional)
+    selectAgency: Select agency...
+    selectDate: Please select a date
+    selectOption: -- select an option --
+    uploadAsset: 'Upload %activeComponent% branding asset'
+  EditorSidebar:
+    backToFeed: Back to Feed
+  EntityDetailsHeader:
+    attributes: Attributes
+    feedInfo: Feed Info
+    noValidationIssues: No validation issues
+    requiredField: '* denotes required field'
+    routeDetails: Route details
+    rules: Rules
+    saveChanges: Save changes
+    tripPatterns: Trip patterns
+    undoChanges: Undo changes
+    validationIssues: validation issue(s)
+    zoomTo: Zoom to
+  EntityList:
+    createFirst: Create first
+    createStop: Right-click a location on map to create a new stop
+    editSchedules: Edit schedules
+    name: Name
   FeedFetchFrequency:
     DAYS: days
     fetchFeedEvery: Fetch feed every
     HOURS: hours
     MINUTES: minutes
+  FeedLabel:
+    delete: 
+      title: Delete Label?
+      body: Are you sure you want to delete the label %name%? This action will remove the label from all feed sources it's assigned to.
   FeedInfo:
     autoFetch: Auto fetch
     autoPublish: Auto publish
+    dateFormat: MMM D, YYYY 
     deployable: Deployable
     edit: Edit
+    lastUpdatedDate: Last updated %date%
+    noUpdates: No updates
     private: Private
     public: Public
   FeedInfoPanel:
+    add: Add %id%
+    backToProject: Back to project
+    backToFeedSource: Back to feed source
+    editingFeed: Editing %feed%
+    noSnapshot: No snapshots created
+    restoreSnapshot:
+      title: Restore %key%?
+      body: 'Are you sure you want to restore this snapshot?'
+    revert: Revert to %snapshot%
+    takeSnapshot: Take snapshot
+    toolbar:
+      hide: Hide toolbar
+      show: Show toolbar
     uploadShapefile:
       body: 'Select a zipped shapefile to display on map. Note: this is only for use as a visual aid.'
       error: Uploaded file must be a valid zip file (.zip).
       title: Upload route shapefile
+    unnamed: Unnamed
   FeedSourceAttributes:
     lastUpdated: Updated
   FeedSourcePanel:
+    chooseProject: [choose project]
+    chooseProjectToView: Choose a project to view feeds
+    createOne: Create one.
+    filters:
+      ALL: All
+      STARRED: Starred
+      PUBLIC: Public
+      PRIVATE: Private
+    forFeed: For feed
+    noFeedsYet: No feeds yet.
     search: Search feeds
+    unnamed: unnamed
   FeedSourceTable:
     comparisonColumn:
       DEPLOYED: Deployed Version
       PUBLISHED: Published Version
     createFirst: Create first feed source!
+    datesValid: Dates Valid
+    feedInfo: Feed Info
+    issues: Issues
+    latestVersion: Latest Version
+    status: Status
   FeedSourceTableRow:
+    dateFormat: MMM D, YYYY 
+    expired: Expired %duration% ago
+    lastUpdated: Last updated %lastVersionUpdate% ago
+    none: None
+    noUpdates: No updates yet
+    startingIn: Starting in %duration%
     status:
       active: Active
       all: All
@@ -248,6 +398,21 @@ components:
       no-version: No version
       same-as-deployed: Same as Deployed
       same-as-published: Same as Published
+    validFor: Valid for another %duration%
+  FeedActionsDropdown:
+    delete: Delete
+    deleteFeedSource: Delete Feed Source?
+    deploy: Deploy
+    deployFeed: Deploy feed source.
+    deployNoPermission: You do not have permission to deploy feed
+    fetch: Fetch
+    menu: Menu
+    notDeployable: Feed source is not deployable. Change in feed source settings.
+    noVersions: No versions exist. Create new version to deploy feed
+    openInEditor: Open in Editor
+    upload: Upload
+    uploadFeed: Upload Feed
+    view: View public page
   FeedSourceViewer:
     deploy: Deploy
     edit: Edit GTFS
@@ -277,6 +442,13 @@ components:
     upload: Upload
     versions: Versions
     viewPublic: View public page
+  FeedSourceSettings:
+    autoPublish: Auto-publish
+    feedTransformations: Feed Transformations
+    general: General
+    noPermission: You do not have permission to edit details for this feed source.
+    properties: properties
+    warning: Warning!
   FeedTransformationDescriptions:
     general:
       fileDefined: below text
@@ -304,13 +476,23 @@ components:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
     confirmLoad: 'This will override all active GTFS Editor data for this Feed Source with the data from this version. If there is unsaved work in the Editor you want to keep, you must snapshot the current Editor data first. Are you sure you want to continue?'
     delete: Delete
+    deployFeed: Deploy feed
     download: Download
+    editFeed: Edit feed
     feed: Feed
+    fetch: Fetch
+    fromSnapshot: From snapshot
     load: Load for Editing
+    newVersion: Create new version
     next: Next
     of: of
     previous: Previous
+    selectFeed: 'Select a GTFS feed to upload:'
+    selectVersion: Select a version to view summary
+    upload: Upload
+    uploadFeed: Upload Feed
     version: Version
+    zipWarning: Uploaded file must be a valid zip file (.zip).
   FeedVersionTabs:
     agencyCount: Agency count
     daysActive: Days active
@@ -394,7 +576,17 @@ components:
         serverPlaceholder: Server name
         title: Servers
   GeneralSettings:
+    autoFetch: 
+      title: Automatic Fetch
+      url: Feed source fetch URL
+      urlButton: Change URL
+      checkbox: Auto fetch feed source
+      hint: Set this feed source to fetch automatically. (Feed source URL must be specified and project auto fetch must be enabled.)
     confirmDelete: Are you sure you want to delete this project? This action cannot be undone and all feed sources and their versions will be permanently deleted.
+    dangerZone: Danger Zone
+    deleteFeedSource: Delete feed source
+    deleteFeedSourceDesc: Delete this feed source.
+    deleteFeedSourceHint: Once you delete a feed source, it cannot be recovered.
     deleteProject: Delete Project?
     deployment:
       buildConfig:
@@ -443,6 +635,7 @@ components:
           placeholder: Updater name
         walkSpeed: Walk Speed
       title: Deployment
+    feedSourceName: Feed source name
     general:
       location:
         boundingBox: 'Bounding box (W,S,E,N)'
@@ -455,9 +648,42 @@ components:
       updates:
         autoFetchFeeds: Auto fetch feed sources?
         title: Updates
+    labels:
+      title: Labels
+    make:
+      private: Make private
+      privateDesc: Make this feed source private.
+      privateState: This feed source is currently private.
+      public: Make public
+      publicDesc: Make this feed source public.
+      publicState: This feed source is currently public.
+    makeDeployable: Make feed source deployable
+    makeDeployableHint: Enable this feed source to be deployed to an OpenTripPlanner (OTP) instance (defined in organization settings) as part of a collection of feed sources or individually.
     rename: Rename
     save: Save
     title: Settings
+  GtfsIcons:
+    agency:
+      title: Edit agencies
+      label: Agencies
+    calendar:
+      title: Edit calendar
+      label: Calendar
+    fare:
+      title: Edit fares
+      label: Fares
+    feedinfo:
+      title: Edit feed info
+      label: Feed Info  
+    route:
+      title: Edit routes
+      label: Routes
+    scheduleExceptions:
+      title: Edit schedule exceptions
+      label: Schedule Exceptions
+    stop:
+      title: Edit stops
+      label: Stops
   GtfsValidationExplorer:
     accessibilityValidation: Accessibility Explorer
     table:
@@ -490,10 +716,51 @@ components:
       resolved before most GTFS consumers can make use of the data for trip
       planning or in other applications."
     title: Validation issues
+  HomeProjectDropdown:
+    new: New Project
+    select: Select project
+    view: View %name%
+  InfoModal:
+    ok: OK
+  RetiredJob:
+    view: View
+    bug: Oh no! Looks like an error has occurred.
+    support: "To submit an error report email a screenshot of your browser
+      window, the following text (current URL and error details),
+      and a detailed description of the steps you followed
+      to <a href='mailto:%supportEmail%'>%supportEmail%</a>."
+  JobMonitor:
+    clearCompleted: Clear completed
+    jobs:
+      none: No active jobs
+      one: One active job
+      some: '%count% active jobs'
+    jobsCompleted: All jobs completed
+    serverJobs: Server Jobs
+    waiting: waiting
+  LabelPanel:
+    labels: Labels
+    new: Add a new label
+    noLabels: There are no labels in this project.
   LanguageSelect:
     placeholder: Select language...
   Login:
     title: Log in
+  ManagerHeader:
+    noUpdateYet: n/a
+    noUrl: (none)
+    private: This feed source and all its versions are private.
+  ManagerPage:
+    alerts: Alerts
+    changelog: Changelog
+    contact: Contact
+    copyright: Copyright
+    datatools: Data Tools
+    guide: Guide
+    home: Home
+  MapModal:
+    ok: OK
+    cancel: Cancel
   MergeFeedsResult:
     body:
       failure: Merge failed with %errorCount% errors.
@@ -508,7 +775,11 @@ components:
     title:
       failure: 'Warning: Errors encountered during feed merge!'
       success: 'Feed merge was successful!'
-
+  NormalizeField:
+    issues:
+      fieldUndefined: Field to normalize must be defined.
+      substitutionUndefined: Substitution patterns must be defined.
+      substitutionInvalid: Some substitution patterns are invalid.
   NormalizeStopTimesTip:
     info: "Tip: when changing travel times, consider
     using the 'Normalize stop times' button above to automatically update
@@ -526,6 +797,8 @@ components:
     refresh: Refresh
     title: Comments
   OrganizationList:
+    create: Create Organization
+    missingName: Must provide organization name.
     new: Create org
     search: Search orgs
   OrganizationSettings:
@@ -545,6 +818,16 @@ components:
       high: High
       low: Low
       medium: Medium
+      title: Usage tier
+  PageNotFound:
+    homePage: home page
+    pageNotFound: Page Not Found.
+  Permissions:
+    approve-alert: Approve GTFS-RT Alerts
+    approve-gtfs: Approve GTFS Feeds
+    edit-alert: Edit GTFS-RT Alerts
+    edit-gtfs: Edit GTFS Feeds
+    manage-feed: Manage Feed Configuration
   ProjectAccessSettings:
     admin: Admin
     cannotFetchFeeds: Cannot fetch feeds
@@ -613,7 +896,11 @@ components:
   ProjectSettingsForm:
     cancel: Cancel
     confirmDelete: Are you sure you want to delete this project? This action cannot be undone and all feed sources and their versions will be permanently deleted.
+    dangerZone: Danger zone
     deleteProject: Delete Project?
+    deleteProjectAction: Delete Project
+    deleteThisProject: Delete this project.
+    deleteWarning: Once you delete an project, the project and all feed sources it contains cannot be recovered.
     fields:
       location:
         boundingBox: 'Bounding box (W,S,E,N)'
@@ -627,9 +914,24 @@ components:
       updates:
         autoFetchFeeds: Auto fetch feed sources?
         title: Updates
+      localPlacesIndex:
+        title: Local Places Index
+        webhookUrl: Webhook URL
+    noPermissions: You do not have permission to edit details for this feed source.
+    required: Required.
     save: Save
+    selectBounds: Select project bounds
+    selectBoundsHint: Pretend this is a map
     title: Settings
+    warning: Warning!
+  ProjectSummaryPanel:
+    hoursPerWeekday: hours per weekday
+    numberOfFeeds: "Number of feeds:"
+    summary: summary
+    totalErrors: "Total errors:"
+    totalService: "Total service:"
   ProjectViewer:
+    autoFetchDisabled: Auto fetch disabled
     deployments: Deployments
     feeds:
       createFirst: Create first feed source!
@@ -645,14 +947,27 @@ components:
         validRange: Valid Range
       title: Feed Sources
       update: Fetch all
+    feedSourceDesc: "A feed source defines the location or upstream source of a GTFS feed.
+          GTFS can be populated via automatic fetch, directly editing or uploading
+          a zip file."
+    feedSourceTitle: What is a feed source?
+    here: here
     makePublic: Publish public feeds
     mergeFeeds: Merge all
+    noProjectFound: No project found for
+    note: "Note:"
+    publicViewed: Public feeds page can be viewed
+    returnToProjects: Return to list of projects
     settings: Settings
   ProjectFeedListToolbar:
+    actions: Actions
+    all: all
+    any: any
     comparison:
       DEPLOYED: Deployed
       LATEST: Latest
       PUBLISHED: Published
+    deployedVersion: 'Deployed Version:'
     deployments: Deployments
     downloadCsv: Download Summary as CSV
     feeds:
@@ -675,34 +990,65 @@ components:
       expired: Expired
       expiring: Expiring
       future: Future
+    filterByLabels: Filter feeds by labels
+    filterFeedSources: Filter feed sources on
+    hasDeployedVersion: Has Deployed Version?
+    hasLatestVersion: Has a latest version?
+    hasPublishedVersion: Has Published Version?
+    isPublic: Is Public
+    labelEndDate: '%labelPrefix% End Date'
+    labelNumberIssues: '%labelPrefix% Number of Issues'
+    labelNumberRoutes: '%labelPrefix% Number of Routes'
+    labelNumberStops: '%labelPrefix% Number of Stops'
+    labelNumberStopTimes: '%labelPrefix% Number of StopsTimes'
+    labelNumberTrips: '%labelPrefix% Number of Trips'
+    labelStartDate: '%labelPrefix% Start Date'
+    lastFetched: Last Time Data Fetched from Feed URL
+    lastUpdated: Last Updated
+    latestValidation:
+      endDate: 'Latest Version: End Date'
+      errorCount: 'Latest Version: Number of Issues'
+      routeCount: 'Latest Version: Number of Routes'
+      startDate: 'Latest Version: Start Date'
+      stopTimesCount: 'Latest Version: Number of Stop Times'
+      stopCount: 'Latest Version: Number of Stops'
+      tripCount: 'Latest Version: Number of Trips'
     makePublic: Publish public feeds
     mergeFeeds: Merge all
+    name: Name
+    noteSorting: 'Note: sorting only available on latest version data'
+    ofTheLabels: 'of the labels:'
+    publishedVersion: 'Published Version:'
     settings: Settings
+    showFeedsWith: Show feeds with
     sort:
-      alphabetically:
-        title: Alphabetically
+      alphabetically: 
         asc: A-Z
         desc: Z-A
+        title: Alphabetically
       endDate:
-        title: Expiration Date
         asc: Earliest-Latest
         desc: Latest-Earliest
+        title: Expiration Date
       lastUpdated:
-        title: Last Update
         asc: Stale-Recent
         desc: Recent-Stale
+        title: Last Update
       numErrors:
-        title: Number of Issues
         asc: Least-Most
         desc: Most-Least
+        title: Number of Issues
       startDate:
-        title: Start Date
         asc: Earliest-Latest
         desc: Latest-Earliest
+        title: Start Date
+    sortBy: Sort By
     sync:
-      transitland: Sync from transit.land
       transitfeeds: Sync from transitfeeds
+      transitland: Sync from transit.land
       mtc: Sync from MTC
+    url: Feed download URL
+    version: version
   ProjectsList:
     createFirst: Create my first project
     help:
@@ -724,6 +1070,14 @@ components:
     stateProvince: State or Province
   PublicFeedsViewer:
     title: Catalogue
+  PublicLandingPage:
+    appLogo: App logo
+    copyright: Copyright
+    existingUsers: Existing users
+    here: here
+    learnMore: Learn more about Data Tools
+    signInHere: sign in here
+    viewDashboard: View dashboard
   RegionSearch:
     placeholder: Search for regions or agencies
   ResultTable:
@@ -732,20 +1086,41 @@ components:
     line: Line
     priority: Priority
     problemType: Problem Type
+  SelectFileModal:
+    ok: OK
+    cancel: Cancel
   ServerSettings:
+    awsSetup: Instructions for setting up OTP deployment servers on AWS
+    confirmDelete: Are you sure you want to delete this server record?
     deployment:
       otpServers:
         new: Add server
         refresh: Refresh
         serverPlaceholder: Server name
         title: Deployment Server Management
+    instructions: Instructions
+    noServers: No servers defined
     save: Save
     title: Settings
+  ServerSpecialFields:
+    confirmTermination: 'Are you sure you want to terminate %count% instance(s)?\n\n WARNING: This will kill OTP service for any deployments launched for this server.'
+    projectSpecific: Project specific?
+    projectSpecificPlaceholder: Assign to a project or leave open for any project
+    terminateEC2: Terminate EC2 Instances
+    useELB: Use Elastic Load Balancer (ELB)?
+    noEC2Instances: No EC2 instances associated with server.
   ShowAllRoutesOnMapFilter:
     fetching: Fetching
     showAllRoutesOnMap: Show all routes
     tooManyShapeRecords: large shapes.txt may impact performance
   Sidebar:
+    about: About this app
+    account: Account
+    serverJobs: Server jobs
+    serverVersion: 'Server version:'
+    settings: Settings
+    uiDeployedAt: 'UI deployed at:'
+    uiVersion: 'UI Version:'
     unknown: Unknown
   SnapshotItem:
     active: Active
@@ -771,8 +1146,71 @@ components:
   StarButton:
     star: Star
     unstar: Unstar
+  Status:
+    REQUESTING_PROJECTS: Loading projects...
+    REQUESTING_PROJECT: Loading project...
+    SAVING_PROJECT: Saving project...
+    REQUESTING_FEEDSOURCES: Loading feeds...
+    REQUESTING_FEEDSOURCE: Loading feed...
+    SAVING_FEEDSOURCE: Saving feed...
+    REQUESTING_FEEDVERSIONS: Loading feed versions...
+    DELETING_FEEDVERSION: Deleting feed version...
+    UPLOADING_FEED: Uploading feed...
+    REQUESTING_SYNC: Syncing feeds...
+    RUNNING_FETCH_FEED_FOR_PROJECT: Updating feeds for project...
+    REQUESTING_PUBLIC_FEEDS: Loading public feeds...
+    REQUESTING_VALIDATION_ISSUE_COUNT: Loading validation result...
+    REQUESTING_NOTES: Loading comments...
+    REQUESTING_GTFSPLUS_CONTENT: Loading GTFS+ data...
+    UPLOADING_GTFSPLUS_FEED: Saving GTFS+ data...
+    PUBLISHING_GTFSPLUS_FEED: Publishing GTFS+ feed...
+    VALIDATING_GTFSPLUS_FEED: Updating GTFS+ validation...
+    REQUESTING_FEEDVERSION_ISOCHRONES: Calculating access shed...
+    REQUESTING_DEPLOYMENTS: Loading deployments...
+    REQUESTING_DEPLOYMENT: Loading deployment...
+    REQUESTING_USERS: Loading users...
+    UPDATING_USER_DATA: Updating user...
+    SAVING_DEPLOYMENT: Saving deployment...
+    REQUESTING_GTFSEDITOR_SNAPSHOTS: Loading snapshots...
+    SAVING_AGENCY: Saving agency...
+    SAVING_STOP: Saving stop...
+    SAVING_ROUTE: Saving route...
+    REQUESTING_AGENCIES: Loading agencies...
+    REQUESTING_STOPS: Loading stops...
+    REQUESTING_ROUTES: Loading routes...
+    REQUESTING_TRIPS_FOR_CALENDAR: Loading trips...
+    CREATING_SNAPSHOT: Creating snapshot...
+    DELETING_SNAPSHOT: Deleting snapshot...
+    DELETING_AGENCY: Deleting agency...
+    DELETING_TRIPS_FOR_CALENDAR: Deleting trips...
+    RESTORING_SNAPSHOT: Restoring snapshot...
+    RENAMING_FEEDVERSION: Renaming feed version...
+    LOADING_FEEDVERSION_FOR_EDITING: Loading version into editor...
+    REQUESTING_ORGANIZATIONS: Loading organizations...
+    UPDATING_SERVER: Saving server...
+    FETCHING_ALL_JOBS: Fetching jobs...
+    REQUEST_RTD_ALERTS: Loading alerts...
+    CREATED_SNAPSHOT:
+      body: 'New snapshot "%payload%" created. It will be accessible from the "Editor Snapshots" tab in the main Feed Source page.'
+      title: Snapshot Created
+  StatusModal:
+    close: Close
+    login: Log in
+    reload: Reload page
+    relock: Re-lock feed
+    relockingFailed:
+      body: Re-locking feed is only permitted if another editing session is in progress for you (not another user). You can try again later or contact the current editor to request that they wrap up their session.
+      title: Attempt to take over editing failed!
+  TimetableEditor:
+    choosePattern: Choose a trip pattern.
+    createNew: create a new one
+    deleteSelectedTrip: 'Are you sure you want to permanently delete %count% selected trip?'
+    deleteSelectedTrips: 'Are you sure you want to permanently delete %count% selected trips?'
+    deleteTrips: Delete trips
+    deleteTripsQuestion: Delete trips?
   TimetableHelpModal:
-    title: Timetable editor keyboard shortcuts
+    close: Close
+    pressQuestionmark: Press <kbd>?</kbd> to view shortcuts
     shortcuts:
       offset:
         title: Offsetting times
@@ -801,6 +1239,7 @@ components:
           - Clone selected trip(s)
           - Copy time value from adjacent cell (the cell immediately to the left)
           - Copy value from cell directly above
+    title: Timetable editor keyboard shortcuts
   TimezoneSelect:
     placeholder: Select timezone...
   UserAccount:
@@ -821,9 +1260,17 @@ components:
       profileInformation: Profile information
       title: Profile
     title: My settings
-  AdminPage:
-    noAccess: You do not have sufficient user privileges to access this area.
-    title: Administration
+  UserAccountInfoPanel:
+    hello: Hello,
+    profile: Profile
+    roles:
+      applicationAdmin: Application admin
+      organizationAdmin: Organization admin
+      standardUser: Standard user
+  UserButtons:
+    admin: Admin
+    myAccount: My account
+    logout: Log out
   UserHomePage:
     createFirst: Create my first project
     help:
@@ -831,12 +1278,17 @@ components:
       title: What's a project?
     new: New Project
     noProjects: You currently do not have any projects.
+    recentActivity: Recent Activity
+    recentActivityNone: No Recent Activity for your subscriptions.
     table:
       name: Project Name
     title: Projects
+    userDocs: User Docs
+    welcomeTo: Welcome to
   UserList:
     filterByOrg: Filter by org.
     of: of
+    noResults: (No results to show)
     perPage: Users per page
     search: Search by username
     showing: Showing Users
@@ -859,6 +1311,7 @@ components:
     cancel: Cancel
     delete: Delete
     edit: Edit
+    noProjects: No projects available
     org:
       admin: Organization administrator
       billing: Billing admin
@@ -879,9 +1332,19 @@ components:
     status: Status
     timestamp: File Timestamp
     version: version
+  VersionComparisonDropdown:
+    compareToVersion: Comparing to version %version%
+    compareVersions: Compare versions
+    exit: Exit compare mode
+    loadAnother: Load another version to enable comparison
+    selectVersion: Select a version to compare with
+  VersionSelectorDropdown:
+    noVersions: No versions available
   WatchButton:
     emailVerificationConfirm: In order to receive email notification, you must first verify your email address. Would you like to resend the email verification message for your account?
     unwatch: Unwatch
     verificationSendError: There was an error sending the email verification!
     verificationSent: Please check your inbox and confirm your email address by clicking the verify link. You will then need to refresh this page after a moment or two and re-click the Watch button to subscribe to notifications.
     watch: Watch
+  WrapComponentInAuthStrategy:
+    adminTestFailed: You have attempted to view a restricted page without proper credentials

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1,0 +1,1425 @@
+_id: de
+_name: Deutsch
+components:
+  Actions:
+    error: Fehler beim %method% Aufruf von %url%
+    errorGraphQL: Fehler beim GTFS-Abruf via GraphQL
+    errorWithStatus: Fehler (%status%) beim %method% Aufruf von %url%
+    networkError: Netzwerk-Fehler (%status%)!\n\n(%method% Aufruf von %url%)
+    noFile: Keine Datei zum Hochladen!
+  AdminPage:
+    applicationLogs: Anwendungs-Logs
+    backToDashboard: Zurück zum Dashboard
+    deploymentServers: Deployment Server
+    noAccess: Sie haben keine ausreichenden Berechtigung zum Zugriff auf diesen Bereich.
+    organizations: Organisationen
+    title: Administration
+    userManagement: Konten-Verwaltung
+  ApplicationStatusView:
+    actions: Aktionen
+    columns:
+      id: ID
+      name: Name
+      path: Pfad
+      status: Status
+      time: Zeit
+      user: Konto
+    feed:
+      filterByLabels: Filtere Feeds nach Etiketten
+      isPublic: Ist öffentlich
+      lastFetched: Letzter Zeitpunkt des Feedabrufs von Feed-URL
+      lastUpdated: Zuletzt aktualisiert
+    lastApiRequests: Letzte API Anfrage nach Nutzenden
+    lastUpdatedAt: letzte Aktualisierung um
+    latestValidation:
+      endDate: 'Aktuellste Version: End-Datum'
+      errorCount: 'Aktuellste Version: Anzahl Fehler'
+      routeCount: 'Aktuellste Version: Anzahl Routen'
+      startDate: 'Aktuellste Version: Start-Datum'
+      stopCount: 'Aktuellste Version: Anzahl Haltestellen'
+      stopTimesCount: 'Aktuellste Version: Anzahl Abfahrtszeiten'
+      tripCount: 'Aktuellste Version: Anzahl Trips'
+    name: Name
+    noDataText: Keine aktiven Jobs.
+    refresh: Aktualisieren
+    serverJobs: Aktive Server Jobs
+    sortBy: Sortiere nach
+    unauthenticated: (unangemeldet)
+    url: Feed-Abruf-URL
+    userLogs: Nutzer-Authentisierungs-Logs
+    viewUserLogs: Nutzenden-Logs auf Auth0.com ansehen
+  Brand:
+    dataTools: Data Tools
+  Breadcrumbs:
+    deployments: Deployments
+    projects: Projekte
+    root: Erkunden
+  ConfirmModal:
+    cancel: Abbrechen
+    ok: OK
+  CreateProject:
+    new: Neues Projekt erstellen
+  CreateSnapshotModal:
+    cancel: Abbrechen
+    description: Schnappschüsse sind gespeicherte Zwischenstände, die Sie immer wiederherstellen
+      können, während Sie eine GTFS Feed bearbeiten. Erstellen Sie einen Schnappschuss
+      mit der aktivierter Option  um automatisch eine neue GTFS-Datei zu veröffentlichen
+      (und diese als neue Feed-Version zu prozessieren).
+    fields:
+      comment:
+        label: Kommentar
+        placeholder: Zusätzliche Information (optional)
+      confirmPublishWithUnapproved:
+        label: Veröffentlichung mit nicht freigegebenen Routen bestätigen
+      name:
+        label: Name
+        placeholder: Name des Schnappschusses (erforderlich)
+      publishNewVersion:
+        label: Veröffentliche Schnappschuss als neue Feed-Version
+    missingNameAlert: Gültiger Schnappschuss-Name erforderlich!
+    ok: OK
+    title: Neuen Schnappschuss erstellen
+    unapprovedRoutesDesc: 'Diese Routen werden nicht im Export enthalten sein:'
+    unapprovedRoutesHeader: Die folgenden Routen sind nicht freigegeben
+  CreateUser:
+    email:
+      label: Email-Adresse
+      placeholder: Email-Adresse eingeben
+    new: Nutzerkonto erstellen
+    password:
+      label: Passwort
+      placeholder: Passwort für neues Konto eingeben
+    title: Erstelle Nutzerkonto
+  DatatoolsNavbar:
+    account: Mein Konto
+    alerts: Warnungen
+    editor: Editor
+    guide: Leitfaden
+    login: Anmelden
+    logout: Abmelden
+    manager: Manager
+    resetPassword: Passwort zurücksetzen
+    signConfig: eTID Konfiguration
+    users: Benutzende
+  DeploymentConfirmModal:
+    alert:
+      alreadyDeployed: ist bereits auf diesen Server und den gleiche Routing-Dienst
+        deployed. (Deployen würde den aktuellen Graph löschen.)
+      boundsTooLarge: Grenzen sind viel zu groß um erfolgreich in OpenTripPlanner
+        bereitgestellt zu werden. Deployment ist deaktiviert.
+      expiredFeeds: Die folgenden Feeds sind abgelaufen (alle Trips liegen in der
+        Vergangenheit)
+      missingBounds: Für diese Feeds sind keinge Grenzen definiert. Deployment ist
+        deaktiviert.
+      missingFeeds: Für dieses Deployment sind keine Feeds definiert. Deployment ist
+        deaktiviert.
+      success: Deployment erfolgreich ausgeführt.
+    cancel: Abbrechen
+    close: Schließen
+    danger: Gefahr!
+    deploy: Deployen
+    invalidBounds: Grenzen sind ungültig!
+    success: Erfolg!
+    to: zu
+    warning: Warnung!
+  DeploymentConfirmModalAlert:
+    danger: Gefahr!
+    success: Erfolg!
+    warning: Warnung!
+  DeploymentSettings:
+    boundsPlaceholder: min_lon, min_lat, max_lon, max_lat
+    buildConfig:
+      elevationBucket:
+        accessKey: Zugangs-Schlüssel
+        bucketName: S3 Bucket Name
+        secretKey: Secret Key
+      fares: Tarife
+      fetchElevationUS: Höhenmodell abrufen
+      save: Speichern
+      stationTransfers: Umstiege
+      subwayAccessTime: U-Bahn-Zugangszeiten
+      title: Build-Konfiguration
+    clear: Zurücksetzen
+    manageServers: Deployment-Server verwalten
+    osm:
+      bounds: Selbst-definierte Extrakt-Grenzen
+      custom: Benutze selbst-definierte Extrakt-Grenzen
+      gtfs: Grenzen aus GTFS ableiten
+      title: OSM-Extrakt
+    routerConfig:
+      brandingUrlRoot: Branding-URL Wurzel
+      carDropoffTime: PKW-Rückgabe-Zeit
+      numItineraries: '# of Reisevorschläge'
+      requestLogFile: Log-Datei anfordern
+      stairsReluctance: Treppen-Abneigung
+      title: Router Konfiguration
+      updaters:
+        $index:
+          defaultAgencyId: Standard-Betreiber ID
+          frequencySec: Frequenz (in Sekunden)
+          sourceType: Quellen-Typ
+          type: Typ
+          url: URL
+        new: Aktualisierer hinzufügen
+        placeholder: Aktualisierer-Name
+        title: Echtzeit-Aktualisierungs-Updater
+      walkSpeed: Geh-Geschwindigkeit
+    save: Speichern
+    title: Deployment
+  DeploymentVersionsTable:
+    dateRetrieved: Abrufdatum
+    errorCount: Fehlerzahl
+    expires: Läuft aus
+    loadStatus: Erfolgreich geladen
+    name: Name
+    routeCount: Routen-Anzahl
+    stopTimesCount: Anzahl StopTimes
+    tripCount: Trip-Anzahl
+    validFrom: Gültig von
+    version: Version
+  DeploymentViewer:
+    addFeedSource: Feed-Quelle hinzufügen
+    allFeedsAdded: Alle Feeds hinzugefügt
+    deploy: Deploy
+    download: Herunterladen
+    noServers: Keine Server definiert
+    search: Suche nach Name
+    table:
+      dateRetrieved: Abrufdatum
+      errorCount: Fehler-Anzahl
+      expires: Läuft aus
+      loadStatus: Erfolgreich geladen
+      name: Name
+      routeCount: Route-Anzahl
+      stopTimesCount: Anzahl StopTimes
+      tripCount: Trip-Anzahl
+      validFrom: Gültig von
+      version: Version
+    to: nach
+    versions: Feed Versionen
+  DeploymentsList:
+    delete: Deployment entfernen
+    new: Neues Deployment
+    search: Nach Deployments suchen
+    table:
+      creationDate: Erstellt
+      deployedTo: Deployed nach
+      feedCount: '# Feeds'
+      lastDeployed: Zuletzt deployed
+      name: Name
+      testDeployment: Testen?
+    title: Deployments
+  DeploymentsPanel:
+    autoDeploy:
+      deployWithErrors:
+        checklabel: Deployen, auch falls einige Feeds kritische Fehler aufweisen?
+        help: |
+          Wenn abgewählt, wird Auto-Deployment will anhalten, falls mindestens eine der Feed-Versionen im Deployment einen kritischen Fehler aufweist
+        title: Critical Errors Handling
+      help: |
+        Ein Deployment wird automatisch gestartet (angenommen es treten keine kritischen Fehler auf) wenn eines der oben definierten Ereignisse auftritt.
+      label: Auto-Deploy Ereignisse
+      placeholder: Auto-Deploy Ereignisse spezifizieren
+      title: Auto-Deployment
+      types:
+        ON_FEED_FETCH: Eine neue Version wurde abgerufen
+        ON_PROCESS_FEED: Eine neue Version wird verarbeitet
+    config:
+      body: |
+        Deployments können projekt-spezifische Konfigurationen nutzen (z.B. für Graphbau- der Router-Konfigurations-Dateien) oder individuell konfiguriert werden.
+      editSettings: Deployment-Einstellungen bearbeiten
+      manageServers: Deployment-Server verwalten
+      title: Deployments konfigurieren
+    delete: Entferne Deployment
+    new: Neues Deployment
+    pinnedDeployment:
+      help: Deployment pinnen (und zumindest einmaliges Deployment auf einen Server
+        ausführen) um Auto-Deployment zu aktivieren.
+      label: Gepinntes Deployment
+      placeholder: Wählen Sie ein zu pinnendes Deployment
+    search: Suche nach Deployments
+    table:
+      creationDate: Erstellt
+      deployedTo: Deployed nach
+      feedCount: '# Feeds'
+      lastDeployed: Zuletzt deployed
+      name: Name
+      testDeployment: Testen?
+    title: Deployments
+  EC2InstanceCard:
+    aws: AWS
+    confirmTermination: 'Sind Sie sicher, dass Sie %count% Instanz(en) beenden möchten?\n\n
+      ACHTUNG: Dies wird OTP Dienste aller auf diesem Server gestarteten Deployments
+      beenden.'
+    log: Log-Datei
+    noPublicIP: Keine öffentliche IP
+    notApplicable: N/A
+    status:
+      booting: Startet.
+      running: Server läuft.
+      terminated: Beendet.
+      terminatedAt: Beendet %moment%
+    terminate: Instanz beenden
+    view: Deployment ansehen
+  EditableTextField:
+    invalidInput: Gültige Eingabe erforderlich.
+    none: (leer)
+  EditorFeedSourcePanel:
+    active: Aktiv
+    availableSnapshots: Verfügbare Schnappschüssse
+    confirmDelete: Dies wird den Schnappschuss dauerhaft löschen. Alle damit gespeicherten
+      Date können nicht wiederhergestellt werden. Sind Sie sicher, dass Sie fortfahren
+      möchten?
+    confirmLoad: Dies wird alle aktiven GTFS Editor Daten dieser Feed-Quelle mit den
+      Daten dieser Version überschreiben. Wenn Sie im Editor ungespeicherte Änderungen
+      behalten möchten, müssen Sie für diese Daten zuerst einen Schnappschuss erstellen.
+      Sind Sie sicher, dass Sie fortfahren möchten?
+    createFromScratch: Erstelle leeren GTFS-Feed
+    created: erstellt
+    date: Datum
+    delete: Löschen
+    download: Herunterladen
+    editFeed: Feed bearbeiten
+    feed: Feed
+    help:
+      body:
+      - Schnappschüsse sind gespeicherte Zwischenstände, die Sie immer wiederherstellen
+        können, während Sie eine GTFS Feed bearbeiten.
+      - Ein Schnapschuss kein eine Arbeitsstand, ein zukünftiges Planungsszenario
+        oder sogar verschiedene Fahrpläne abbilden (z.B. Sommerfahrplan).
+      title: Was sind Schnappschüsse?
+    load: Zur Bearbeitung laden
+    loadLatest: Aktuellsten zur Bearbeitung herunterladen
+    name: Name
+    noSnapshotsExist: Für diese Feed-Quelle existieren noch keine Schnappschüsse.
+      Schnappschüsse können im Editor erstellt werden. Wählen Sie "Feed bearbeiten"
+      um den Bearbeitungsmodus zu starten.
+    noVersions: (Keine Versionen)
+    noVersionsExist: Für diese Feed-Quelle existieren noch keine Versionen.
+    of: von
+    publish: Veröffentlichen
+    restore: Wiederherstellen
+    snapshot: Schnappschuss
+    snapshotLatest: Schnappschuss erstellen
+    title: Schnappschüsse
+    version: Version
+  EditorInput:
+    daysOfService: Service-Tage
+    dropImage: Ziehen Sie ein %activeComponent%-Bild hier hin, oder klicken Sie um
+      ein Bild hochzuladen.
+    optional: (optional)
+    selectAgency: Betreiber auswählen...
+    selectDate: Bitte wählen Sie ein Datum
+    selectOption: -- Option auswählen --
+    uploadAsset: '%activeComponent%-Branding-Asset hochladen'
+  EditorSidebar:
+    backToFeed: Zurück zum Feed
+  EntityDetailsHeader:
+    attributes: Attribute
+    feedInfo: Feed Info
+    noValidationIssues: Keine Validierungsfehler
+    requiredField: '* kenzeichnet verpflichtendes Feld'
+    routeDetails: Routen-Details
+    rules: Regeln
+    saveChanges: Änderungen speicheren
+    tripPatterns: Trip-Muster
+    undoChanges: Änderungen rückgängig machen
+    validationIssues: Validatungsfehler
+    zoomTo: Zoome auf
+  EntityList:
+    createFirst: Erstelle erste/n
+    createStop: Um eine neue Haltestelle zu erstellen, klicken Sie per rechter Maustaste
+      auf eine Örtlickeit in der Karte
+    editSchedules: Abfahrzeiten erstellen
+    name: Name
+  FeedActionsDropdown:
+    delete: Löschen
+    deleteFeedSource: Feed-Quelle löschen?
+    deploy: Deployen
+    deployFeed: Feed-Quelle deployen.
+    deployNoPermission: Sie haben keine Berechtigungen, um den Feed zu deployen
+    fetch: Abrufen
+    menu: Menü
+    noVersions: Keine Versionen. Erstellen Sie eine neue Version um den Feed zu deployen
+    notDeployable: Feed-Quelle nicht deploybar. Ändern Sie die Feed-Quelle-Einstellungen.
+    openInEditor: Im Editor öffnen
+    upload: Hochladen
+    uploadFeed: Feed hochladen
+    view: Öffentliche Seite ansehen
+  FeedFetchFrequency:
+    DAYS: Tage
+    HOURS: Stunden
+    MINUTES: Minuten
+    fetchFeedEvery: Feed-Abruf alle
+  FeedInfo:
+    autoFetch: Automatischer Abruf
+    autoPublish: Automatische Veröffentlichung
+    dateFormat: DD.MM.YYYY
+    deployable: Deploybar
+    edit: Bearbeiten
+    lastUpdatedDate: Zuletzt aktualisiert am %date%
+    noUpdates: Keine Aktualisierungen
+    private: Privat
+    public: Öffentlich
+  FeedInfoPanel:
+    add: '%id% hinzufügen'
+    backToFeedSource: Zurück zur Feed-Quelle
+    backToProject: Zurück zum Projekt
+    editingFeed: '%feed% bearbeiten'
+    noSnapshot: Keine Schnappschüsse erstellt
+    restoreSnapshot:
+      body: Sind Sie sicher, dass Sie diesen Schnappschuss wiederherstellen möchten?
+      title: '%key% wiederherstellen?'
+    revert: '%snapshot% wiederherstelllen'
+    takeSnapshot: Schnappschuss erstelllen
+    toolbar:
+      hide: Verberge Werkzeugleiste
+      show: Zeige Werkzeugleiste
+    unnamed: Unbenannt
+    uploadShapefile:
+      body: 'Wählen Sie eine gezippte Shape-Datei zur Darstellung in der Karte. Hinweis:
+        Dies dient nur zur visuellen Unterstützung.'
+      error: Hochgeladene Datei muss gültige zip-Datei sein (.zip).
+      title: Routen-Shapefile hochladen
+  FeedLabel:
+    delete:
+      body: Sind Sie sicher, dass Sie Etikett %name% löschen möchten? Diese Aktion
+        wird das Etikett von allen Feed-Quellen, denen es zugewiesen ist, entfernen.
+      title: Etikett löschen?
+  FeedSourceAttributes:
+    lastUpdated: Aktualisiert
+  FeedSourcePanel:
+    chooseProject:
+    - Projekt auswählen
+    chooseProjectToView: Projekt wählen um Feeds anzusehen
+    createOne: Projekt erstellen.
+    filters:
+      ALL: Alle
+      PRIVATE: Privat
+      PUBLIC: Öffentlich
+      STARRED: Favoriten
+    forFeed: Feeds für
+    noFeedsYet: Noch keine Feeds.
+    search: Suche Feeds
+    unnamed: unbenannt
+  FeedSourceSettings:
+    autoPublish: Auto-Veröffentlichung
+    feedTransformations: Feed-Transformationen
+    general: Allgemein
+    noPermission: Sie verfügen nicht über die notwendigen Berechtigungen um Eigenschaften
+      dieser Feed-Quelle zu bearbeiten.
+    properties: Eigenschaften
+    warning: Achtung!
+  FeedSourceTable:
+    comparisonColumn:
+      DEPLOYED: Deployte Version
+      PUBLISHED: Veröffentlichte Version
+    createFirst: Erste Feed-Quelle erstellen!
+    datesValid: Gültigkeits-Zeitraum
+    feedInfo: Feed Info
+    issues: Fehler
+    latestVersion: Aktuellste Version
+    status: Status
+  FeedSourceTableRow:
+    dateFormat: DD.MM.YYYY
+    delete: Löschen
+    expired: Vor %duration% ausgelaufen
+    lastUpdated: Zuletzt aktualsiert vor %lastVersionUpdate%
+    noUpdates: Noch keine Aktualisierungen
+    none: Keine
+    startingIn: Beginnt in %duration%
+    status:
+      active: Aktiv
+      all: Alle
+      expired: Veraltet
+      expiring-within-5-days: Veraltet in 5 Tagen
+      expiring-within-20-days: Veraltet in 20 Tagen
+      feedNotInDeployment: Feed nicht deployed
+      feedNotPublished: Feed nicht veröffentlicht
+      future: Zukunft
+      no-version: Keine Version
+      same-as-deployed: Entspricht deploytem
+      same-as-published: Entspricht veröffentlichtem
+    validFor: Gültig für weitere %duration%
+  FeedSourceViewer:
+    deploy: Deployen
+    edit: GTFS bearbeiten
+    gtfs: GTFS
+    notesTitle: Notizen
+    private: Private Ansicht
+    properties:
+      deployable: Deploybar?
+      name: Name
+      noneSelected: (Nichts ausgewählt)
+      property: Eigenschaft
+      public: Öffentlich?
+      retrievalMethod:
+        fetchedAutomatically: Automatisch abgerufen
+        manuallyUploaded: Manuell hochgeladen
+        producedInHouse: Selbst produziert
+        producedInHouseGtfsPlus: Selbst produziert (GTFS+)
+        regionalMerge: Regionale Zusammenführung
+        servicePeriodMerge: Service -Zeitraum Zusammenführung
+        title: Abruf-Methode
+        versionClone: Version klonen
+      snapshot: Editor Schnappschuss
+      title: Einstellungen
+      value: Wert
+    snapshotsTitle: Schnappschüsse
+    update: Aktualisieren
+    upload: Hochladen
+    versions: Versionen
+    viewPublic: Öffentliche Seite ansehen
+  FeedTransformationDescriptions:
+    DeleteRecordsTransformation:
+      label: Lösche Einträge von %tablePlaceholder%
+      name: Lösche Datensatz-Transformation
+    NormalizeFieldTransformation:
+      filePlaceholder: Zu normalisierende Datei/Tabelle auswählen
+      label: Feld normalisieren
+      name: Feld-Normalisierungs-Abbildung
+    ReplaceFileFromStringTransformation:
+      filePlaceholder: Zu ersetzende Datei/Tabelle auswählen
+      label: Ersetze %tablePlaceholder% durch %filePlaceholder%
+      name: Ersetze Datei von String-Transformation
+    ReplaceFileFromVersionTransformation:
+      filePlaceholder: Zu ersetzende Datei/Tabelle auswählen
+      label: Ersetze %tablePlaceholder% durch %versionPlaceholder%
+      name: Ersetze Datei von Versions-Transformation
+    general:
+      fileDefined: unterhalb des Textes
+      filePlaceholder: '[Datei auswählen]'
+      table: Tabelle
+      tablePlaceholder: '[Tabelle auswählen]'
+      version: Version
+      versionPlaceholder: '[Version auswählen]'
+  FeedVersionNavigator:
+    confirmDelete: Sind Sie sicher, dass sie diese Version endgültig löschen möchten?
+    confirmLoad: Dies wird alle aktiven GTFS Editor Daten dieser Feed-Quelle mit den
+      Daten dieser Version überschreiben. Wenn Sie im Editor ungespeicherte Änderungen
+      behalten möchten, müssen Sie für diese Daten zuerst einen Schnappschuss erstellen.
+      Sind Sie sicher, dass Sie fortfahren möchten?
+    delete: Löschen
+    deployFeed: Feed deployen
+    download: Herunterladen
+    editFeed: Feed bearbeiten
+    feed: Feed
+    fetch: Abrufen
+    fromSnapshot: Von Schnapschuss
+    load: Zur Bearbeitung laden
+    newVersion: Erstelle neue Version
+    next: Nächster
+    of: von
+    previous: Voriger
+    selectFeed: 'Hochzuladenden GTFS-Feed auswählen:'
+    selectVersion: Wählen Sie eine Version umd Zusammenfassung anzuzeigen
+    upload: Hochladen
+    uploadFeed: Feed hochladen
+    version: Version
+    zipWarning: Hochgeladene Datei muss gültige Zip-Datei sein (.zip).
+  FeedVersionTabs:
+    agencyCount: Betreiber-Anzahl
+    daysActive: aktive Tage
+    routeCount: Routen-Anzahl
+    stopCount: Haltestellen-Anzahl
+    stopTimesCount: Abfahrtszeiten-Anzahl
+    tripCount: Trip-Anzahl
+    validDates: Gültige Daten
+  FeedVersionViewer:
+    confirmDelete: Sind Sie sicher, dass Sie diese Version löschen möchten? Dies kann
+      nicht rückgängig gemacht werden.
+    confirmLoad: Dies wird alle aktiven GTFS Editor Daten dieser Feed-Quelle mit den
+      Daten dieser Version überschreiben. Wenn Sie im Editor ungespeicherte Änderungen
+      behalten möchten, müssen Sie für diese Daten zuerst einen Schnappschuss erstellen.
+      Sind Sie sicher, dass Sie fortfahren möchten?
+    delete: Löschen
+    download: Herunterladen
+    feed: Feed
+    load: Laden
+    noVersionsExist: Für diese Feed-Quelle existieren keine Versionen.
+    status: Status
+    timestamp: Datei Zeitstempel
+    version: Version
+  FormInput:
+    buildConfig:
+      elevationBucket:
+        accessKey: Zugriffs-Schlüssel (access)
+        bucketName: S3 Bucket Name
+        secretKey: Geheim-Schlüssel (secret)
+      fares: Tarife
+      fetchElevationUS: Höheninformation abrufen
+      stationTransfers: Umstiege
+      subwayAccessTime: Zeitaufschlag U-Bahn-Zugang
+      title: Graph-Bau-Konfiguration
+    deployment:
+      osm:
+        bounds: Benutzerdefinierte Extrakt-Grenzen
+        custom: Benutze benutzerdefinierte Extrakt-Grenzen
+        gtfs: Benutze GTFS-abgeleitete Extrakt-Grenzen
+        title: OSM Extrakt
+      title: Deployment
+    otpServers:
+      $index:
+        admin: Nur Admin-Zugriff?
+        delete: Entfernen
+        ec2Info:
+          amiId: AMI ID
+          buildAmiId: Graphbau AMI ID
+          buildImageDescription: Neue Image-Beschreibung
+          buildImageName: Neuer Image-Name
+          buildInstanceType: Graph build instance type
+          iamInstanceProfileArn: IAM Instanz Profil ARN
+          instanceCount: Instanz-Anzahl
+          instanceType: Instanztyp
+          keyName: Name Schlüsseldatei
+          recreateBuildImage: Build-Image nach Graphbau eu erstellen?
+          region: Name der Region
+          securityGroupId: ID der Sicherheitsgrupp
+          subnetId: Subnetz ID
+          targetGroupArn: Zielgruppen ARN (Load-Aalancer)
+        internalUrl: Interne URLs
+        name: Name
+        namePlaceholder: Produktion
+        publicUrl: Öffentliche URL
+        role: AWS Rolle
+        s3Bucket: S3 Bucket-Name
+        serverPlaceholder: Server-Name
+        title: Server
+    routerConfig:
+      brandingUrlRoot: Branding Wurzel-URL
+      carDropoffTime: Zeitaufschlag PKW abstellen
+      numItineraries: '# Reisevorschläge'
+      requestLogFile: Log-Datei anfordern
+      stairsReluctance: Treppen-Abneigung
+      title: Router Konfiguration
+      updaters:
+        $index:
+          defaultAgencyId: Standard-Betreiber-ID
+          frequencySec: Frequenz (in Sekunden)
+          sourceType: Quell-Type
+          type: Typ
+          url: URL
+        new: Updater hinzufügen
+        placeholder: Updater name
+        title: Real-time Updater
+      walkSpeed: Geh-Geschwindigkeit
+  GeneralSettings:
+    autoFetch:
+      checkbox: Feed-Quelle automatisch abrufen
+      hint: Aktiviert den automatischen Feed-Abruf. (Feed-Quelle-URL must angegeben
+        sein und Projekteinstellung Automatischer Abruf muss aktiviert sein.)
+      title: Automatischer Abruf
+      url: Feed-Quelle Abruf-URL
+      urlButton: URL ändern
+    confirmDelete: Sind Sie sicher, dass Sie dieses Projekt löschen möchten? Diese
+      Aktion kan nicht rückgängig gemacht werden und alle Feed-Quellen und ihre Versionen
+      werden dauerhaft gelöscht.
+    dangerZone: Gefahrenzone
+    deleteFeedSource: Feed-Quelle löschen
+    deleteFeedSourceDesc: Diese Feed-Quelle löschen.
+    deleteFeedSourceHint: Wenn Sie eine Feed-Quelle löschen, kann diese nicht wiederhergestellt
+      werden.
+    deleteProject: Projekt löschen?
+    deployment:
+      buildConfig:
+        elevationBucket:
+          accessKey: Zugriffs-Schlüssel (access)
+          bucketName: S3 Bucket Name
+          secretKey: Geheim-Schlüssel (secret)
+        fares: Tarife
+        fetchElevationUS: Höheninformation abrufen
+        stationTransfers: Umstiege
+        subwayAccessTime: Zeitaufschlag U-Bahn-Zugang
+        title: Graph-Bau-Konfiguration
+      osm:
+        bounds: Benutzerdefinierte Extrakt-Grenzen
+        custom: Benutze benutzerdefinierte Extrakt-Grenzen
+        gtfs: Benutze GTFS-abgeleitete Extrakt-Grenzen
+        title: OSM Extrakt
+      otpServers:
+        $index:
+          admin: Nur Admin-Zugriff?
+          delete: Entfernen
+          internalUrl: Interne URLs
+          name: Name
+          namePlaceholder: Produktion
+          publicUrl: Öffentliche URL
+          s3Bucket: S3 Bucket-Name
+        new: Server hinzufügen
+        serverPlaceholder: Server-Name
+        title: Server
+      routerConfig:
+        brandingUrlRoot: Branding Wurzel-URL
+        carDropoffTime: PKW-Abstell-Zeit
+        numItineraries: '# of Reisevorschläge'
+        requestLogFile: Log-Datei anfordern
+        stairsReluctance: Treppen-Abneigung
+        title: Router Konfiguration
+        updaters:
+          $index:
+            defaultAgencyId: Standard-Betreiber-ID
+            frequencySec: Frequenz (in Sekunden)
+            sourceType: Quell-Type
+            type: Type
+            url: URL
+          new: Updater hinzufügen
+          placeholder: Updater-Name
+          title: Real-time Updater
+        walkSpeed: Geh-Geschwindigkeit
+      title: Deployment
+    feedSourceName: Feed-Quellen-Name
+    general:
+      location:
+        boundingBox: Geographische Grenzen (W,S,E,N)
+        defaultLanguage: Standard-Sprache
+        defaultLocation: Standard-Örtlichkeit (Breitengrad, Längengrad)
+        defaultTimeZone: Standard-Zeitzone
+        title: Örtlichkeit
+      name: Projektname
+      title: Allgemein
+      updates:
+        autoFetchFeeds: Feed-Quellen automatisch abrufen?
+        title: Aktualisierungen
+    labels:
+      title: Ettiketten
+    make:
+      private: Privat setzen
+      privateDesc: Setzt diese Feed-Quelle auf Privat.
+      privateState: Diese Feed-Quelle ist aktuell privat.
+      public: Öffentlich setzen
+      publicDesc: Setzt diese Feed-Quelle auf Öffentlich.
+      publicState: Diese Feed-Quelle ist aktuell öffentlich.
+    makeDeployable: Deploybar machen
+    makeDeployableHint: Setzen Sie diese Feed-Quelle auf Deploybar, um Sie zu einer
+      (in den Organisations-Einstellungen definierten) OpenTripPlanner (OTP) Instanz
+      als Teil einer Feed-Quelle oder als einzelen Feed zu deployen.
+    rename: Umbenennen
+    save: Speichern
+    title: Einstellungen
+  GtfsIcons:
+    agency:
+      label: Betreiber
+      title: Betreiber bearbeiten
+    calendar:
+      label: Abfahrtzeiten
+      title: Abfahrtzeiten bearbeiten
+    fare:
+      label: Tarife
+      title: Tarife bearbeiten
+    feedinfo:
+      label: Feed Info
+      title: Feed-Info bearbeiten
+    route:
+      label: Routen
+      title: Routen bearbeiten
+    scheduleExceptions:
+      label: Fahrplan-Ausnahmen
+      title: Fahrplan-Ausnahmen bearbeiten
+    stop:
+      label: Haltestellen
+      title: Haltestellen bearbeiten
+  GtfsValidationExplorer:
+    accessibilityValidation: Erreichbarkeits-Explorer
+    table:
+      count: Anzahl
+      file: Datei
+      issue: Fehler
+      priority: Priorität
+    timeValidation: Zeit-basierte Validierung
+    title: Validierungs-Explorer
+    validationIssues: Validatierungs-Fehler
+  GtfsValidationViewer:
+    explorer: Validierungs-Explorer
+    issues:
+      other: Andere Fehler
+      routes: Routen-Fehler
+      shapes: Streckenverlauf-Fehler
+      stop_times: Abfahrtszeiten-Fehler
+      stops: Haltestellen-Fehler
+      trips: Trip-Fehler
+    noResults: Keine anzuzeigenden Validierungsergebnisse.
+    tips:
+      DATE_NO_SERVICE: Wenn die Linie nicht an Wochenenden verkehrt, können einige
+        oder alle dieser Validierungsergebnisse ignoriert werden. Analog können Feiertage,
+        an denen keine Fahrten verkehren, in dieser Liste erscheinen.
+      FEED_TRAVEL_TIMES_ROUNDED: Dies ist eine übliche Eigenschaft von GTFS-Feeds,
+        die keine sekundengenaue Präzision für Abfahrts- und Ankunftszeite nutzen.
+        Wenn diese Präzision jedoch erwartet wird, könnte beim Feed-Export ein Problem
+        entstehen.
+      MISSING_TABLE: Eine fehlende Pflicht-Tabelle ist ein größeres Problem, das behoben
+        werden muss, bevor die meisten GTFS-Konsumenten diese Daten für Reiseauskünfte
+        oder in anderen Anwendungen nutzen können.
+    title: Validierungs-Fehler
+  HomeProjectDropdown:
+    new: Neues Projekt
+    select: Projekt auswählen
+    view: '%name% ansehen'
+  InfoModal:
+    ok: OK
+  JobMonitor:
+    clearCompleted: Abgeschlossene löschen
+    jobs:
+      none: Kein aktiver Job
+      one: Ein aktiver Job
+      some: '%count% aktive Jobs'
+    jobsCompleted: Alle Jobs abgeschlossen
+    serverJobs: Server Jobs
+    waiting: Wartend
+  LabelPanel:
+    labels: Etiketten
+    new: Neues Etikett hinzufügen
+    noLabels: Es gibt keine Etiketten in diesem Projekt.
+  LanguageSelect:
+    placeholder: Sprache wählen...
+  Login:
+    title: Anmelden
+  ManagerHeader:
+    noUpdateYet: keine
+    noUrl: (keine URL)
+    private: Diese Feed-Quelle und all ihre Versionen sind privat.
+  ManagerPage:
+    alerts: Alarme
+    changelog: Änderungs-Liste
+    contact: Kontakt
+    copyright: Copyright
+    datatools: Data Tools
+    guide: Leitfaden
+    home: Startseite
+  MapModal:
+    cancel: Cancel
+    ok: OK
+  MergeFeedsResult:
+    CHECK_STOP_TIMES: Einige Trip IDs wurden in beiden Quell-Feeds gefunden. Der zusammengeführte
+      Feed wurde erfolgreich erstellt.
+    DEFAULT: Trip IDs waren in den Quell-Feeds eindeutig. Der zusammengeführte Feed
+      wurde erfolgreich erstellt.
+    body:
+      failure: Zusammenführung mit %errorCount% Fehlern fehlgeschlagen.
+      success: Zusammenführung erfolgreich durchgeführt. Eine neue Version mit dem
+        Ergebnios-Feed wird verarbeitet/validiert.
+    remappedIds: 'Abgebildete IDs: %remappedIdCount%'
+    skipped: 'Übersprungene Datensätze:'
+    skippedTableRecords: '%table%: %skippedCount%'
+    strategyUsed: 'Benutzte Strategie: %strategy%'
+    title:
+      failure: 'Warnung: Während der Feed-Zusammenführung sind Fehler aufgetreten!'
+      success: Feed-Zusammeführung war erfolgreich!
+    tripIdsToCheck: 'Zu prüfende Trip IDs: %tripIdCount%'
+  NormalizeField:
+    issues:
+      fieldUndefined: Zu normalisierendes Feld muss angegeben werden.
+      substitutionInvalid: Substitutions-Muster ungültig.
+      substitutionUndefined: Substitution-Muster müssen angegeben werden.
+  NormalizeStopTimesTip:
+    info: 'Tipp: Wenn Sie Reisezeiten ändern, erwägen Sie die Benutzung des "Stop
+      times normalisieren"-Buttons oberhalb, um automatisch alle Stop Times auf die
+      aktualisierte Reisezeit anzupassen.'
+  NoteForm:
+    adminOnly: Nur für Admins?
+    new: Senden
+    postComment: Neuen Kommentar absenden
+  NotesViewer:
+    adminOnly: Diese Nachricht ist nur für Administratoren sichtbar.
+    all: Alle Kommentare
+    feedSource: Feed-Quelle
+    feedVersion: Version
+    none: Keine Kommentare.
+    refresh: Aktualisieren
+    title: Kommentare
+  OrganizationList:
+    create: Organisation erstellen
+    missingName: Sie müssen einen Namen für die Organisations angeben.
+    new: Organisation anlegen
+    search: Organisation suchen
+  OrganizationSettings:
+    extensions: Erweiterungen
+    logoUrl:
+      label: Logo URL
+      placeholder: http://example.com/logo_30x30.png
+    name:
+      label: Name
+      placeholder: Big City Transit
+    orgDetails: Organisations-Details
+    projects: Projekte
+    subDetails: Subskriptions-Details
+    subscriptionBeginDate: Subskription beginnt
+    subscriptionEndDate: Subskription endet
+    usageTier:
+      high: Hoch
+      low: Niedrig
+      medium: Mittel
+      title: Nutzungsstufe
+  PageNotFound:
+    homePage: Startseite
+    pageNotFound: Seite nicht gefunden.
+  Permissions:
+    approve-alert: GTFS-RT Alerts freigeben
+    approve-gtfs: GTFS Feeds freigeben
+    edit-alert: GTFS-RT Alerts bearbeiten
+    edit-gtfs: GTFS Feeds bearbeiten
+    manage-feed: Feed-Konfiguration verwalten
+  ProjectAccessSettings:
+    admin: Admin
+    cannotFetchFeeds: Feeds nicht abrufbar
+    custom: Benutzerdefiniert
+    feeds: Feed-Quellen
+    noAccess: Kein Zugriff
+    permissions: Berechtigungen
+    title: Projekt-Einstellungen für
+  ProjectFeedListToolbar:
+    actions: Aktionen
+    all: alle
+    any: mind. einer
+    comparison:
+      DEPLOYED: deployter
+      LATEST: aktuellster
+      PUBLISHED: veröffentlichter
+    deployedVersion: 'Deployte Version:'
+    deployments: Deployments
+    downloadCsv: Zusammenfassung als CSV herunterladen
+    feeds:
+      createFirst: Erste Feed-Quelle erstellen!
+      new: Neu
+      search: Suche nach Name
+      table:
+        deployable: Deploybar?
+        errorCount: Fehler
+        lastUpdated: Aktualisiert
+        name: Name
+        public: Öffentlich?
+        retrievalMethod: Abruf-Methode
+        validRange: Gültigkeits-Zeitraum
+      title: Feed-Quellem
+      update: Alle abrufen
+    filter:
+      active: Aktiv
+      all: Alle
+      expired: Abgelaufen
+      expiring: Ablaufend
+      future: Zukünftig
+    filterByLabels: Filtere Feeds nach Label
+    filterFeedSources: Filtere Feed-Quellen nach
+    hasDeployedVersion: Hat deployete Version?
+    hasLatestVersion: Hat aktuellste Version?
+    hasPublishedVersion: Hat veröffentlichte Version?
+    isPublic: Ist Öffentlich
+    labelEndDate: '%labelPrefix% End-Datum'
+    labelNumberIssues: '%labelPrefix% Anzahl Fehler'
+    labelNumberRoutes: '%labelPrefix% Anzahl Routen'
+    labelNumberStopTimes: '%labelPrefix% Anzahl Abfahrtszeiten'
+    labelNumberStops: '%labelPrefix% Anzahl  Haltestellen'
+    labelNumberTrips: '%labelPrefix% Anzahl Trips'
+    labelStartDate: '%labelPrefix% Start-Datum'
+    lastFetched: Zeitpunkt des letzten Datenabrufs des Feeds von URL
+    lastUpdated: Zuletzt aktualisiert
+    latestValidation:
+      endDate: 'Aktuellste Version: End-Datum'
+      errorCount: 'Aktuellste Version: Anzahl Fehler'
+      routeCount: 'Aktuellste Version: Anzahl Routen'
+      startDate: 'Aktuellste Version: Start-Datum'
+      stopCount: 'Aktuellste Version: Anzahl Haltestellen'
+      stopTimesCount: 'Aktuellste Version: Anzahl Abfahrtszeiten'
+      tripCount: 'Aktuellste Version: Anzahl Trips'
+    makePublic: Öffentliche Feeds veröffentlichen
+    mergeFeeds: Alle Zusammenführen
+    name: Name
+    noteSorting: 'Hinweis: Sortieren ist nur anhand der jeweils aktuellste Feed-Version
+      möglich'
+    ofTheLabels: 'der Labels:'
+    publishedVersion: 'Veröffentlichte Version:'
+    settings: Einstellungen
+    showFeedsWith: Zeige Feeds mit
+    sort:
+      alphabetically:
+        asc: A-Z
+        desc: Z-A
+        title: Alphabetisch
+      endDate:
+        asc: Frühest-Spätest
+        desc: Spätest-Frühest
+        title: Auslauf-Datum
+      lastUpdated:
+        asc: Veraltet-Aktuell
+        desc: Aktuell-Veraltet
+        title: Letzte Aktualisierung
+      numErrors:
+        asc: Wenigste-Meiste
+        desc: Meiste-Wenigste
+        title: Anzahl Auffälligkeiten
+      startDate:
+        asc: Frühest-Spätest
+        desc: Spätest-Frühest
+        title: Start-Datum
+    sortBy: Sortiere nach
+    sync:
+      mtc: Sync von MTC
+      transitfeeds: Sync von transitfeeds
+      transitland: Sync von transit.land
+    url: Feed-Abruf URL
+    version: Version
+  ProjectSettings:
+    deployment:
+      buildConfig:
+        elevationBucket:
+          accessKey: Zugriffs-Schlüssel (access)
+          bucketName: S3 Bucket Name
+          secretKey: Geheim-Schlüssel (secret)
+        fares: Tarife
+        fetchElevationUS: Rufe Geländemodell ab
+        stationTransfers: Umstiege
+        subwayAccessTime: U-Bahn-Zugangszeiten
+        title: Build Konfiguration
+      osm:
+        bounds: Benutzerdefinierte Extraktions-Grenzen
+        custom: Benutzerdefinierte Extraktions-Grenzen verwenden
+        gtfs: Benutzerdefinierte Extraktions-Grenzen verwenden
+        title: OSM Extrakt
+      otpServers:
+        $index:
+          admin: Nur Admin-Zugriff?
+          delete: Entfernen
+          internalUrl: Interne URLs
+          name: Name
+          namePlaceholder: Produktion
+          publicUrl: Öffentliche URL
+          r5: R5 Server?
+          s3Bucket: S3 Bucket Name
+          targetGroupArn: Zielgruppen ARN
+        new: Server hinzufügen
+        serverPlaceholder: Server-Name
+        title: Server
+      routerConfig:
+        brandingUrlRoot: Branding-URL Wurzel
+        carDropoffTime: PKW-Abstell-Zeit
+        numItineraries: '# Reisevorschläge'
+        requestLogFile: Log-Datei anfordern
+        stairsReluctance: Treppen-Vermeidung
+        title: Router Konfiguration
+        updaters:
+          $index:
+            defaultAgencyId: Default Betreiber-ID
+            frequencySec: Frequenz (in Sekunden)
+            sourceType: Quellen-Typ
+            type: Typ
+            url: URL
+          new: Updater hinzufügen
+          placeholder: Updater-Name
+          title: Real-time Updater
+        walkSpeed: Lauf-Geschwindigkeit
+      title: Deployment
+    project:
+      cannotFetchFeeds: Feeds können nicht abgerufen werden
+      feeds: Feeds
+      permissions: Berechtigungen
+    rename: Umbennenen
+    save: Speichern
+    title: Einstellungen
+  ProjectSettingsForm:
+    cancel: Abbrechen
+    confirmDelete: Sind Sie sicher, dass Sie dieses Projekt löschen möchten? Diese
+      Aktion kan nicht rückgängig gemacht werden und alle Feed-Quellen und ihre Versionen
+      werden dauerhaft gelöscht.
+    dangerZone: Gefarenzone
+    deleteProject: Projekt löschen?
+    deleteProjectAction: Projekt löschen
+    deleteThisProject: Dieses Projekt löschen.
+    deleteWarning: Wenn Sie ein Projekt löschen, kann das Projekt und all seine Feed-Quellen
+      nicht wieder hergestellt werden.
+    fields:
+      localPlacesIndex:
+        title: Adress-Index
+        webhookUrl: Webhook URL
+      location:
+        boundingBox: Gebiets-Grenzen (W,S,E,N)
+        boundingBoxPlaceHolder: min_lon, min_lat, max_lon, max_lat
+        defaultLanguage: Standard-Sprache
+        defaultLocation: Standard-Ort (lat, lng)
+        defaultTimeZone: Standard-Zeitzone
+        title: Bereich
+      name: Projektname
+      title: Allgemein
+      updates:
+        autoFetchFeeds: Feed-Quelle automatisch abrufen?
+        title: Aktualisierungen
+    noPermissions: Sie haben keine Bearbeitungs-Rechte für die Eigenschaften dieser
+      Feed-Quelle.
+    required: Erforderlich.
+    save: Speichern
+    selectBounds: Wähle Projekt-Grenzen
+    selectBoundsHint: Spiegele Karte vor
+    title: Einstellungen
+    warning: Warnung!
+  ProjectSummaryPanel:
+    hoursPerWeekday: Stunden pro Wochentag
+    numberOfFeeds: 'Anzahl Feeds:'
+    summary: Zusammenfassung
+    totalErrors: 'Anzahl Fehler:'
+    totalService: 'Anzahl Services:'
+  ProjectViewer:
+    autoFetchDisabled: Automatischer Abruf deaktiviert
+    deployments: Deployments
+    feedSourceDesc: Eine Feed-Quelle defininert den Veröffentlichungsort eines GTFS-Feeds.
+      GTFS kann durch automatischen Abruf, direktes Bearbeiten, oder das manuelle
+      Hochladen einer GTFS-Zip-Datei befüllt werden.
+    feedSourceTitle: Was ist eine Feed-Quelle?
+    feeds:
+      createFirst: Erste Feed-Quelle erstellen!
+      new: Neue Feed Quelle
+      search: Suchen nach Name
+      table:
+        deployable: Deploybar?
+        errorCount: Fehler
+        lastUpdated: Aktualisiert
+        name: Name
+        public: Öffentlich?
+        retrievalMethod: Abruf-Method
+        validRange: Gültiger Bereich
+      title: Feed Quellen
+      update: Alle abrufen
+    here: hier
+    makePublic: Öffentliche Feeds publizieren
+    mergeFeeds: Alle zusammeführen
+    noProjectFound: Keine Projekte gefunden für
+    note: 'Hinweis:'
+    publicViewed: Öffentliche Feed-Seite ist sichtbar
+    returnToProjects: Zurück zur Projektliste
+    settings: Einstellungen
+  ProjectsList:
+    createFirst: Erstelle mein erstes Projekt
+    help:
+      content: Ein Projekt dient dazu, GTFS-Feeds zu gruppieren. Zum Beispiel können
+        die Feeds eines Projekts alle zur gleichen Region gehören oder sie definieren
+        zusammen ein Planungs-Szenario.
+      title: Was ist ein Projekt?
+    new: Neues Projekt
+    noProjects: Sie haben derzeit noch keine Projekte.
+    search: Suche nach Projektname
+    table:
+      name: Projektname
+    title: Projekte
+  PublicFeedsTable:
+    country: Ablaufend
+    lastUpdated: Letzte Aktualisierung
+    link: Link zum GTFS
+    name: Feed-Name
+    region: Region
+    search: Suche
+    stateProvince: Staat oder Bundesland
+  PublicFeedsViewer:
+    title: Katalog
+  PublicLandingPage:
+    appLogo: Applikations-Logo
+    copyright: Copyright
+    existingUsers: Existiende Nutzer
+    here: hier
+    learnMore: Erfahre mehr über Daten-Werkzeuge
+    signInHere: hier anmelden
+    viewDashboard: Dashboard ansehen
+  RegionSearch:
+    placeholder: Suche nach Regionen oder Unternehmen
+  ResultTable:
+    affectedIds: Betroffene ID(s)
+    description: Beschreibung
+    line: Linie
+    priority: Priorität
+    problemType: Problemtyp
+  RetiredJob:
+    bug: Oh nein! Es sieht so aus, als wäre ein Fehler aufgetreten.
+    support: Um einen Fehlerbericht einzusenden, übermitteln Sie bitte einen Screenshot
+      ihres Browser-Fensters, de folgenden Text (aktuelle URL and Fehler-Details),
+      und eine detailierte Beschreibung der Schritte, die Sie zuvor ausgeführt haben
+      an <a href='mailto:%supportEmail%'>%supportEmail%</a>.
+    view: Ansehen
+  SelectFileModal:
+    cancel: Abbrechen
+    ok: OK
+  ServerSettings:
+    awsSetup: Anleitungen um OTP Deployment Server auf AWS aufzusetzen
+    confirmDelete: Sind Sie sicher, dass Sie diesen Server-Eintrag löschen möchten?
+    confirmTermination: 'Sind Sie sicher, dass Sie %count% Instanz(en) beenden möchten?\n\n
+      ACHTUNG: Dies wird OTP Dienste aller auf diesem Server gestarteten Deployments
+      beenden.'
+    deployment:
+      otpServers:
+        new: Server hinzufügen
+        refresh: Aktualisieren
+        serverPlaceholder: Servername
+        title: Deployment Server Verwaltung
+    instructions: Anleitungen
+    noServers: Keine Server angelegt
+    save: Speichern
+    title: Einstellungen
+  ServerSpecialFields:
+    confirmTermination: Sind Sie sicher, dass Sie diese EC2-Instanz beenden möchten?
+      Diese Aktion kann nicht rückgängig gemacht werden und entfernt diese Instanz
+      aus dem Load Balancer.
+    noEC2Instances: Keine mit diesem Server assoziierten EC2-Instanzen.
+    projectSpecific: Project spezifisch?
+    projectSpecificPlaceholder: Weisen Sie ein Projekt zu oder lassen Sie es das Feld
+      leer für beliebige Projekte
+    terminateEC2: EC2-Instanzen beenden
+    useELB: Elastic Load Balancer (ELB) verwenden?
+  ShowAllRoutesOnMapFilter:
+    fetching: Abruf läuft...
+    showAllRoutesOnMap: Zeige alle Routen
+    tooManyShapeRecords: große shapes.txt können Performance beeinträchtigen
+  Sidebar:
+    about: Über diese Applikation
+    account: Konto
+    serverJobs: Server Jobs
+    serverVersion: 'Server Version:'
+    settings: Einstellungen
+    uiDeployedAt: 'UI deployed:'
+    uiVersion: 'UI Version:'
+    unknown: Unbekannt
+  SnapshotItem:
+    active: Aktiv
+    confirmDelete: Dies wird den Schnappschuss dauerhaft löschen. Alle damit gespeicherten
+      Date können nicht wiederhergestellt werden. Sind Sie sicher, dass Sie fortfahren
+      möchten?
+    confirmLoad: Dies wird alle aktiven GTFS Editor Daten dieser Feed-Quelle mit den
+      Daten dieser Version überschreiben. Wenn Sie im Editor ungespeicherte Änderungen
+      behalten möchten, müssen Sie für diese Daten zuerst einen Schnappschuss erstellen.
+      Sind Sie sicher, dass Sie fortfahren möchten?
+    createFromScratch: Erstelle leeres GTFS
+    created: erstellt
+    date: Datum
+    delete: Löschen
+    download: Herunterladen
+    feed: Feed
+    load: Zur Bearbeitung laden
+    loadLatest: Lade aktuellste Version zur Bearbeitung
+    name: Name
+    noVersions: (Keine Versionen)
+    noVersionsExist: Für diese Feed-Quelle existieren noch keine Versionen.
+    of: von
+    publish: Veröffentlichen
+    restore: Wiederherstellen
+    snapshot: Schnappschuss
+    title: Schnappschüsse
+    version: Version
+  StarButton:
+    star: Favorisieren
+    unstar: Favorisieren aufheben
+  Status:
+    CREATED_SNAPSHOT:
+      body: Neuer Schnappschuss "%payload%" erstellt. Er wird vom "Schnappschüsse"
+        Reiter in der Feed-Quelle-Seite aus zugänglich sein.
+      title: Schnappschuss erstellt
+    CREATING_SNAPSHOT: Erstelle Schnappschuss...
+    DELETING_AGENCY: Lösche Betreiber...
+    DELETING_FEEDVERSION: Lösche Feed-Version...
+    DELETING_SNAPSHOT: Lösche Schnappschuss...
+    DELETING_TRIPS_FOR_CALENDAR: Lösche Trips...
+    FETCHING_ALL_JOBS: Rufe Jobs ab...
+    LOADING_FEEDVERSION_FOR_EDITING: Lade Version in Editor...
+    PUBLISHING_GTFSPLUS_FEED: Veröffentlichte GTFS+ Feed...
+    RENAMING_FEEDVERSION: Benenne Feed-Version um...
+    REQUEST_RTD_ALERTS: Lade Alerts...
+    REQUESTING_AGENCIES: Lade Betreiber...
+    REQUESTING_DEPLOYMENT: Lade Deployment...
+    REQUESTING_DEPLOYMENTS: Lade Deployments...
+    REQUESTING_FEEDSOURCE: Lade Feed...
+    REQUESTING_FEEDSOURCES: Lade Feeds...
+    REQUESTING_FEEDVERSION_ISOCHRONES: Berechne Zugangszeiten...
+    REQUESTING_FEEDVERSIONS: Lade Feed-Versionen...
+    REQUESTING_GTFSEDITOR_SNAPSHOTS: Lade Schnappschuss...
+    REQUESTING_GTFSPLUS_CONTENT: Lade GTFS+ Daten...
+    REQUESTING_NOTES: Lade Kommentare...
+    REQUESTING_ORGANIZATIONS: Lade Organisationen...
+    REQUESTING_PROJECT: Lade Projekt...
+    REQUESTING_PROJECTS: Lade Projekte...
+    REQUESTING_PUBLIC_FEEDS: Lade öffentliche Feeds...
+    REQUESTING_ROUTES: Lade Routes...
+    REQUESTING_STOPS: Lade Haltestellen...
+    REQUESTING_SYNC: Synchronisiere Feeds...
+    REQUESTING_TRIPS_FOR_CALENDAR: Lade Trips...
+    REQUESTING_USERS: Lade Nutzer...
+    REQUESTING_VALIDATION_ISSUE_COUNT: Lade Validatierungs-Ergebnisse...
+    RESTORING_SNAPSHOT: Stelle Schnappschuss wieder her...
+    RUNNING_FETCH_FEED_FOR_PROJECT: Aktualisiere Feeds für Projekt...
+    SAVING_AGENCY: Speichere Betreiber...
+    SAVING_DEPLOYMENT: Speichere Deployment...
+    SAVING_FEEDSOURCE: Speichere Feed...
+    SAVING_PROJECT: Speichere Projekt...
+    SAVING_ROUTE: Speichere Route...
+    SAVING_STOP: Speichere Haltestelle...
+    UPDATING_SERVER: Speichere Server...
+    UPDATING_USER_DATA: Aktualisiere Nutzerkonto...
+    UPLOADING_FEED: Lade Feed hoch...
+    UPLOADING_GTFSPLUS_FEED: Speichere GTFS+ Daten...
+    VALIDATING_GTFSPLUS_FEED: Aktualisiere GTFS+ Validierung...
+  StatusModal:
+    close: Schließen
+    login: Anmelden
+    reload: Seite neu laden
+    relock: Feed zur Bearbeitung sperren
+    relockingFailed:
+      body: Erneutes Sperren ist nur erlaubt, wenn eine andere Bearbeitung-Sitzung
+        durch Sie im Gange ist (nicht für andere Nutzende). Sie können es später erneut
+        versuchen, oder den/die aktuelle Bearbeiter*in kontaktieren, dass sie die
+        Sitzung beendet.
+      title: Versuch, Bearbeitung zu übernehmen, ist fehlgeschlagen!
+  TimetableEditor:
+    choosePattern: Trip-Muster auswählen.
+    createNew: Erstelle neues
+    deleteSelectedTrip: Sind Sie sicher, dass Sie den ausgewählten Trip permanent
+      lösche möchten?
+    deleteSelectedTrips: Sind Sie sicher, dass Sie die %count% ausgewählten Trips
+      permanent lösche möchten?
+    deleteTrips: Lösche Trips
+    deleteTripsQuestion: Trips löschen?
+  TimetableHelpModal:
+    close: Schließen
+    pressQuestionmark: Drücken Sie <kbd>?</kbd> um Tastatur-Shortcuts anzusehen
+    shortcuts:
+      modify:
+        desc:
+        - Lösche ausgewählte Trip(s)
+        - Neuer Trip
+        - Klone ausgewählte(n) Trip(s)
+        - Wert von benachbarter Zelle (links) übernehmen
+        - Wert von Zelle oberhalb übernehmen
+        title: Ändere Trips
+      navigate:
+        desc:
+        - Voriger/nächter Trip
+        - Voorige/nächste Spalte
+        - Wähle Trip
+        - Alle Trips auswählen
+        - Alle Trips abwählen
+        title: Navigatieren und Trips auswählen
+      offset:
+        desc:
+        - Verschiebe Abfahrtszeiten des ausgewählten Trips durch Addieren eines Zeitversatzes
+        - Verschiebe Abfahrtszeiten des ausgewählten Trips durch Subtrahieren eines
+          Zeitversatzes
+        - Verschiebe nur Zeit der aktiven Zelle durch Addieren eines Zeitversatzes
+        - Verschiebe nur Zeit der aktiven Zelle durch Subtrahieren eines Zeitversatzes
+        - Reduziere Zeitversatz um 1 Minute
+        - Reduziere Zeitversatz um 10 Minuten
+        - Erhöhe Zeitversatz um 1 Minute
+        - Erhöhe Zeitversatz um 10 Minuten
+        title: Zeiten verschieben
+    title: Abfahrtszeiten-Editor Tastatur-Shortcuts
+  TimezoneSelect:
+    placeholder: Zeitzone auswählen...
+  UserAccount:
+    account:
+      title: Konto
+    billing:
+      title: Rechnung
+    notifications:
+      methods: Benachrichtigungs-Methoden
+      subscriptions: Ihre Subskriptionen
+      title: Benachrichtigungen
+      unsubscribeAll: Von allen abmelden
+    organizationSettings: Organisations-Einstellungen
+    organizations:
+      title: Organisationen
+    personalSettings: Persönliche Einstellungen
+    profile:
+      profileInformation: Profil-Information
+      title: Profil
+    title: Meine Einstellungen
+  UserAccountInfoPanel:
+    hello: Hallo
+    profile: Profil
+    roles:
+      applicationAdmin: Applikations-Admin
+      organizationAdmin: Organisations-Admin
+      standardUser: Standard-Nutzer*in
+  UserButtons:
+    admin: Verwaltung
+    logout: Abmelden
+    myAccount: Mein Konto
+  UserHomePage:
+    createFirst: Erstelle mein erstes Projekt
+    help:
+      content: Ein Projekt dient dazu, GTFS-Feeds zu gruppieren. Zum Beispiel können
+        die Feeds eines Projekts alle zur gleichen Region gehören oder sie definieren
+        zusammen ein Planungs-Szenario.
+      title: Was ist ein Projekt?
+    new: Neues Projekt
+    noProjects: Sie haben derzeit noch keine Projekte.
+    recentActivity: Letzte Aktivitäten
+    recentActivityNone: Keine aktuellen Aktivitäten für Ihre Subskriptionen.
+    table:
+      name: Projekt Name
+    title: Projekte
+    userDocs: Benutzungs-Dokumentation
+    welcomeTo: Willkommen zu
+  UserList:
+    filterByOrg: Filtere nach Org.
+    noResults: (Keine anzuzeigenden Ergebnisse)
+    of: von
+    perPage: Konten pro Seite
+    search: Suche nach Kontoname
+    showing: Angezeigt werden Nutzer*innen
+    title: Nutzer*innen-Verwaltungen
+  UserRow:
+    appAdmin: App-Admin
+    cancel: Abbrechen
+    delete: Löschen
+    deleteConfirm: Sind Sie sicher, dass Sie dieses Konto dauerhaft löschen möchten?
+    edit: Bearbeiten
+    missingProject: unbekannt
+    noProjectsFound: Keine Projekte
+    orgAdmin: Organisation-Admin
+    save: Speichern
+  UserSettings:
+    admin:
+      description: Applikations-Admininistrator*innen haben vollen Zugriff auf alle
+        Projekte.
+      title: Applikations-Admininistrator*in
+    application: Applikations-Einstellungen
+    cancel: Abbrechen
+    delete: Löschen
+    edit: Bearbeiten
+    noProjects: Keine Projekte verfügbar
+    org:
+      admin: Organisations-Administrator*in
+      billing: Rechungsstellung-Admin
+      description: Organisations-Administratoren haben vollen Zugriff auf Projekte
+        dieser Organisation.
+    project:
+      admin: Admin
+      custom: Benutzerdefiniert
+      noAccess: Kein Zugriff
+    save: Speichern
+  VersionButtonToolbar:
+    confirmDelete: Sind Sie sicher, dass sie diese Version endgültig löschen möchten?
+    confirmLoad: Dies wird alle aktiven GTFS Editor Daten dieser Feed-Quelle mit den
+      Daten dieser Version überschreiben. Wenn Sie im Editor ungespeicherte Änderungen
+      behalten möchten, müssen Sie für diese Daten zuerst einen Schnappschuss erstellen.
+      Sind Sie sicher, dass Sie fortfahren möchten?
+    delete: Löschen
+    download: Herunterladen
+    feed: Feed
+    load: Laden
+    noVersionsExist: Für diese Feed-Quelle existieren keine Versionen.
+    status: Status
+    timestamp: Datei-Zeitstempel
+    version: Version
+  VersionComparisonDropdown:
+    compareToVersion: Vergleich mit Version %version%
+    compareVersions: Vergleiche Versionen
+    exit: Vergleichsmodus verlassen
+    loadAnother: Andere Version laden um zu vergleichen
+    selectVersion: Version zum Vergleich auswählen
+  VersionSelectorDropdown:
+    noVersions: Keine Versionen verfügbar
+  WatchButton:
+    emailVerificationConfirm: Um EMail-Benachrichtigungen zu erhalten, müssen Sie
+      zuerst Ihre EMail-Adresse bestätigen. Möchten Sie die Email-Bestätigungs-Nachricht
+      für Ihr Konto erneut versenden lassen?
+    unwatch: Nicht weiter verfolgen.
+    verificationSendError: Beim Versenden der EMail-Überprüfung ist ein Fehler aufgetreten!
+    verificationSent: Bitte prüfen Sie Ihr Posteingangsfach und bestätigen Sie Ihre
+      Email-Adresse durch Klick auf den Bestätigen-Links. Sie müssen dann diese Seite
+      aktualisieren und den 'Verfolgen'-Button klicken, um sich für Benachrichtigungen
+      zu registrieren.
+    watch: Beobachten
+  WrapComponentInAuthStrategy:
+    adminTestFailed: Sie haben versucht, eine eingeschränkt sichtbare Seite aufzurufen,
+      verfügen jedoch nicht über die erforderlichen Rechte.

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -318,7 +318,7 @@ components:
     attributes: Attribute
     feedInfo: Feed Info
     noValidationIssues: Keine Validierungsfehler
-    requiredField: '* kenzeichnet verpflichtendes Feld'
+    requiredField: '* kenzeichnet Pflichtfeld'
     routeDetails: Routen-Details
     rules: Regeln
     saveChanges: Änderungen speicheren

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -389,8 +389,7 @@ components:
   FeedSourceAttributes:
     lastUpdated: Aktualisiert
   FeedSourcePanel:
-    chooseProject:
-    - Projekt auswählen
+    chooseProject: '[Projekt auswählen]'
     chooseProjectToView: Projekt wählen um Feeds anzusehen
     createOne: Projekt erstellen.
     filters:

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1,34 +1,94 @@
 _id: pl
 _name: Polski
 components:
+  Actions:
+    error: Error making %method% request to %url%
+    errorGraphQL: Error fetching GTFS entities via GraphQL
+    errorWithStatus: Error (%status%) making %method% request to %url%
+    networkError: Network error (%status%)!\n\n(%method% request on %url%)
+    noFile: No file to upload!
+  AdminPage:
+    applicationLogs: Application logs
+    backToDashboard: Back to dashboard
+    deploymentServers: Deployment servers
+    noAccess: You do not have sufficient user privileges to access this area.
+    organizations: Organizations
+    title: Administration
+    userManagement: User Management
+  ApplicationStatusView:
+    actions: Actions
+    columns:
+      id: ID
+      name: Name
+      path: Path
+      status: Status
+      time: Time
+      user: User
+    feed:
+      filterByLabels: Filter feeds by labels
+      isPublic: Is Public
+      lastFetched: Last Time Data Fetched from Feed URL
+      lastUpdated: Last Updated
+    lastApiRequests: Last API requests by User
+    lastUpdatedAt: last updated at
+    latestValidation:
+      endDate: 'Latest Version: End Date'
+      errorCount: 'Latest Version: Number of Issues'
+      routeCount: 'Latest Version: Number of Routes'
+      startDate: 'Latest Version: Start Date'
+      stopCount: 'Latest Version: Number of Stops'
+      stopTimesCount: 'Latest Version: Number of Stop Times'
+      tripCount: 'Latest Version: Number of Trips'
+    name: Name
+    noDataText: No active jobs in progress.
+    refresh: Refresh
+    serverJobs: Active Server Jobs
+    sortBy: Sort By
+    unauthenticated: (unauthenticated)
+    url: Feed download URL
+    userLogs: User Authentication Logs
+    viewUserLogs: View user logs on Auth0.com
+  Brand:
+    dataTools: Data Tools
   Breadcrumbs:
     deployments: Wdrożenia
     projects: Projekty
     root: Eksploruj
-  CreateUser:
-    new: Utwórz użytkownika
+  ConfirmModal:
+    cancel: Cancel
+    ok: OK
+  CreateProject:
+    new: Create New Project
   CreateSnapshotModal:
     cancel: Anuluj
-    description: >-
-      Migawki to zapisywanie punktów, na które możesz powrócić do powrotu do
-      Edytowanie paszy GTFS. Do Auto-Publikuj nowy plik GTFS (i proces jako
-      Nowa wersja pliku danych, stwórz migawkę za pomocą opcji poniżej.
+    description: Migawki to zapisywanie punktów, na które możesz powrócić do powrotu
+      do Edytowanie paszy GTFS. Do Auto-Publikuj nowy plik GTFS (i proces jako Nowa
+      wersja pliku danych, stwórz migawkę za pomocą opcji poniżej.
     fields:
-      name:
-        label: Nazwa
-        placeholder: Nazwa migawki (wymagana)
       comment:
         label: Komentarz
         placeholder: Dodatkowe informacje (opcjonalnie)
+      confirmPublishWithUnapproved:
+        label: Potwierdź publikację z niezatwierdzonymi trasami
+      name:
+        label: Nazwa
+        placeholder: Nazwa migawki (wymagana)
       publishNewVersion:
         label: Publikuj migawkę jako nowa wersja pliku
-      confirmPublishWithUnapproved:
-        label: Potwierdź publikację z niezatwierdzonymi trasami 
-    unapprovedRoutesHeader: "Następujące trasy nie są akceptowane:"
-    unapprovedRoutesDesc: "Trasy te nie zostaną uwzględnione w danych wyjściowych:"
     missingNameAlert: Migawce należy nadać prawidłową nazwę!
     ok: OK
     title: Utwórz nową migawkę
+    unapprovedRoutesDesc: 'Trasy te nie zostaną uwzględnione w danych wyjściowych:'
+    unapprovedRoutesHeader: 'Następujące trasy nie są akceptowane:'
+  CreateUser:
+    email:
+      label: Email Address
+      placeholder: Enter email
+    new: Utwórz użytkownika
+    password:
+      label: Password
+      placeholder: Enter password for new user
+    title: Create User
   DatatoolsNavbar:
     account: Moje konto
     alerts: Alerty
@@ -42,20 +102,15 @@ components:
     users: Użytkownicy
   DeploymentConfirmModal:
     alert:
-      alreadyDeployed: >-
-        is already deployed to this server at the same router. (Deploying
+      alreadyDeployed: is already deployed to this server at the same router. (Deploying
         would evict the current graph.)
-      boundsTooLarge: >-
-        Bounds are much too large to successfully deploy to OpenTripPlanner.
+      boundsTooLarge: Bounds are much too large to successfully deploy to OpenTripPlanner.
         Deployment is disabled.
-      expiredFeeds: >-
-        The following feeds have expired (all scheduled trips are for past
-        dates)
-      missingBounds: >-
-        There are no bounds defined for the set of feeds. Deployment is
-        disabled.
-      missingFeeds: >-
-        There are no feeds defined for this deployment. Deployment is
+      expiredFeeds: The following feeds have expired (all scheduled trips are for
+        past dates)
+      missingBounds: There are no bounds defined for the set of feeds. Deployment
+        is disabled.
+      missingFeeds: There are no feeds defined for this deployment. Deployment is
         disabled.
       success: Deployment successfully deployed.
     cancel: Anuluj
@@ -63,15 +118,15 @@ components:
     danger: Uwaga!
     deploy: Wdrożenie
     invalidBounds: Granice są nieprawidłowe!
+    success: Sukces!
     to: do
     warning: Ostrzeżenie!
-    success: Sukces!
   DeploymentConfirmModalAlert:
     danger: Uwaga!
     success: Sukces!
     warning: Ostrzeżenie!
   DeploymentSettings:
-    boundsPlaceholder: "min_lon, min_lat, max_lon, max_lat"
+    boundsPlaceholder: min_lon, min_lat, max_lon, max_lat
     buildConfig:
       elevationBucket:
         accessKey: Access Key
@@ -93,7 +148,7 @@ components:
     routerConfig:
       brandingUrlRoot: Branding URL Root
       carDropoffTime: Car Dropoff Time
-      numItineraries: "# of itineraries"
+      numItineraries: '# of itineraries'
       requestLogFile: Request log file
       stairsReluctance: Stairs Reluctance
       title: Router Config
@@ -105,8 +160,8 @@ components:
           type: Typ
           url: URL
         new: Add updater
-        title: Real-time updaters
         placeholder: Updater name
+        title: Real-time updaters
       walkSpeed: Walk Speed
     save: Zapisz
     title: Wdrożenie
@@ -147,23 +202,21 @@ components:
     search: Search for deployments
     table:
       creationDate: Utworzony
-      lastDeployed: Ostatnio wdrożony
       deployedTo: Wdrożony do
-      feedCount: "# of feeds"
-      testDeployment: Test?
+      feedCount: '# of feeds'
+      lastDeployed: Ostatnio wdrożony
       name: Nazwa
+      testDeployment: Test?
     title: Wdrożenia
   DeploymentsPanel:
     autoDeploy:
       deployWithErrors:
         checklabel: Deploy even if some feed versions have critical errors
-        help: >
-          If this is unchecked, an auto-deployment will halt if any of the
-          feed versions in the deployment have at least one critical error
+        help: |
+          If this is unchecked, an auto-deployment will halt if any of the feed versions in the deployment have at least one critical error
         title: Critical Errors Handling
-      help: >
-        A deployment will automatically be kicked off (assuming there are no
-        critical errors) whenever one of the above-defined events occurs.
+      help: |
+        A deployment will automatically be kicked off (assuming there are no critical errors) whenever one of the above-defined events occurs.
       label: Auto-deploy events
       placeholder: Specify auto-deploy events
       title: Auto-deployment
@@ -171,110 +224,214 @@ components:
         ON_FEED_FETCH: A new version is fetched
         ON_PROCESS_FEED: A new version is processed
     config:
-      body: >
-        Deployments can use project-level configurations (e.g., for build or
-        router config files) or be configured individually.
+      body: |
+        Deployments can use project-level configurations (e.g., for build or router config files) or be configured individually.
       editSettings: Edit deployment settings
       manageServers: Manage deployment servers
       title: Configuring deployments
     delete: Remove deployment
     new: New Deployment
     pinnedDeployment:
-      help: >-
-        Pin a deployment (and deploy to a server at least once) to enable
-        auto-deployment.
+      help: Pin a deployment (and deploy to a server at least once) to enable auto-deployment.
       label: Pinned deployment
       placeholder: Select a deployment to pin
     search: Search for deployments
     table:
       creationDate: Utworzony
-      lastDeployed: Ostatnio wdrożony
       deployedTo: Wdrożony do
-      feedCount: "# kanałów"
-      testDeployment: Test?
+      feedCount: '# kanałów'
+      lastDeployed: Ostatnio wdrożony
       name: Nazwa
+      testDeployment: Test?
     title: Wdrożenia
+  EC2InstanceCard:
+    aws: AWS
+    confirmTermination: Are you sure you want to terminate this EC2 instance? This
+      action cannot be undone and will remove this instance from the load balancer.
+    log: log
+    noPublicIP: No public IP
+    notApplicable: N/A
+    status:
+      booting: Booting up.
+      running: Running as server.
+      terminated: Terminated.
+      terminatedAt: Terminated %moment%
+    terminate: Terminate instance
+    view: View deployment
+  EditableTextField:
+    invalidInput: Must provide a valid input.
+    none: (none)
   EditorFeedSourcePanel:
     active: Aktywny
-    confirmDelete: >-
-      Spowoduje to trwałe usunięcie tego zrzutu. Zapisane tutaj dane nie
-      mogą być odzyskane. Jesteś pewien, że chcesz kontynuować?
-    confirmLoad: >-
-      Spowoduje to zastąpienie wszystkich aktywnych danych edytora GTFS dla
-      tego źródła kanału danymi z tej wersji. Jeśli w Edytorze jest
-      niezapisana praca, którą chcesz zachować, musisz najpierw wykonać
-      zrzut bieżących danych Edytora. Jesteś pewien, że chcesz kontynuować?
-    created: utworzony
+    availableSnapshots: Available snapshots
+    confirmDelete: Spowoduje to trwałe usunięcie tego zrzutu. Zapisane tutaj dane
+      nie mogą być odzyskane. Jesteś pewien, że chcesz kontynuować?
+    confirmLoad: Spowoduje to zastąpienie wszystkich aktywnych danych edytora GTFS
+      dla tego źródła kanału danymi z tej wersji. Jeśli w Edytorze jest niezapisana
+      praca, którą chcesz zachować, musisz najpierw wykonać zrzut bieżących danych
+      Edytora. Jesteś pewien, że chcesz kontynuować?
     createFromScratch: Twórz GTFS od podstaw
+    created: utworzony
     date: Data
     delete: Usuń
     download: Pobierz
+    editFeed: Edit feed
     feed: Kanał
     help:
       body:
-        "0": >-
-          Migawki to punkty zapisu, do których zawsze można wrócić podczas
-          edytowania kanału GTFS.
-        "1": >-
-          Migawka może reprezentować pracę w toku, scenariusz przyszłego
-          planowania lub nawet różne wzorce usług (np. znaczniki
-          harmonogramu letniego).
+        "0": Migawki to punkty zapisu, do których zawsze można wrócić podczas edytowania
+          kanału GTFS.
+        "1": Migawka może reprezentować pracę w toku, scenariusz przyszłego planowania
+          lub nawet różne wzorce usług (np. znaczniki harmonogramu letniego).
       title: Co to są migawki?
     load: Wczytaj do edycji
     loadLatest: Załaduj najnowszy do edycji
     name: Nazwa
-    noSnapshotsExist: >-
-      Obecnie nie istnieją żadne zrzuty tego kanału. Migawki można tworzyć w
-      Edytorze. Kliknij „Edytuj kanał”, aby przejść do trybu edycji.
+    noSnapshotsExist: Obecnie nie istnieją żadne zrzuty tego kanału. Migawki można
+      tworzyć w Edytorze. Kliknij „Edytuj kanał”, aby przejść do trybu edycji.
     noVersions: (Brak wersji)
     noVersionsExist: Brak wersji dla tego źródła kanału.
     of: z
     publish: Publikuj
     restore: Przywróć
     snapshot: migawka
+    snapshotLatest: Take snapshot of latest changes
     title: Migawki
     version: Wersja
+  EditorInput:
+    daysOfService: Days of service
+    dropImage: Drop %activeComponent% image here, or click to select image to upload.
+    optional: (optional)
+    selectAgency: Select agency...
+    selectDate: Please select a date
+    selectOption: -- select an option --
+    uploadAsset: Upload %activeComponent% branding asset
+  EditorSidebar:
+    backToFeed: Back to Feed
+  EntityDetailsHeader:
+    attributes: Attributes
+    feedInfo: Feed Info
+    noValidationIssues: No validation issues
+    requiredField: '* denotes required field'
+    routeDetails: Route details
+    rules: Rules
+    saveChanges: Save changes
+    tripPatterns: Trip patterns
+    undoChanges: Undo changes
+    validationIssues: validation issue(s)
+    zoomTo: Zoom to
+  EntityList:
+    createFirst: Create first
+    createStop: Right-click a location on map to create a new stop
+    editSchedules: Edit schedules
+    name: Name
+  FeedActionsDropdown:
+    delete: Delete
+    deleteFeedSource: Delete Feed Source?
+    deploy: Deploy
+    deployFeed: Deploy feed source.
+    deployNoPermission: You do not have permission to deploy feed
+    fetch: Fetch
+    menu: Menu
+    noVersions: No versions exist. Create new version to deploy feed
+    notDeployable: Feed source is not deployable. Change in feed source settings.
+    openInEditor: Open in Editor
+    upload: Upload
+    uploadFeed: Upload Feed
+    view: View public page
   FeedFetchFrequency:
     DAYS: dni
-    fetchFeedEvery: Pobieraj kanał co
     HOURS: godzin
     MINUTES: minut
-  FeedInfo: # Need to check these translations.
+    fetchFeedEvery: Pobieraj kanał co
+  FeedInfo:
     autoFetch: Automatyczne pobieranie
     autoPublish: Automatycznie publikuj
+    dateFormat: MMM D, YYYY
     deployable: Rozmieszczany
     edit: Edytować
+    lastUpdatedDate: Last updated %date%
+    noUpdates: No updates
     private: Prywatny
     public: Publiczny
   FeedInfoPanel:
+    add: Add %id%
+    backToFeedSource: Back to feed source
+    backToProject: Back to project
+    editingFeed: Editing %feed%
+    noSnapshot: No snapshots created
+    restoreSnapshot:
+      body: Are you sure you want to restore this snapshot?
+      title: Restore %key%?
+    revert: Revert to %snapshot%
+    takeSnapshot: Take snapshot
+    toolbar:
+      hide: Hide toolbar
+      show: Show toolbar
+    unnamed: Unnamed
     uploadShapefile:
-      body: >-
-        Wybierz spakowany plik kształtu do wyświetlenia na mapie. Uwaga:
-        służy tylko jako pomoc wizualna.
+      body: 'Wybierz spakowany plik kształtu do wyświetlenia na mapie. Uwaga: służy
+        tylko jako pomoc wizualna.'
       error: Przesłany plik musi być prawidłowym plikiem zip (.zip).
       title: Prześlij plik kształtu trasy
+  FeedLabel:
+    delete:
+      body: Are you sure you want to delete the label %name%? This action will remove
+        the label from all feed sources it's assigned to.
+      title: Delete Label?
   FeedSourceAttributes:
     lastUpdated: Zaktualizowano
   FeedSourcePanel:
+    chooseProject:
+    - choose project
+    chooseProjectToView: Choose a project to view feeds
+    createOne: Create one.
+    filters:
+      ALL: All
+      PRIVATE: Private
+      PUBLIC: Public
+      STARRED: Starred
+    forFeed: For feed
+    noFeedsYet: No feeds yet.
     search: Wyszukaj kanały
+    unnamed: unnamed
+  FeedSourceSettings:
+    autoPublish: Auto-publish
+    feedTransformations: Feed Transformations
+    general: General
+    noPermission: You do not have permission to edit details for this feed source.
+    properties: properties
+    warning: Warning!
   FeedSourceTable:
     comparisonColumn:
       DEPLOYED: Wdrożona wersja
       PUBLISHED: Wersja opublikowana
     createFirst: Utwórz pierwsze źródło kanału!
+    datesValid: Dates Valid
+    feedInfo: Feed Info
+    issues: Issues
+    latestVersion: Latest Version
+    status: Status
   FeedSourceTableRow:
+    dateFormat: MMM D, YYYY
+    expired: Expired %duration% ago
+    lastUpdated: Last updated %lastVersionUpdate% ago
+    noUpdates: No updates yet
+    none: None
+    startingIn: Starting in %duration%
     status:
       active: Aktywny
       all: Wszystkie
       expired: Wygasłe
-      expiring-within-20-days: Wygasające w ciągu 20 dni
       expiring-within-5-days: Wygasające w ciągu 5 dni
+      expiring-within-20-days: Wygasające w ciągu 20 dni
       feedNotInDeployment: Kanały niebędące w wdrożeniu
       feedNotPublished: Kanały nieopublikowane
       future: W przyszłości
       no-version: Brak wersji
       same-as-deployed: Taki sam jak wdrożony
       same-as-published: Taki sam jak opublikowany
+    validFor: Valid for another %duration%
   FeedSourceViewer:
     deploy: Wdrażaj
     edit: Edytuj GTFS
@@ -294,8 +451,8 @@ components:
         producedInHouseGtfsPlus: Produced In-house (GTFS+)
         regionalMerge: Regional Merge
         servicePeriodMerge: Service Period Merge
-        versionClone: Version Clone
         title: Retrieval Method
+        versionClone: Version Clone
       snapshot: Migawka edytora
       title: Ustawienia
       value: Wartość
@@ -305,13 +462,6 @@ components:
     versions: Wersje
     viewPublic: View public page
   FeedTransformationDescriptions:
-    general:
-      fileDefined: below text
-      filePlaceholder: "[choose file]"
-      tablePlaceholder: "[choose table]"
-      table: table
-      version: version
-      versionPlaceholder: "[choose version]"
     DeleteRecordsTransformation:
       label: Delete records from %tablePlaceholder%
       name: Delete records transformation
@@ -327,21 +477,37 @@ components:
       filePlaceholder: Choose the file/table to replace
       label: Replace %tablePlaceholder% from %versionPlaceholder%
       name: Replace file from version transformation
+    general:
+      fileDefined: below text
+      filePlaceholder: '[choose file]'
+      table: table
+      tablePlaceholder: '[choose table]'
+      version: version
+      versionPlaceholder: '[choose version]'
   FeedVersionNavigator:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
-    confirmLoad: >-
-      This will override all active GTFS Editor data for this Feed Source
-      with the data from this version. If there is unsaved work in the
-      Editor you want to keep, you must snapshot the current Editor data
-      first. Are you sure you want to continue?
+    confirmLoad: This will override all active GTFS Editor data for this Feed Source
+      with the data from this version. If there is unsaved work in the Editor you
+      want to keep, you must snapshot the current Editor data first. Are you sure
+      you want to continue?
     delete: Delete
+    deployFeed: Deploy feed
     download: Download
+    editFeed: Edit feed
     feed: Feed
+    fetch: Fetch
+    fromSnapshot: From snapshot
     load: Load for Editing
+    newVersion: Create new version
     next: Next
     of: of
     previous: Previous
+    selectFeed: 'Select a GTFS feed to upload:'
+    selectVersion: Select a version to view summary
+    upload: Upload
+    uploadFeed: Upload Feed
     version: Version
+    zipWarning: Uploaded file must be a valid zip file (.zip).
   FeedVersionTabs:
     agencyCount: Agency count
     daysActive: Days active
@@ -352,11 +518,10 @@ components:
     validDates: Valid Dates
   FeedVersionViewer:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
-    confirmLoad: >-
-      This will override all active GTFS Editor data for this Feed Source
-      with the data from this version. If there is unsaved work in the
-      Editor you want to keep, you must snapshot the current Editor data
-      first. Are you sure you want to continue?
+    confirmLoad: This will override all active GTFS Editor data for this Feed Source
+      with the data from this version. If there is unsaved work in the Editor you
+      want to keep, you must snapshot the current Editor data first. Are you sure
+      you want to continue?
     delete: Delete
     download: Download
     feed: Feed
@@ -383,24 +548,6 @@ components:
         gtfs: Use GTFS-Derived Extract Bounds
         title: OSM Extract
       title: Deployment
-    routerConfig:
-      brandingUrlRoot: Branding URL Root
-      carDropoffTime: Car Dropoff Time
-      numItineraries: "# of itineraries"
-      requestLogFile: Request log file
-      stairsReluctance: Stairs Reluctance
-      title: Router Config
-      updaters:
-        $index:
-          defaultAgencyId: Default agency ID
-          frequencySec: Frequency (in seconds)
-          sourceType: Source type
-          type: Type
-          url: URL
-        new: Add updater
-        title: Real-time updaters
-        placeholder: Updater name
-      walkSpeed: Walk Speed
     otpServers:
       $index:
         admin: Admin access only?
@@ -411,9 +558,9 @@ components:
           buildImageDescription: New Image Description
           buildImageName: New Image Name
           buildInstanceType: Graph build instance type
+          iamInstanceProfileArn: IAM Instance Profile ARN
           instanceCount: Instance count
           instanceType: Instance type
-          iamInstanceProfileArn: IAM Instance Profile ARN
           keyName: Key file name
           recreateBuildImage: Recreate Build Image after Graph Build?
           region: Region name
@@ -428,11 +575,38 @@ components:
         s3Bucket: S3 bucket name
         serverPlaceholder: Server name
         title: Servers
+    routerConfig:
+      brandingUrlRoot: Branding URL Root
+      carDropoffTime: Car Dropoff Time
+      numItineraries: '# of itineraries'
+      requestLogFile: Request log file
+      stairsReluctance: Stairs Reluctance
+      title: Router Config
+      updaters:
+        $index:
+          defaultAgencyId: Default agency ID
+          frequencySec: Frequency (in seconds)
+          sourceType: Source type
+          type: Type
+          url: URL
+        new: Add updater
+        placeholder: Updater name
+        title: Real-time updaters
+      walkSpeed: Walk Speed
   GeneralSettings:
-    confirmDelete: >-
-      Are you sure you want to delete this project? This action cannot be
-      undone and all feed sources and their versions will be permanently
-      deleted.
+    autoFetch:
+      checkbox: Auto fetch feed source
+      hint: Set this feed source to fetch automatically. (Feed source URL must be
+        specified and project auto fetch must be enabled.)
+      title: Automatic Fetch
+      url: Feed source fetch URL
+      urlButton: Change URL
+    confirmDelete: Are you sure you want to delete this project? This action cannot
+      be undone and all feed sources and their versions will be permanently deleted.
+    dangerZone: Danger Zone
+    deleteFeedSource: Delete feed source
+    deleteFeedSourceDesc: Delete this feed source.
+    deleteFeedSourceHint: Once you delete a feed source, it cannot be recovered.
     deleteProject: Delete Project?
     deployment:
       buildConfig:
@@ -465,7 +639,7 @@ components:
       routerConfig:
         brandingUrlRoot: Branding URL Root
         carDropoffTime: Car Dropoff Time
-        numItineraries: "# of itineraries"
+        numItineraries: '# of itineraries'
         requestLogFile: Request log file
         stairsReluctance: Stairs Reluctance
         title: Router Config
@@ -477,15 +651,16 @@ components:
             type: Type
             url: URL
           new: Add updater
-          title: Real-time updaters
           placeholder: Updater name
+          title: Real-time updaters
         walkSpeed: Walk Speed
       title: Deployment
+    feedSourceName: Feed source name
     general:
       location:
-        boundingBox: "Bounding box (W,S,E,N)"
+        boundingBox: Bounding box (W,S,E,N)
         defaultLanguage: Default language
-        defaultLocation: "Default location (lat, lng)"
+        defaultLocation: Default location (lat, lng)
         defaultTimeZone: Default time zone
         title: Location
       name: Project name
@@ -493,9 +668,44 @@ components:
       updates:
         autoFetchFeeds: Auto fetch feed sources?
         title: Updates
+    labels:
+      title: Labels
+    make:
+      private: Make private
+      privateDesc: Make this feed source private.
+      privateState: This feed source is currently private.
+      public: Make public
+      publicDesc: Make this feed source public.
+      publicState: This feed source is currently public.
+    makeDeployable: Make feed source deployable
+    makeDeployableHint: Enable this feed source to be deployed to an OpenTripPlanner
+      (OTP) instance (defined in organization settings) as part of a collection of
+      feed sources or individually.
     rename: Rename
     save: Save
     title: Settings
+  GtfsIcons:
+    agency:
+      label: Agencies
+      title: Edit agencies
+    calendar:
+      label: Calendar
+      title: Edit calendar
+    fare:
+      label: Fares
+      title: Edit fares
+    feedinfo:
+      label: Feed Info
+      title: Edit feed info
+    route:
+      label: Routes
+      title: Edit routes
+    scheduleExceptions:
+      label: Schedule Exceptions
+      title: Edit schedule exceptions
+    stop:
+      label: Stops
+      title: Edit stops
   GtfsValidationExplorer:
     accessibilityValidation: Accessibility Explorer
     table:
@@ -517,51 +727,101 @@ components:
       trips: Trip issues
     noResults: No validation results to show.
     tips:
-      DATE_NO_SERVICE: >-
-        If the transit service does not operate on weekends, some or all of
-        these validation issue may be ignored. Similarly, holidays for which
+      DATE_NO_SERVICE: If the transit service does not operate on weekends, some or
+        all of these validation issue may be ignored. Similarly, holidays for which
         there is no transit service running may appear in this list.
-      FEED_TRAVEL_TIMES_ROUNDED: >-
-        This is a common feature of GTFS feeds that do not use
-        down-to-the-second precision for arrival/departure times. However,
-        if this precision is expected, there may be an issue occurring
-        during feed export.
-      MISSING_TABLE: >-
-        Missing a required table is a major issue that must be resolved
-        before most GTFS consumers can make use of the data for trip
-        planning or in other applications.
+      FEED_TRAVEL_TIMES_ROUNDED: This is a common feature of GTFS feeds that do not
+        use down-to-the-second precision for arrival/departure times. However, if
+        this precision is expected, there may be an issue occurring during feed export.
+      MISSING_TABLE: Missing a required table is a major issue that must be resolved
+        before most GTFS consumers can make use of the data for trip planning or in
+        other applications.
     title: Validation issues
+  HomeProjectDropdown:
+    new: New Project
+    select: Select project
+    view: View %name%
+  InfoModal:
+    ok: OK
+  JobMonitor:
+    clearCompleted: Clear completed
+    jobs:
+      none: No active jobs
+      one: One active job
+      some: '%count% active jobs'
+    jobsCompleted: All jobs completed
+    serverJobs: Server Jobs
+    waiting: waiting
+  LabelPanel:
+    labels: Labels
+    new: Add a new label
+    noLabels: There are no labels in this project.
   LanguageSelect:
     placeholder: Select language...
   Login:
     title: Log in
+  ManagerHeader:
+    noUpdateYet: n/a
+    noUrl: (none)
+    private: This feed source and all its versions are private.
+  ManagerPage:
+    alerts: Alerts
+    changelog: Changelog
+    contact: Contact
+    copyright: Copyright
+    datatools: Data Tools
+    guide: Guide
+    home: Home
+  MapModal:
+    cancel: Cancel
+    ok: OK
+  MergeFeedsResult:
+    CHECK_STOP_TIMES: Some trip IDs were found in both feeds. The merged feed was
+      successfully created.
+    DEFAULT: Trip IDs were unique in the source feeds. The merged feed was successfully
+      created.
+    body:
+      failure: Merge failed with %errorCount% errors.
+      success: Merge was completed successfully. A new version will be processed/validated
+        containing the resulting feed.
+    remappedIds: 'Remapped IDs: %remappedIdCount%'
+    skipped: 'Skipped records:'
+    skippedTableRecords: '%table%: %skippedCount%'
+    strategyUsed: 'Strategy used: %strategy%'
+    title:
+      failure: 'Warning: Errors encountered during feed merge!'
+      success: Feed merge was successful!
+    tripIdsToCheck: 'Trip IDs to check: %tripIdCount%'
+  NormalizeField:
+    issues:
+      fieldUndefined: Field to normalize must be defined.
+      substitutionInvalid: Some substitution patterns are invalid.
+      substitutionUndefined: Substitution patterns must be defined.
   NormalizeStopTimesTip:
-    info: >-
-      Tip: when changing travel times, consider using the 'Normalize stop
-      times' button above to automatically update all stop times to the
-      updated travel time.
+    info: 'Tip: when changing travel times, consider using the "Normalize stop times"
+      button above to automatically update all stop times to the updated travel time.'
   NoteForm:
-    postComment: "TODO: Translate"
-    new: "TODO: Translate"
-    adminOnly: "TODO: Translate"
+    adminOnly: 'TODO: Translate'
+    new: 'TODO: Translate'
+    postComment: 'TODO: Translate'
   NotesViewer:
+    adminOnly: 'TODO: Translate'
     all: All Comments
     feedSource: Feed Source
     feedVersion: Version
-    new: Post
     none: No comments.
-    postComment: Post a New Comment
     refresh: Refresh
     title: Comments
-    adminOnly: "TODO: Translate"
   OrganizationList:
+    create: Create Organization
+    missingName: Must provide organization name.
     new: Create org
     search: Search orgs
   OrganizationSettings:
     extensions: Extensions
     logoUrl:
       label: Logo URL
-      placeholder: "http://example.com/logo_30x30.png"
+      placeholder: http://example.com/logo_30x30.png
     name:
       label: Name
       placeholder: Big City Transit
@@ -574,6 +834,16 @@ components:
       high: High
       low: Low
       medium: Medium
+      title: Usage tier
+  PageNotFound:
+    homePage: home page
+    pageNotFound: Page Not Found.
+  Permissions:
+    approve-alert: Approve GTFS-RT Alerts
+    approve-gtfs: Approve GTFS Feeds
+    edit-alert: Edit GTFS-RT Alerts
+    edit-gtfs: Edit GTFS Feeds
+    manage-feed: Manage Feed Configuration
   ProjectAccessSettings:
     admin: Admin
     cannotFetchFeeds: Cannot fetch feeds
@@ -582,6 +852,96 @@ components:
     noAccess: No Access
     permissions: Permissions
     title: Project Settings for
+  ProjectFeedListToolbar:
+    actions: Actions
+    all: all
+    any: any
+    comparison:
+      DEPLOYED: Deployed
+      LATEST: Latest
+      PUBLISHED: Published
+    deployedVersion: 'Deployed Version:'
+    deployments: Deployments
+    downloadCsv: Download Summary as CSV
+    feeds:
+      createFirst: Create first feed source!
+      new: New
+      search: Search by name
+      table:
+        deployable: Deployable?
+        errorCount: Errors
+        lastUpdated: Updated
+        name: Name
+        public: Public?
+        retrievalMethod: Retrieval Method
+        validRange: Valid Range
+      title: Feed Sources
+      update: Fetch all
+    filter:
+      active: Active
+      all: All
+      expired: Expired
+      expiring: Expiring
+      future: Future
+    filterByLabels: Filter feeds by labels
+    filterFeedSources: Filter feed sources on
+    hasDeployedVersion: Has Deployed Version?
+    hasLatestVersion: Has a latest version?
+    hasPublishedVersion: Has Published Version?
+    isPublic: Is Public
+    labelEndDate: '%labelPrefix% End Date'
+    labelNumberIssues: '%labelPrefix% Number of Issues'
+    labelNumberRoutes: '%labelPrefix% Number of Routes'
+    labelNumberStopTimes: '%labelPrefix% Number of StopsTimes'
+    labelNumberStops: '%labelPrefix% Number of Stops'
+    labelNumberTrips: '%labelPrefix% Number of Trips'
+    labelStartDate: '%labelPrefix% Start Date'
+    lastFetched: Last Time Data Fetched from Feed URL
+    lastUpdated: Last Updated
+    latestValidation:
+      endDate: 'Latest Version: End Date'
+      errorCount: 'Latest Version: Number of Issues'
+      routeCount: 'Latest Version: Number of Routes'
+      startDate: 'Latest Version: Start Date'
+      stopCount: 'Latest Version: Number of Stops'
+      stopTimesCount: 'Latest Version: Number of Stop Times'
+      tripCount: 'Latest Version: Number of Trips'
+    makePublic: Publish public feeds
+    mergeFeeds: Merge all
+    name: Name
+    noteSorting: 'Note: sorting only available on latest version data'
+    ofTheLabels: 'of the labels:'
+    publishedVersion: 'Published Version:'
+    settings: Settings
+    showFeedsWith: Show feeds with
+    sort:
+      alphabetically:
+        asc: A-Z
+        desc: Z-A
+        title: Alphabetically
+      endDate:
+        asc: Earliest-Latest
+        desc: Latest-Earliest
+        title: Expiration Date
+      lastUpdated:
+        asc: Stale-Recent
+        desc: Recent-Stale
+        title: Last Update
+      numErrors:
+        asc: Least-Most
+        desc: Most-Least
+        title: Number of Issues
+      startDate:
+        asc: Earliest-Latest
+        desc: Latest-Earliest
+        title: Start Date
+    sortBy: Sort By
+    sync:
+      mtc: Sync from MTC
+      transitfeeds: Sync from transitfeeds
+      transitland: Sync from transit.land
+    url: Feed download URL
+    version: version
   ProjectSettings:
     deployment:
       buildConfig:
@@ -616,7 +976,7 @@ components:
       routerConfig:
         brandingUrlRoot: Branding URL Root
         carDropoffTime: Car Dropoff Time
-        numItineraries: "# of itineraries"
+        numItineraries: '# of itineraries'
         requestLogFile: Request log file
         stairsReluctance: Stairs Reluctance
         title: Router Config
@@ -628,8 +988,8 @@ components:
             type: Type
             url: URL
           new: Add updater
-          title: Real-time updaters
           placeholder: Updater name
+          title: Real-time updaters
         walkSpeed: Walk Speed
       title: Deployment
     project:
@@ -641,17 +1001,23 @@ components:
     title: Settings
   ProjectSettingsForm:
     cancel: Cancel
-    confirmDelete: >-
-      Are you sure you want to delete this project? This action cannot be
-      undone and all feed sources and their versions will be permanently
-      deleted.
+    confirmDelete: Are you sure you want to delete this project? This action cannot
+      be undone and all feed sources and their versions will be permanently deleted.
+    dangerZone: Danger zone
     deleteProject: Delete Project?
+    deleteProjectAction: Delete Project
+    deleteThisProject: Delete this project.
+    deleteWarning: Once you delete an project, the project and all feed sources it
+      contains cannot be recovered.
     fields:
+      localPlacesIndex:
+        title: Local Places Index
+        webhookUrl: Webhook URL
       location:
-        boundingBox: "Bounding box (W,S,E,N)"
-        boundingBoxPlaceHolder: "min_lon, min_lat, max_lon, max_lat"
+        boundingBox: Bounding box (W,S,E,N)
+        boundingBoxPlaceHolder: min_lon, min_lat, max_lon, max_lat
         defaultLanguage: Default language
-        defaultLocation: "Default location (lat, lng)"
+        defaultLocation: Default location (lat, lng)
         defaultTimeZone: Default time zone
         title: Location
       name: Project name
@@ -659,10 +1025,26 @@ components:
       updates:
         autoFetchFeeds: Auto fetch feed sources?
         title: Updates
+    noPermissions: You do not have permission to edit details for this feed source.
+    required: Required.
     save: Save
+    selectBounds: Select project bounds
+    selectBoundsHint: Pretend this is a map
     title: Settings
+    warning: Warning!
+  ProjectSummaryPanel:
+    hoursPerWeekday: hours per weekday
+    numberOfFeeds: 'Number of feeds:'
+    summary: summary
+    totalErrors: 'Total errors:'
+    totalService: 'Total service:'
   ProjectViewer:
+    autoFetchDisabled: Auto fetch disabled
     deployments: Deployments
+    feedSourceDesc: A feed source defines the location or upstream source of a GTFS
+      feed. GTFS can be populated via automatic fetch, directly editing or uploading
+      a zip file.
+    feedSourceTitle: What is a feed source?
     feeds:
       createFirst: Create first feed source!
       new: New Feed Source
@@ -677,71 +1059,20 @@ components:
         validRange: Valid Range
       title: Feed Sources
       update: Fetch all
+    here: here
     makePublic: Publish public feeds
     mergeFeeds: Merge all
+    noProjectFound: No project found for
+    note: 'Note:'
+    publicViewed: Public feeds page can be viewed
+    returnToProjects: Return to list of projects
     settings: Settings
-  ProjectFeedListToolbar:
-    comparison:
-      DEPLOYED: Deployed
-      LATEST: Latest
-      PUBLISHED: Published
-    deployments: Deployments
-    downloadCsv: Download Summary as CSV
-    feeds:
-      createFirst: Create first feed source!
-      new: New
-      search: Search by name
-      table:
-        deployable: Deployable?
-        errorCount: Errors
-        lastUpdated: Updated
-        name: Name
-        public: Public?
-        retrievalMethod: Retrieval Method
-        validRange: Valid Range
-      title: Feed Sources
-      update: Fetch all
-    filter:
-      active: Active
-      all: All
-      expired: Expired
-      expiring: Expiring
-      future: Future
-    makePublic: Publish public feeds
-    mergeFeeds: Merge all
-    settings: Settings
-    sort:
-      alphabetically:
-        title: Alphabetically
-        asc: A-Z
-        desc: Z-A
-      endDate:
-        title: Expiration Date
-        asc: Earliest-Latest
-        desc: Latest-Earliest
-      lastUpdated:
-        title: Last Update
-        asc: Stale-Recent
-        desc: Recent-Stale
-      numErrors:
-        title: Number of Issues
-        asc: Least-Most
-        desc: Most-Least
-      startDate:
-        title: Start Date
-        asc: Earliest-Latest
-        desc: Latest-Earliest
-    sync:
-      transitland: Sync from transit.land
-      transitfeeds: Sync from transitfeeds
-      mtc: Sync from MTC
   ProjectsList:
     createFirst: Create my first project
     help:
-      content: >-
-        A project is used to group GTFS feeds. For example, the feeds in a
-        project may be in the same region or they may collectively define a
-        planning scenario.
+      content: A project is used to group GTFS feeds. For example, the feeds in a
+        project may be in the same region or they may collectively define a planning
+        scenario.
       title: What's a project?
     new: New Project
     noProjects: You currently do not have any projects.
@@ -759,6 +1090,14 @@ components:
     stateProvince: State or Province
   PublicFeedsViewer:
     title: Catalogue
+  PublicLandingPage:
+    appLogo: App logo
+    copyright: Copyright
+    existingUsers: Existing users
+    here: here
+    learnMore: Learn more about Data Tools
+    signInHere: sign in here
+    viewDashboard: View dashboard
   RegionSearch:
     placeholder: Search for regions or agencies
   ResultTable:
@@ -767,33 +1106,59 @@ components:
     line: Line
     priority: Priority
     problemType: Problem Type
+  RetiredJob:
+    bug: Oh no! Looks like an error has occurred.
+    support: To submit an error report email a screenshot of your browser window,
+      the following text (current URL and error details), and a detailed description
+      of the steps you followed to <a href='mailto:%supportEmail%'>%supportEmail%</a>.
+    view: View
+  SelectFileModal:
+    cancel: Cancel
+    ok: OK
   ServerSettings:
+    awsSetup: Instructions for setting up OTP deployment servers on AWS
+    confirmDelete: Are you sure you want to delete this server record?
     deployment:
       otpServers:
         new: Add server
         refresh: Refresh
         serverPlaceholder: Server name
         title: Deployment Server Management
+    instructions: Instructions
+    noServers: No servers defined
     save: Save
     title: Settings
+  ServerSpecialFields:
+    confirmTermination: 'Are you sure you want to terminate %count% instance(s)?\n\n
+      WARNING: This will kill OTP service for any deployments launched for this server.'
+    noEC2Instances: No EC2 instances associated with server.
+    projectSpecific: Project specific?
+    projectSpecificPlaceholder: Assign to a project or leave open for any project
+    terminateEC2: Terminate EC2 Instances
+    useELB: Use Elastic Load Balancer (ELB)?
   ShowAllRoutesOnMapFilter:
     fetching: Fetching
     showAllRoutesOnMap: Show all routes
     tooManyShapeRecords: large shapes.txt may impact performance
   Sidebar:
+    about: About this app
+    account: Account
+    serverJobs: Server jobs
+    serverVersion: 'Server version:'
+    settings: Settings
+    uiDeployedAt: 'UI deployed at:'
+    uiVersion: 'UI Version:'
     unknown: Unknown
   SnapshotItem:
     active: Active
-    confirmDelete: >-
-      This will permanently delete this snapshot. Any data saved here cannot
-      be recovered. Are you sure you want to continue?
-    confirmLoad: >-
-      This will override all active GTFS Editor data for this Feed Source
-      with the data from this version. If there is unsaved work in the
-      Editor you want to keep, you must snapshot the current Editor data
-      first. Are you sure you want to continue?
-    created: created
+    confirmDelete: This will permanently delete this snapshot. Any data saved here
+      cannot be recovered. Are you sure you want to continue?
+    confirmLoad: This will override all active GTFS Editor data for this Feed Source
+      with the data from this version. If there is unsaved work in the Editor you
+      want to keep, you must snapshot the current Editor data first. Are you sure
+      you want to continue?
     createFromScratch: Create GTFS from Scratch
+    created: created
     date: Date
     delete: Delete
     download: Download
@@ -812,11 +1177,94 @@ components:
   StarButton:
     star: Star
     unstar: Unstar
+  Status:
+    CREATED_SNAPSHOT:
+      body: New snapshot "%payload%" created. It will be accessible from the "Editor
+        Snapshots" tab in the main Feed Source page.
+      title: Snapshot Created
+    CREATING_SNAPSHOT: Creating snapshot...
+    DELETING_AGENCY: Deleting agency...
+    DELETING_FEEDVERSION: Deleting feed version...
+    DELETING_SNAPSHOT: Deleting snapshot...
+    DELETING_TRIPS_FOR_CALENDAR: Deleting trips...
+    FETCHING_ALL_JOBS: Fetching jobs...
+    LOADING_FEEDVERSION_FOR_EDITING: Loading version into editor...
+    PUBLISHING_GTFSPLUS_FEED: Publishing GTFS+ feed...
+    RENAMING_FEEDVERSION: Renaming feed version...
+    REQUEST_RTD_ALERTS: Loading alerts...
+    REQUESTING_AGENCIES: Loading agencies...
+    REQUESTING_DEPLOYMENT: Loading deployment...
+    REQUESTING_DEPLOYMENTS: Loading deployments...
+    REQUESTING_FEEDSOURCE: Loading feed...
+    REQUESTING_FEEDSOURCES: Loading feeds...
+    REQUESTING_FEEDVERSION_ISOCHRONES: Calculating access shed...
+    REQUESTING_FEEDVERSIONS: Loading feed versions...
+    REQUESTING_GTFSEDITOR_SNAPSHOTS: Loading snapshots...
+    REQUESTING_GTFSPLUS_CONTENT: Loading GTFS+ data...
+    REQUESTING_NOTES: Loading comments...
+    REQUESTING_ORGANIZATIONS: Loading organizations...
+    REQUESTING_PROJECT: Loading project...
+    REQUESTING_PROJECTS: Loading projects...
+    REQUESTING_PUBLIC_FEEDS: Loading public feeds...
+    REQUESTING_ROUTES: Loading routes...
+    REQUESTING_STOPS: Loading stops...
+    REQUESTING_SYNC: Syncing feeds...
+    REQUESTING_TRIPS_FOR_CALENDAR: Loading trips...
+    REQUESTING_USERS: Loading users...
+    REQUESTING_VALIDATION_ISSUE_COUNT: Loading validation result...
+    RESTORING_SNAPSHOT: Restoring snapshot...
+    RUNNING_FETCH_FEED_FOR_PROJECT: Updating feeds for project...
+    SAVING_AGENCY: Saving agency...
+    SAVING_DEPLOYMENT: Saving deployment...
+    SAVING_FEEDSOURCE: Saving feed...
+    SAVING_PROJECT: Saving project...
+    SAVING_ROUTE: Saving route...
+    SAVING_STOP: Saving stop...
+    UPDATING_SERVER: Saving server...
+    UPDATING_USER_DATA: Updating user...
+    UPLOADING_FEED: Uploading feed...
+    UPLOADING_GTFSPLUS_FEED: Saving GTFS+ data...
+    VALIDATING_GTFSPLUS_FEED: Updating GTFS+ validation...
+  StatusModal:
+    close: Close
+    login: Log in
+    reload: Reload page
+    relock: Re-lock feed
+    relockingFailed:
+      body: Re-locking feed is only permitted if another editing session is in progress
+        for you (not another user). You can try again later or contact the current
+        editor to request that they wrap up their session.
+      title: Attempt to take over editing failed!
+  TimetableEditor:
+    choosePattern: Choose a trip pattern.
+    createNew: create a new one
+    deleteSelectedTrip: Are you sure you want to permanently delete %count% selected
+      trip?
+    deleteSelectedTrips: Are you sure you want to permanently delete %count% selected
+      trips?
+    deleteTrips: Delete trips
+    deleteTripsQuestion: Delete trips?
   TimetableHelpModal:
-    title: Timetable editor keyboard shortcuts
+    close: Close
+    pressQuestionmark: Press <kbd>?</kbd> to view shortcuts
     shortcuts:
+      modify:
+        desc:
+          "0": Delete selected trip(s)
+          "1": New trip
+          "2": Clone selected trip(s)
+          "3": Copy time value from adjacent cell (the cell immediately to the left)
+          "4": Copy value from cell directly above
+        title: Modify trips
+      navigate:
+        desc:
+          "0": Previous/next trip
+          "1": Previous/next column
+          "2": Select trip
+          "3": Select all trips
+          "4": Deselect all trips
+        title: Navigating and selecting trips
       offset:
-        title: Offsetting times
         desc:
           "0": Offset selected trips' stop times by adding offset time
           "1": Offset selected trips' stop times by subtracting offset time
@@ -826,24 +1274,8 @@ components:
           "5": Decrease offset time by 10 minutes
           "6": Increase offset time by 1 minute
           "7": Increase offset time by 10 minutes
-      navigate:
-        title: Navigating and selecting trips
-        desc:
-          "0": Previous/next trip
-          "1": Previous/next column
-          "2": Select trip
-          "3": Select all trips
-          "4": Deselect all trips
-      modify:
-        title: Modify trips
-        desc:
-          "0": Delete selected trip(s)
-          "1": New trip
-          "2": Clone selected trip(s)
-          "3": >-
-            Copy time value from adjacent cell (the cell immediately to the
-            left)
-          "4": Copy value from cell directly above
+        title: Offsetting times
+    title: Timetable editor keyboard shortcuts
   TimezoneSelect:
     placeholder: Select timezone...
   UserAccount:
@@ -864,24 +1296,36 @@ components:
       profileInformation: Profile information
       title: Profile
     title: My settings
-  AdminPage:
-    noAccess: You do not have sufficient user privileges to access this area.
-    title: Administration
+  UserAccountInfoPanel:
+    hello: Hello,
+    profile: Profile
+    roles:
+      applicationAdmin: Application admin
+      organizationAdmin: Organization admin
+      standardUser: Standard user
+  UserButtons:
+    admin: Admin
+    logout: Log out
+    myAccount: My account
   UserHomePage:
     createFirst: Create my first project
     help:
-      content: >-
-        A project is used to group GTFS feeds. For example, the feeds in a
-        project may be in the same region or they may collectively define a
-        planning scenario.
+      content: A project is used to group GTFS feeds. For example, the feeds in a
+        project may be in the same region or they may collectively define a planning
+        scenario.
       title: What's a project?
     new: New Project
     noProjects: You currently do not have any projects.
+    recentActivity: Recent Activity
+    recentActivityNone: No Recent Activity for your subscriptions.
     table:
       name: Project Name
     title: Projects
+    userDocs: User Docs
+    welcomeTo: Welcome to
   UserList:
     filterByOrg: Filter by org.
+    noResults: (No results to show)
     of: of
     perPage: Users per page
     search: Search by username
@@ -905,12 +1349,12 @@ components:
     cancel: Cancel
     delete: Delete
     edit: Edit
+    noProjects: No projects available
     org:
       admin: Organization administrator
       billing: Billing admin
-      description: >-
-        Organization administrators have full access to projects within the
-        organization.
+      description: Organization administrators have full access to projects within
+        the organization.
     project:
       admin: Admin
       custom: Custom
@@ -918,11 +1362,10 @@ components:
     save: Save
   VersionButtonToolbar:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
-    confirmLoad: >-
-      This will override all active GTFS Editor data for this Feed Source
-      with the data from this version. If there is unsaved work in the
-      Editor you want to keep, you must snapshot the current Editor data
-      first. Are you sure you want to continue?
+    confirmLoad: This will override all active GTFS Editor data for this Feed Source
+      with the data from this version. If there is unsaved work in the Editor you
+      want to keep, you must snapshot the current Editor data first. Are you sure
+      you want to continue?
     delete: Delete
     download: Download
     feed: Feed
@@ -931,15 +1374,23 @@ components:
     status: Status
     timestamp: File Timestamp
     version: version
+  VersionComparisonDropdown:
+    compareToVersion: Comparing to version %version%
+    compareVersions: Compare versions
+    exit: Exit compare mode
+    loadAnother: Load another version to enable comparison
+    selectVersion: Select a version to compare with
+  VersionSelectorDropdown:
+    noVersions: No versions available
   WatchButton:
-    emailVerificationConfirm: >-
-      In order to receive email notification, you must first verify your
-      email address. Would you like to resend the email verification message
+    emailVerificationConfirm: In order to receive email notification, you must first
+      verify your email address. Would you like to resend the email verification message
       for your account?
     unwatch: Unwatch
     verificationSendError: There was an error sending the email verification!
-    verificationSent: >-
-      Please check your inbox and confirm your email address by clicking the
-      verify link. You will then need to refresh this page after a moment or
-      two and re-click the Watch button to subscribe to notifications.
+    verificationSent: Please check your inbox and confirm your email address by clicking
+      the verify link. You will then need to refresh this page after a moment or two
+      and re-click the Watch button to subscribe to notifications.
     watch: Watch
+  WrapComponentInAuthStrategy:
+    adminTestFailed: You have attempted to view a restricted page without proper credentials

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -382,8 +382,7 @@ components:
   FeedSourceAttributes:
     lastUpdated: Zaktualizowano
   FeedSourcePanel:
-    chooseProject:
-    - choose project
+    chooseProject: '[choose project]'
     chooseProjectToView: Choose a project to view feeds
     createOne: Create one.
     filters:

--- a/lib/admin/components/AdminPage.js
+++ b/lib/admin/components/AdminPage.js
@@ -89,15 +89,15 @@ class AdminPage extends React.Component<Props> {
     ({to, children: <ListGroupItem>{label}</ListGroupItem>})
 
   _getLinks = (isApplicationAdmin: boolean): React.Node[] => {
-    const links = [this._createLink('/admin/users', 'User management')]
+    const links = [this._createLink('/admin/users', this.messages('userManagement'))]
     // Do not show non-appAdmin users these application-level settings
     if (isApplicationAdmin) {
       if (!isModuleEnabled('enterprise')) {
-        links.push(this._createLink('/admin/organizations', 'Organizations'))
+        links.push(this._createLink('/admin/organizations', this.messages('organizations')))
       }
-      links.push(this._createLink('/admin/logs', 'Application logs'))
+      links.push(this._createLink('/admin/logs', this.messages('applicationLogs')))
       if (isModuleEnabled('deployment')) {
-        links.push(this._createLink('/admin/servers', 'Deployment servers'))
+        links.push(this._createLink('/admin/servers', this.messages('deploymentServers')))
       }
     }
     return links.map(link => (<LinkContainer key={link.to} {...link} />))
@@ -122,7 +122,7 @@ class AdminPage extends React.Component<Props> {
               <h2>
                 <LinkContainer className='pull-right' to='/home'>
                   <Button>
-                    Back to dashboard
+                    {this.messages('backToDashboard')}
                   </Button>
                 </LinkContainer>
                 <Icon type='cog' /> {this.messages('title')}

--- a/lib/admin/components/ApplicationStatus.js
+++ b/lib/admin/components/ApplicationStatus.js
@@ -9,8 +9,8 @@ import BootstrapTable from 'react-bootstrap-table/lib/BootstrapTable'
 import TableHeaderColumn from 'react-bootstrap-table/lib/TableHeaderColumn'
 
 import * as adminActions from '../actions/admin'
+import {getComponentMessages} from '../../common/util/config'
 import {formatTimestamp} from '../../common/util/date-time'
-
 import type {ServerJob} from '../../types'
 import type {AppState} from '../../types/reducers'
 
@@ -32,12 +32,14 @@ class ApplicationStatusView extends Component<Props, {refreshTime: ?Date}> {
     refreshTime: null
   }
 
+  messages = getComponentMessages('ApplicationStatusView')
+
   componentWillMount () {
     this._refreshJobs()
   }
 
   _formatUser = (val: ?string) => {
-    return val || '(unauthenticated)'
+    return val || this.messages('unauthenticated')
   }
 
   _refreshJobs = () => {
@@ -58,31 +60,31 @@ class ApplicationStatusView extends Component<Props, {refreshTime: ?Date}> {
       striped: true
     }
     const jobTableOptions = {...defaultTableOptions}
-    jobTableOptions.options.noDataText = 'No active jobs in progress.'
+    jobTableOptions.options.noDataText = this.messages('noDataText')
     const jobColumns = [
-      {children: 'ID', dataField: 'jobId', isKey: true, hidden: true},
-      {children: 'Name', dataField: 'name'},
-      {children: 'User', dataField: 'email', width: '120px'},
-      {children: 'Status', dataField: 'message'},
+      {children: this.messages('columns.id'), dataField: 'jobId', isKey: true, hidden: true},
+      {children: this.messages('columns.name'), dataField: 'name'},
+      {children: this.messages('columns.user'), dataField: 'email', width: '120px'},
+      {children: this.messages('columns.status'), dataField: 'message'},
       {children: '%', dataField: 'percentComplete', width: '60px'}
     ]
     const requestColumns = [
-      {children: 'ID', dataField: 'id', isKey: true, hidden: true},
-      {children: 'Path', dataField: 'path'},
-      {children: 'User', dataField: 'user', width: '180px', dataFormat: this._formatUser},
-      {children: 'Time', dataField: 'time', width: '140px', dataFormat: formatTimestamp}
+      {children: this.messages('columns.id'), dataField: 'id', isKey: true, hidden: true},
+      {children: this.messages('columns.path'), dataField: 'path'},
+      {children: this.messages('columns.user'), dataField: 'user', width: '180px', dataFormat: this._formatUser},
+      {children: this.messages('columns.time'), dataField: 'time', width: '140px', dataFormat: formatTimestamp}
     ]
     return (
       <div>
         <h3>
-          Active Server Jobs
+          {this.messages('serverJobs')}
           <Button
             className='pull-right'
             onClick={this._refreshJobs}>
-            <Icon type='refresh' /> Refresh
+            <Icon type='refresh' /> {this.messages('refresh')}
           </Button>
           <br />
-          <small>last updated at {moment(this.state.refreshTime).format(TIME_FORMAT)}</small>
+          <small>{this.messages('lastUpdatedAt')} {moment(this.state.refreshTime).format(TIME_FORMAT)}</small>
         </h3>
         <BootstrapTable
           {...jobTableOptions}
@@ -99,9 +101,9 @@ class ApplicationStatusView extends Component<Props, {refreshTime: ?Date}> {
           })}
         </BootstrapTable>
         <h3>
-          Last API requests by User
+          {this.messages('lastApiRequests')}
           <br />
-          <small>last updated at {moment(this.state.refreshTime).format(TIME_FORMAT)}</small>
+          <small>{this.messages('lastUpdatedAt')} {moment(this.state.refreshTime).format(TIME_FORMAT)}</small>
         </h3>
         <BootstrapTable
           {...defaultTableOptions}
@@ -112,13 +114,13 @@ class ApplicationStatusView extends Component<Props, {refreshTime: ?Date}> {
             return <TableHeaderColumn {...col} key={index} />
           })}
         </BootstrapTable>
-        <h3>User Authentication Logs</h3>
+        <h3>{this.messages('userLogs')}</h3>
         <Button
           bsStyle='danger'
           bsSize='large'
           block
           href='https://manage.auth0.com/#/logs'>
-          <Icon type='star' /> View user logs on Auth0.com
+          <Icon type='star' /> {this.messages('viewUserLogs')}
         </Button>
       </div>
     )

--- a/lib/admin/components/CreateUser.js
+++ b/lib/admin/components/CreateUser.js
@@ -77,36 +77,36 @@ export default class CreateUser extends Component<Props, State> {
           onClick={this.open}
         >
           <Icon type='plus' />{' '}
-          Create User
+          {this.messages('new')}
         </Button>
         <Modal
           onHide={this.cancel}
           show={showModal}
         >
           <Modal.Header closeButton>
-            <Modal.Title>Create User</Modal.Title>
+            <Modal.Title>{this.messages('title')}</Modal.Title>
           </Modal.Header>
           <form onSubmit={this.save}>
             <Modal.Body>
               <FormGroup controlId='formControlsEmail'>
-                <ControlLabel>Email Address</ControlLabel>
+                <ControlLabel>{this.messages('email.label')}</ControlLabel>
                 <FormControl
                   autoComplete='username email'
                   name='email'
                   onChange={this._updateField}
-                  placeholder='Enter email'
+                  placeholder={this.messages('email.placeholder')}
                   type='email'
                   value={email}
                 />
               </FormGroup>
               <FormGroup controlId='formControlsPassword'>
-                <ControlLabel>Password</ControlLabel>
+                <ControlLabel>{this.messages('password.label')}</ControlLabel>
                 <FormControl
                   autoComplete='new-password'
                   minLength='8'
                   name='password'
                   onChange={this._updateField}
-                  placeholder='Enter password for new user'
+                  placeholder={this.messages('password.placeholder')}
                   type='password'
                   value={password}
                 />

--- a/lib/admin/components/OrganizationList.js
+++ b/lib/admin/components/OrganizationList.js
@@ -46,7 +46,7 @@ class OrganizationList extends Component<Props, State> {
       this.props.createOrganization(settings)
       this.close()
     } else {
-      window.alert('Must provide organization name.')
+      window.alert(this.messages('missingName'))
     }
   }
 
@@ -98,7 +98,7 @@ class OrganizationList extends Component<Props, State> {
           show={this.state.showModal}
           onHide={this.close}>
           <Modal.Header closeButton>
-            <Modal.Title>Create Organization</Modal.Title>
+            <Modal.Title>{this.messages('create')}</Modal.Title>
           </Modal.Header>
           <Modal.Body>
             <OrganizationSettings

--- a/lib/admin/components/OrganizationSettings.js
+++ b/lib/admin/components/OrganizationSettings.js
@@ -129,7 +129,7 @@ export default class OrganizationSettings extends Component<Props, State> {
           </FormGroup>
           <h4>{this.messages('subDetails')}</h4>
           <FormGroup>
-            <ControlLabel style={{marginRight: '5px'}}>Usage tier</ControlLabel>
+            <ControlLabel style={{marginRight: '5px'}}>this.messages('usageTier.title')}</ControlLabel>
             {USAGE_TIERS.map((tier, index) => (
               <Radio
                 checked={this.state.usageTier === tier.value}

--- a/lib/admin/components/ServerSettings.js
+++ b/lib/admin/components/ServerSettings.js
@@ -142,7 +142,7 @@ class ServerSettings extends Component<Props, State> {
   _onRefresh = () => this.props.fetchServers()
 
   _onDeleteServer = (index: number) => {
-    if (window.confirm('Are you sure you want to delete this server record?')) {
+    if (window.confirm(this.messages('confirmDelete'))) {
       const server = this.state.otpServers[index]
       if (!server.id) this.setState(update(this.state, {otpServers: {$splice: [[index, 1]]}}))
       else this.props.deleteServer(this.state.otpServers[index])
@@ -250,7 +250,7 @@ class ServerSettings extends Component<Props, State> {
                       projects={projects} />
                   </CollapsiblePanel>
                 ))
-                : <p className='lead text-center'>No servers defined</p>
+                : <p className='lead text-center'>{this.messages('noServers')}</p>
               }
             </div>
           </Panel.Body>
@@ -258,11 +258,9 @@ class ServerSettings extends Component<Props, State> {
         <Panel>
           <Panel.Body>
             <div>
-              <h3>Instructions</h3>
+              <h3>{this.messages('instructions')}</h3>
               <p>
-                <a href={serverDocUrl} target='_blank'>
-                Instructions for setting up OTP deployment servers on AWS
-                </a>
+                <a href={serverDocUrl} target='_blank'>{this.messages('awsSetup')}</a>
               </p>
             </div>
           </Panel.Body>
@@ -284,6 +282,8 @@ type ServerSpecialFieldsProps = {
 }
 
 class ServerSpecialFields extends Component<ServerSpecialFieldsProps> {
+  messages = getComponentMessages('ServerSpecialFields')
+
   _onChange = evt => this.props.getOnChange(evt, this.props.index)
 
   _onChangeProject = (val: ReactSelectOption) =>
@@ -294,7 +294,7 @@ class ServerSpecialFields extends Component<ServerSpecialFieldsProps> {
   _terminateEC2Instances = () => {
     const {server, terminateEC2Instances} = this.props
     const count = getActiveInstanceCount(server.ec2Instances)
-    if (window.confirm(`Are you sure you want to terminate ${count} instance(s)?\n\n WARNING: This will kill OTP service for any deployments launched for this server.`)) {
+    if (window.confirm(this.messages('confirmTermination').replace('%count%', count.toString()))) {
       terminateEC2Instances(server)
     }
   }
@@ -305,11 +305,11 @@ class ServerSpecialFields extends Component<ServerSpecialFieldsProps> {
       <div>
         <Col xs={12}>
           <FormGroup>
-            <ControlLabel>Project specific?</ControlLabel>
+            <ControlLabel>{this.messages('projectSpecific')}</ControlLabel>
             <Select
               style={{marginBottom: '20px'}}
               clearable
-              placeholder='Assign to a project or leave open for any project'
+              placeholder={this.messages('projectSpecificPlaceholder')}
               options={projects.map(p => ({value: p.id, label: p.name}))}
               value={server.projectId}
               onChange={this._onChangeProject} />
@@ -321,7 +321,7 @@ class ServerSpecialFields extends Component<ServerSpecialFieldsProps> {
               <Checkbox
                 checked={!!server.ec2Info}
                 onChange={this._onToggleEc2Info}>
-                Use Elastic Load Balancer (ELB)?
+                {this.messages('useELB')}
               </Checkbox>
             </FormGroup>
             {server.ec2Info
@@ -349,7 +349,7 @@ class ServerSpecialFields extends Component<ServerSpecialFieldsProps> {
                 bsStyle='warning'
                 disabled={getActiveInstanceCount(server.ec2Instances) === 0}
                 onClick={this._terminateEC2Instances}>
-                <Icon type='window-close' /> Terminate EC2 Instances
+                <Icon type='window-close' /> {this.messages('terminateEC2')}
               </Button>
               <div style={{ height: '492px', overflowY: 'scroll', paddingRight: '10px' }}>
                 {server.ec2Instances && server.ec2Instances.length > 0
@@ -360,7 +360,7 @@ class ServerSpecialFields extends Component<ServerSpecialFieldsProps> {
                       terminateEC2InstanceForDeployment={this.props.terminateEC2InstanceForDeployment}
                       instance={instance} />
                   ))
-                  : 'No EC2 instances associated with server.'
+                  : this.messages('noEC2Instances')
                 }
               </div>
             </Col>

--- a/lib/admin/components/UserList.js
+++ b/lib/admin/components/UserList.js
@@ -159,7 +159,7 @@ class UserList extends Component<Props, State> {
                 {minUserIndex } - {maxUserIndex}{' '}
                 {this.messages('of')} {userCount}
               </span>
-              : <span style={headerStyle}>(No results to show)</span>
+              : <span style={headerStyle}>{this.messages('noResults')}</span>
             }
             <div className='pull-right'>
               {this.messages('perPage')}{' '}

--- a/lib/admin/components/UserSettings.js
+++ b/lib/admin/components/UserSettings.js
@@ -287,7 +287,7 @@ export default class UserSettings extends Component<Props, State> {
     const orgProjects = projects
       .filter(p => !p.organizationId || (this.state.organization && this.state.organization.id === p.organizationId))
     const currentProject: Project = orgProjects[this.state.currentProjectIndex]
-    const displayedProjectTitle = currentProject ? currentProject.name : 'No projects available'
+    const displayedProjectTitle = currentProject ? currentProject.name : this.messages('noProjects')
     const projectPanel = (
       <Panel>
         <Panel.Heading>

--- a/lib/admin/components/permissions.js
+++ b/lib/admin/components/permissions.js
@@ -1,32 +1,35 @@
 // @flow
 
 import type {Permission} from '../../common/user/UserPermissions'
+import {getComponentMessages} from '../../common/util/config'
+
+const messages = getComponentMessages('Permissions')
 
 const permissions: Array<Permission> = [
   {
     type: 'manage-feed',
-    name: 'Manage Feed Configuration',
+    name: messages('manage-feed'),
     feedSpecific: true
   },
   {
     type: 'edit-gtfs',
-    name: 'Edit GTFS Feeds',
+    name: messages('edit-gtfs'),
     feedSpecific: true
   },
   {
     type: 'approve-gtfs',
-    name: 'Approve GTFS Feeds',
+    name: messages('approve-gtfs'),
     feedSpecific: true
   },
   {
     type: 'edit-alert',
-    name: 'Edit GTFS-RT Alerts',
+    name: messages('edit-alert'),
     feedSpecific: true,
     module: 'alerts'
   },
   {
     type: 'approve-alert',
-    name: 'Approve GTFS-RT Alerts',
+    name: messages('approve-alert'),
     feedSpecific: true,
     module: 'alerts'
   }

--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -3,6 +3,7 @@
 import fetch from 'isomorphic-fetch'
 
 import {GTFS_GRAPHQL_PREFIX} from '../../common/constants'
+import {getComponentMessages} from '../../common/util/config'
 import { setErrorMessage } from '../../manager/actions/status'
 import type {dispatchFn, getStateFn} from '../../types/reducers'
 
@@ -11,11 +12,15 @@ type ErrorResponse = {
   message?: string
 }
 
+const messages = getComponentMessages('Actions')
+
 function getErrorMessage (method: string, url: string, status?: number) {
-  let errorMessage = status ? `Error (${status}) making ${method} request to ${url}` : `Error making ${method} request to ${url}`
-  if (status && status >= 500) {
-    errorMessage = `Network error (${status})!\n\n(${method} request on ${url})`
+  let errorMessage = messages('error')
+  if (status) {
+    errorMessage = status >= 500 ? messages('networkError') : messages('errorWithStatus')
+    errorMessage = errorMessage.replace('%status%', status.toString())
   }
+  errorMessage = errorMessage.replace('%url%', url).replace('%method%', method)
   return errorMessage
 }
 
@@ -30,7 +35,7 @@ export function createVoidPayloadAction (type: string) {
 export function postFormData (url: string, file: File, customHeaders?: {[string]: string}) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     if (!file) {
-      alert('No file to upload!')
+      alert(messages('noFile'))
       return
     }
     const data = new window.FormData()
@@ -157,7 +162,7 @@ export function fetchGraphQL ({
       .then(json => {
         if (json.errors && json.errors.length) {
           dispatch(setErrorMessage({
-            message: errorMessage || 'Error fetching GTFS entities via GraphQL',
+            message: errorMessage || messages('errorGraphQL'),
             // action,
             detail: graphQLErrorsToString(json.errors)
           }))

--- a/lib/common/components/ConfirmModal.js
+++ b/lib/common/components/ConfirmModal.js
@@ -3,6 +3,8 @@
 import React from 'react'
 import { Modal, Button } from 'react-bootstrap'
 
+import {getComponentMessages} from '../../common/util/config'
+
 type Props = {
   body?: string,
   confirmButtonStyle?: Object,
@@ -23,6 +25,8 @@ type State = {
 }
 
 export default class ConfirmModal extends React.Component<Props, State> {
+  messages = getComponentMessages('ConfirmModal')
+
   state = {
     showModal: false
   }
@@ -72,11 +76,11 @@ export default class ConfirmModal extends React.Component<Props, State> {
             data-test-id='modal-confirm-ok-button'
             onClick={this.ok}
           >
-            {this.state.confirmButtonText ? this.state.confirmButtonText : 'OK'}
+            {this.state.confirmButtonText ? this.state.confirmButtonText : this.messages('ok')}
           </Button>
           <Button
             onClick={this.close}>
-            Cancel
+            {this.messages('cancel')}
           </Button>
         </Footer>
       </Modal>

--- a/lib/common/components/EC2InstanceCard.js
+++ b/lib/common/components/EC2InstanceCard.js
@@ -7,6 +7,7 @@ import React, { Component } from 'react'
 import { Button, Panel } from 'react-bootstrap'
 import { Link } from 'react-router'
 
+import {getComponentMessages} from '../../common/util/config'
 import * as deploymentActions from '../../manager/actions/deployments'
 import { formatTimestamp } from '../util/date-time'
 import type { EC2InstanceSummary, ServerJob } from '../../types'
@@ -20,10 +21,12 @@ type Props = {
 }
 
 export default class EC2InstanceCard extends Component<Props> {
+  messages = getComponentMessages('EC2InstanceCard')
+
   _getTimeActive = () => {
     const { instance } = this.props
     // If instance hasn't launched, don't calculate time.
-    if (!instance.launchTime) return 'N/A'
+    if (!instance.launchTime) return this.messages('notApplicable')
     // Set end time as termination time or now.
     const endTimestamp = this._getTerminationTime()
     const endTime = endTimestamp ? moment(endTimestamp) : moment()
@@ -72,7 +75,7 @@ export default class EC2InstanceCard extends Component<Props> {
   handleTerminate = () => {
     const {instance, terminateEC2InstanceForDeployment} = this.props
     const { deploymentId, instanceId } = instance
-    if (window.confirm('Are you sure you want to terminate this EC2 instance? This action cannot be undone and will remove this instance from the load balancer.')) {
+    if (window.confirm(this.messages('confirmTermination'))) {
       terminateEC2InstanceForDeployment(deploymentId, [instanceId])
     }
   }
@@ -97,7 +100,7 @@ export default class EC2InstanceCard extends Component<Props> {
                 ? <div>
                   <Icon type='globe' />{' '}
                   <Link to={`/project/${projectId}/deployments/${deploymentId}`}>
-                  View deployment
+                    {this.messages('view')}
                   </Link>
                 </div>
                 : null
@@ -116,12 +119,12 @@ export default class EC2InstanceCard extends Component<Props> {
                 {job
                   ? job.status.message
                   : terminationTime
-                    ? `Terminated ${formatTimestamp(terminationTime)}`
+                    ? this.messages('status.terminatedAt').replace('%moment%', formatTimestamp(terminationTime))
                     : instance.state.name === 'pending'
-                      ? 'Booting up.'
+                      ? this.messages('status.booting')
                       : instance.state.name === 'terminated'
-                        ? 'Terminated.'
-                        : 'Running as server.'
+                        ? this.messages('status.terminated')
+                        : this.messages('status.running')
                 }
               </div>
               <div>
@@ -129,7 +132,7 @@ export default class EC2InstanceCard extends Component<Props> {
                   ? <a target='_blank' href={`http://${instance.publicIpAddress}/otp`}>
                     {instance.publicIpAddress}
                   </a>
-                  : 'No public IP'
+                  : this.messages('noPublicIP')
                 }
                 {this.props.onClickDownloadUserData
                   ? <Button
@@ -137,7 +140,7 @@ export default class EC2InstanceCard extends Component<Props> {
                     bsStyle='link'
                     style={{marginTop: 0, paddingTop: 0, borderTop: 0, marginLeft: '10px'}}
                     onClick={this._onClickDownloadUserDataLog}>
-                    <Icon type='download' /> log
+                    <Icon type='download' /> {this.messages('log')}
                   </Button>
                   : null
                 }
@@ -146,14 +149,14 @@ export default class EC2InstanceCard extends Component<Props> {
                   target='_blank'
                   href={this._getInstanceUrl()}
                 >
-                  <Icon type='external-link' /> AWS
+                  <Icon type='external-link' /> {this.messages('aws')}
                 </a>
                 <Button
                   bsStyle='link'
                   bsSize='small'
                   disabled={instance.state.name === 'terminated' || instance.state.name === 'shutting-down'}
                   style={{padding: '0 2px 4px 2px'}}
-                  title='Terminate instance'
+                  title={this.messages('terminate')}
                   onClick={this.handleTerminate}>
                   <span className='text-danger'><Icon type='trash' /></span>
                 </Button>

--- a/lib/common/components/EditableTextField.js
+++ b/lib/common/components/EditableTextField.js
@@ -5,6 +5,8 @@ import React, {Component} from 'react'
 import { Form, FormControl, InputGroup, FormGroup, Button } from 'react-bootstrap'
 import { Link } from 'react-router'
 
+import {getComponentMessages} from '../../common/util/config'
+
 type Props = {
   disabled?: ?boolean,
   hideEditButton?: boolean,
@@ -30,6 +32,7 @@ type State = {
 }
 
 export default class EditableTextField extends Component<Props, State> {
+  messages = getComponentMessages('EditableTextField')
   input = {}
 
   static defaultProps = {
@@ -73,7 +76,7 @@ export default class EditableTextField extends Component<Props, State> {
     const {onChange, rejectEmptyValue} = this.props
     const {initialValue, value} = this.state
     // Do not allow save if there is no input value.
-    if (rejectEmptyValue && !value) return window.alert('Must provide a valid input.')
+    if (rejectEmptyValue && !value) return window.alert(this.messages('invalidInput'))
     // If there was no change in the value, cancel editing.
     if (value === initialValue) return this.cancel()
     // Otherwise, call onChange function from props and store value in state.
@@ -88,7 +91,7 @@ export default class EditableTextField extends Component<Props, State> {
     const {rejectEmptyValue} = this.props
     const {initialValue} = this.state
     // Do not allow cancel if there is no input value
-    if (rejectEmptyValue && !initialValue) return window.alert('Must provide a valid input.')
+    if (rejectEmptyValue && !initialValue) return window.alert(this.messages('invalidInput'))
     else this.setState({isEditing: false, value: initialValue})
   }
 
@@ -141,7 +144,7 @@ export default class EditableTextField extends Component<Props, State> {
     // trim length of display text to fit content
     const displayValue = typeof maxLength === 'number' && value && value.length > maxLength
       ? `${value.substr(0, maxLength)}...`
-      : value || '(none)'
+      : value || this.messages('none')
     return (
       <div
         style={newStyle}>

--- a/lib/common/components/FeedLabel.js
+++ b/lib/common/components/FeedLabel.js
@@ -8,6 +8,7 @@ import { deleteLabel } from '../../manager/actions/labels'
 import type { Label } from '../../types'
 import type { ManagerUserState } from '../../types/reducers'
 import ConfirmModal from '../../common/components/ConfirmModal'
+import {getComponentMessages} from '../../common/util/config'
 import LabelEditorModal from '../../manager/components/LabelEditorModal'
 
 export type Props = {
@@ -40,6 +41,8 @@ const getComplementaryColor = (cssHex, strength) => {
  * buttons alongside the label
  */
 class FeedLabel extends React.Component<Props, State> {
+  messages = getComponentMessages('FeedLabel')
+
   _onConfirmDelete = () => {
     this.props.deleteLabel && this.props.deleteLabel(this.props.label)
   }
@@ -125,8 +128,8 @@ class FeedLabel extends React.Component<Props, State> {
           <span className='actionButtons'>
             <ConfirmModal
               ref='deleteModal'
-              title='Delete Label?'
-              body={`Are you sure you want to delete the label ${label.name}? This action will remove the label from all feed sources it's assigned to.`}
+              title={this.messages('delete.title')}
+              body={this.messages('delete.body').replace('%name%', label.name)}
               onConfirm={this._onConfirmDelete}
             />
             <LabelEditorModal ref='editModal' label={this.props.label} />

--- a/lib/common/components/InfoModal.js
+++ b/lib/common/components/InfoModal.js
@@ -3,6 +3,8 @@
 import React from 'react'
 import { Modal, Button } from 'react-bootstrap'
 
+import {getComponentMessages} from '../../common/util/config'
+
 type Props = {
   body?: string,
   title?: string
@@ -15,6 +17,8 @@ type State = {
 }
 
 export default class InfoModal extends React.Component<Props, State> {
+  messages = getComponentMessages('InfoModal')
+
   state = {
     body: '',
     showModal: false,

--- a/lib/common/components/InfoModal.js
+++ b/lib/common/components/InfoModal.js
@@ -3,8 +3,6 @@
 import React from 'react'
 import { Modal, Button } from 'react-bootstrap'
 
-import {getComponentMessages} from '../../common/util/config'
-
 type Props = {
   body?: string,
   title?: string
@@ -17,8 +15,6 @@ type State = {
 }
 
 export default class InfoModal extends React.Component<Props, State> {
-  messages = getComponentMessages('InfoModal')
-
   state = {
     body: '',
     showModal: false,

--- a/lib/common/components/JobMonitor.js
+++ b/lib/common/components/JobMonitor.js
@@ -6,11 +6,11 @@ import {ProgressBar, Button, OverlayTrigger, Popover} from 'react-bootstrap'
 import {Link} from 'react-router'
 
 import {removeRetiredJob} from '../../manager/actions/status'
-import SidebarPopover from './SidebarPopover'
-import {getConfigProperty} from '../util/config'
-
+import {getComponentMessages, getConfigProperty} from '../util/config'
 import type {ServerJob} from '../../types'
 import type {JobStatusState} from '../../types/reducers'
+
+import SidebarPopover from './SidebarPopover'
 
 type Props = {
   close: () => void,
@@ -24,6 +24,8 @@ const sortByDate = (a: ServerJob, b: ServerJob) =>
   new Date(a.status.initialized) - new Date(b.status.initialized)
 
 export default class JobMonitor extends Component<Props> {
+  messages = getComponentMessages('JobMonitor')
+
   popover = null
 
   // Remove any retired jobs from the monitor
@@ -39,14 +41,14 @@ export default class JobMonitor extends Component<Props> {
     const {jobMonitor, removeRetiredJob} = this.props
     const {jobs, retired} = jobMonitor
     const activeJobsMessage = retired.length && jobs.length === 0
-      ? <span data-test-id='all-jobs-completed'>All jobs completed</span>
+      ? <span data-test-id='all-jobs-completed'>{this.messages('jobsCompleted')}</span>
       : <span data-test-id='possibly-active-jobs'>
-        {`${jobs.length ? jobs.length : 'No'} active job${!jobs.length || jobs.length > 1 ? 's' : ''}`}
+        {jobs.length ? this.messages(`jobs.${jobs.length > 1 ? 'some' : 'one'}`).replace('%count%', jobs.length.toString()) : this.messages('jobs.none') }
       </span>
     return (
       <SidebarPopover
         ref={(SidebarPopover) => { this.popover = SidebarPopover }}
-        title='Server Jobs'
+        title={this.messages('serverJobs')}
         fixedHeight={300}
         minMarginBottom={75}
         {...this.props}
@@ -72,7 +74,7 @@ export default class JobMonitor extends Component<Props> {
                         now={pctComplete}
                         className='job-status-progress-bar' />
                       <div className='job-status-message' >
-                        {job.status ? job.status.message : 'waiting'}
+                        {job.status ? job.status.message : this.messages('waiting')}
                       </div>
                     </div>
                   </li>
@@ -94,7 +96,7 @@ export default class JobMonitor extends Component<Props> {
               data-test-id='clear-completed-jobs-button'
               disabled={retired.length === 0}
               onClick={this.removeAll}>
-              <Icon type='times-circle' /> Clear completed
+              <Icon type='times-circle' />{this.messages('clearCompleted')}
             </Button>
             <div style={{ paddingTop: 6, fontSize: 13 }}>
               {activeJobsMessage}
@@ -110,6 +112,7 @@ class RetiredJob extends Component<{
   job: ServerJob,
   removeRetiredJob: typeof removeRetiredJob
 }> {
+  messages = getComponentMessages('RetiredJob')
   removeJob = () => this.props.removeRetiredJob(this.props.job)
 
   /**
@@ -173,7 +176,7 @@ class RetiredJob extends Component<{
               {job.status.message}{' '}
               {path && !job.status.error
                 ? <Link to={this._getPathToObject()}>
-                  View
+                  {this.messages('view')}
                 </Link>
                 : null}
               {job.status.exceptionDetails
@@ -188,15 +191,12 @@ class RetiredJob extends Component<{
                       }}
                       title={
                         <span>
-                          <Icon type='bug' /> Oh no! Looks like an error has occurred.
+                          <Icon type='bug' /> {this.messages('bug')}
                         </span>
                       }>
                       {supportEmail
                         ? <p>
-                          To submit an error report email a screenshot of your browser
-                          window, the following text (current URL and error details),
-                          and a detailed description of the steps you followed
-                          to <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+                          {this.messages('support').replace('%supportEmail%', supportEmail)}
                         </p>
                         : null
                       }

--- a/lib/common/components/ManagerPage.js
+++ b/lib/common/components/ManagerPage.js
@@ -2,12 +2,12 @@
 
 import * as React from 'react'
 
+import { getComponentMessages, getConfigProperty, isModuleEnabled } from '../../common/util/config'
 import CurrentStatusMessage from '../containers/CurrentStatusMessage'
 import CurrentStatusModal from '../containers/CurrentStatusModal'
 import ActiveSidebar from '../containers/ActiveSidebar'
 import ActiveSidebarNavItem from '../containers/ActiveSidebarNavItem'
 import PageContent from '../containers/PageContent'
-import { getConfigProperty, isModuleEnabled } from '../util/config'
 
 import ConfirmModal from './ConfirmModal'
 import InfoModal from './InfoModal'
@@ -21,6 +21,8 @@ type Props = {
 }
 
 export default class ManagerPage extends React.Component<Props> {
+  messages = getComponentMessages('ManagerPage')
+
   showInfoModal (props: any) {
     this.refs.infoModal.open(props)
   }
@@ -40,7 +42,7 @@ export default class ManagerPage extends React.Component<Props> {
   render () {
     const {itemToLock, title} = this.props
     const homeIsActive = this.isActive('home') || this.isActive('feed') || this.isActive('project')
-    const appTitle = getConfigProperty('application.title') || 'Data Tools'
+    const appTitle = getConfigProperty('application.title') || this.messages('datatools')
     const changelogUrl: ?string = getConfigProperty('application.changelog_url')
     const docsUrl: ?string = getConfigProperty('application.docs_url')
     const supportEmail: ?string = getConfigProperty('application.support_email')
@@ -55,13 +57,13 @@ export default class ManagerPage extends React.Component<Props> {
         <ActiveSidebar>
           <ActiveSidebarNavItem
             icon='home'
-            label='Home'
+            label={this.messages('home')}
             link={`/home`}
             active={homeIsActive} />
           {isModuleEnabled('alerts')
             ? <ActiveSidebarNavItem
               icon='exclamation-circle'
-              label='Alerts'
+              label={this.messages('alerts')}
               link={`/alerts`}
               active={this.isActive('alerts')} />
             : null
@@ -84,12 +86,12 @@ export default class ManagerPage extends React.Component<Props> {
           <footer className='manager-footer'>
             <div className='container'>
               <ul className='list-inline text-center text-muted'>
-                {changelogUrl && <li><a href={changelogUrl}>Changelog</a></li>}
-                {docsUrl && <li><a href={docsUrl}>Guide</a></li>}
-                {supportEmail && <li><a href={`mailto:${supportEmail}`}>Contact</a></li>}
+                {changelogUrl && <li><a href={changelogUrl}>{this.messages('changelog')}</a></li>}
+                {docsUrl && <li><a href={docsUrl}>{this.messages('guide')}</a></li>}
+                {supportEmail && <li><a href={`mailto:${supportEmail}`}>{this.messages('contact')}</a></li>}
               </ul>
               <p className='text-center text-muted'>
-                <span role='img' title='Copyright' aria-label='copyright'>
+                <span role='img' title={this.messages('copyright')} aria-label='copyright'>
                   &copy;
                 </span>{' '}
                 <a href='https://www.ibigroup.com'>IBI Group</a>

--- a/lib/common/components/MapModal.js
+++ b/lib/common/components/MapModal.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import {Modal, Button} from 'react-bootstrap'
 import {Map, Marker, TileLayer} from 'react-leaflet'
 
+import {getComponentMessages} from '../util/config'
 import {boundsContainNaN} from '../../editor/util/map'
 import {defaultTileLayerProps} from '../util/maps'
 import type {LatLng} from '../../types'
@@ -34,6 +35,8 @@ type State = {
 }
 
 export default class MapModal extends Component<Props, State> {
+  messages = getComponentMessages('MapModal')
+
   state = {
     showModal: false,
     onConfirm: () => {},
@@ -110,8 +113,8 @@ export default class MapModal extends Component<Props, State> {
           </Map>}
         </Body>
         <Footer>
-          <Button onClick={this.ok}>OK</Button>
-          <Button onClick={this.close}>Cancel</Button>
+          <Button onClick={this.ok}>{this.messages('ok')}</Button>
+          <Button onClick={this.close}>{this.messages('cancel')}</Button>
         </Footer>
       </Modal>
     )

--- a/lib/common/components/PageNotFound.js
+++ b/lib/common/components/PageNotFound.js
@@ -3,18 +3,21 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import {Grid, Row, Col} from 'react-bootstrap'
-
-import ManagerPage from './ManagerPage'
-import PublicPage from '../../public/components/PublicPage'
 import {Link} from 'react-router'
 
+import {getComponentMessages} from '../util/config'
+import PublicPage from '../../public/components/PublicPage'
 import type {AppState, ManagerUserState, RouterProps} from '../../types/reducers'
+
+import ManagerPage from './ManagerPage'
 
 type Props = {message?: string, user: ManagerUserState}
 
+const messages = getComponentMessages('PageNotFound')
+
 class PageNotFound extends React.Component<Props> {
   static defaultProps = {
-    message: 'Page Not Found.'
+    message: messages('pageNotFound')
   }
 
   render () {
@@ -29,7 +32,7 @@ class PageNotFound extends React.Component<Props> {
             <h1>{message}</h1>
             <p>
               Go to{' '}
-              <Link to={`/${user.profile ? 'home' : ''}`}>home page</Link>
+              <Link to={`/${user.profile ? 'home' : ''}`}>{messages('homePage')}</Link>
             </p>
           </Col>
         </Row>

--- a/lib/common/components/SelectFileModal.js
+++ b/lib/common/components/SelectFileModal.js
@@ -4,6 +4,8 @@ import React, { Component } from 'react'
 import { Modal, Button, FormControl } from 'react-bootstrap'
 import ReactDOM from 'react-dom'
 
+import {getComponentMessages} from '../util/config'
+
 type Props = {
   body?: string,
   errorMessage?: string,
@@ -23,6 +25,8 @@ type State = {
 }
 
 export default class SelectFileModal extends Component<Props, State> {
+  messages = getComponentMessages('SelectFileModal')
+
   state = {
     disabled: false,
     errorMessage: '',
@@ -101,8 +105,8 @@ export default class SelectFileModal extends Component<Props, State> {
         </Body>
 
         <Footer>
-          <Button disabled={disabled} onClick={this.ok}>OK</Button>
-          <Button disabled={disabled} onClick={this.close}>Cancel</Button>
+          <Button disabled={disabled} onClick={this.ok}>{this.messages('ok')}</Button>
+          <Button disabled={disabled} onClick={this.close}>{this.messages('cancel')}</Button>
         </Footer>
       </Modal>
     )

--- a/lib/common/components/Sidebar.js
+++ b/lib/common/components/Sidebar.js
@@ -109,21 +109,21 @@ export default class Sidebar extends PureComponent<Props, State> {
               loading={hasActiveJobs}
               keyName={POPOVER.JOB}
               finished={jobMonitor.jobs.length === 0 && jobMonitor.retired.length > 0}
-              label='Server jobs'
+              label={this.messages('serverJobs')}
               onClick={this._select} />
             <SidebarNavItem
               ref='userNav'
               expanded={expanded}
               keyName={POPOVER.USER}
               icon='user'
-              label='Account'
+              label={this.messages('account')}
               onClick={this._select} />
             <SidebarNavItem
               ref='settingsNav'
               keyName={POPOVER.HELP}
               expanded={expanded}
               icon='gear'
-              label='Settings'
+              label={this.messages('settings')}
               onClick={this._select} />
           </div>
         </Navbar>
@@ -152,17 +152,17 @@ export default class Sidebar extends PureComponent<Props, State> {
           close={this._closePopover}
           expanded={expanded}
           target={this.refs.settingsNav}
-          title='Settings'
+          title={this.messages('settings')}
           visible={visiblePopover === POPOVER.HELP}
           width={300}
         >
           <div>
             <div className='app-info'>
-              <h5>About this app</h5>
+              <h5>{this.messages('about')}</h5>
               <table>
                 <tbody>
                   <tr>
-                    <td>UI Version:</td>
+                    <td>{this.messages('uiVersion')}</td>
                     <td>
                       {commit && repoUrl
                         ? <a href={`${repoUrl}/commit/${commit}`}>{commit.slice(0, 6)}</a>
@@ -171,7 +171,7 @@ export default class Sidebar extends PureComponent<Props, State> {
                     </td>
                   </tr>
                   <tr>
-                    <td>UI deployed at:</td>
+                    <td>{this.messages('uiDeployedAt')}</td>
                     <td>
                       {buildTimestamp
                         ? moment(buildTimestamp).format('LLL')
@@ -180,7 +180,7 @@ export default class Sidebar extends PureComponent<Props, State> {
                     </td>
                   </tr>
                   <tr>
-                    <td>Server version:</td>
+                    <td>{this.messages('serverVersion')}</td>
                     <td>
                       {appInfo && appInfo.repoUrl !== '?'
                         ? (
@@ -203,6 +203,8 @@ export default class Sidebar extends PureComponent<Props, State> {
 }
 
 class Brand extends PureComponent<{expanded: boolean}> {
+  messages = getComponentMessages('Brand')
+
   render () {
     const {expanded} = this.props
     const backgroundImage = `url(${getConfigProperty('application.logo') || DEFAULT_LOGO_SMALL})`
@@ -212,7 +214,7 @@ class Brand extends PureComponent<{expanded: boolean}> {
           <div
             style={{backgroundImage}}
             className='Logo' />
-          {expanded && <div className='LogoLabel'>Data Tools</div>}
+          {expanded && <div className='LogoLabel'>{this.messages('dataTools')}</div>}
           <div className='clearfix' />
         </div>
       </Link>

--- a/lib/common/components/StatusModal.js
+++ b/lib/common/components/StatusModal.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import { Auth0ContextInterface } from '@auth0/auth0-react'
 import {Modal, Button} from 'react-bootstrap'
 
+import {getComponentMessages} from '../../common/util/config'
 import * as statusActions from '../../manager/actions/status'
 import * as editorActions from '../../editor/actions/editor'
 import type {Props as ContainerProps} from '../containers/CurrentStatusModal'
@@ -25,6 +26,8 @@ type State = ModalStatus & {
 }
 
 export default class StatusModal extends Component<Props, State> {
+  messages = getComponentMessages('StatusModal')
+
   componentWillMount () {
     // Set initial state.
     this.setState({
@@ -66,9 +69,9 @@ export default class StatusModal extends Component<Props, State> {
           if (!success) {
             this.setState({
               body: this.state.body + '\n\n' +
-                'Re-locking feed is only permitted if another editing session is in progress for you (not another user). You can try again later or contact the current editor to request that they wrap up their session.',
+                this.messages('relockingFailed.body'),
               disabled: true,
-              title: 'Attempt to take over editing failed!'
+              title: this.messages('relockingFailed.title')
             })
           }
         }, console.log)
@@ -104,21 +107,21 @@ export default class StatusModal extends Component<Props, State> {
           bsStyle='primary'
           disabled={disabled}
           onClick={this._onLoginClick}>
-          Log in
+          {this.messages('login')}
         </Button>
       case 'RE_LOCK':
         return <Button
           bsStyle='danger'
           disabled={disabled}
           onClick={this._handleReLock}>
-          Re-lock feed
+          {this.messages('relock')}
         </Button>
       case 'RELOAD':
         return <Button
           bsStyle='success'
           disabled={disabled}
           onClick={this._handleReload}>
-          Reload page
+          {this.messages('reload')}
         </Button>
       default:
         return null
@@ -145,7 +148,7 @@ export default class StatusModal extends Component<Props, State> {
             data-test-id='status-modal-close-button'
             onClick={this.close}
           >
-            Close
+            {this.messages('close')}
           </Button>
         </Footer>
       </Modal>

--- a/lib/common/components/UserButtons.js
+++ b/lib/common/components/UserButtons.js
@@ -5,6 +5,7 @@ import { Button, ButtonToolbar } from 'react-bootstrap'
 import { LinkContainer } from 'react-router-bootstrap'
 import Icon from '@conveyal/woonerf/components/icon'
 
+import {getComponentMessages} from '../../common/util/config'
 import type {ManagerUserState} from '../../types/reducers'
 
 type Props = {
@@ -17,6 +18,8 @@ type Props = {
  *  Account", "Site Admin", and "Logout"
  */
 export default class UserButtons extends Component<Props> {
+  messages = getComponentMessages('UserButtons')
+
   render () {
     const { logout, user } = this.props
     const buttonStyle = { margin: 2 }
@@ -26,7 +29,7 @@ export default class UserButtons extends Component<Props> {
       <ButtonToolbar>
         <LinkContainer to='/settings/profile'>
           <Button bsSize='small' style={buttonStyle}>
-            <Icon type='user' /> My account
+            <Icon type='user' /> {this.messages('myAccount')}
           </Button>
         </LinkContainer>
         {isSiteAdmin && (
@@ -35,16 +38,16 @@ export default class UserButtons extends Component<Props> {
               bsSize='small'
               style={buttonStyle}
             >
-              <Icon type='cog' /> Admin
+              <Icon type='cog' /> {this.messages('admin')}
             </Button>
           </LinkContainer>
         )}
         <Button
-          style={buttonStyle}
           bsSize='small'
           bsStyle='primary'
-          onClick={logout}>
-          <Icon type='sign-out' /> Log out
+          onClick={logout}
+          style={buttonStyle}>
+          <Icon type='sign-out' /> {this.messages('logout')}
         </Button>
       </ButtonToolbar>
     )

--- a/lib/common/containers/wrapComponentInAuthStrategy.js
+++ b/lib/common/containers/wrapComponentInAuthStrategy.js
@@ -7,6 +7,7 @@ import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import { browserHistory } from 'react-router'
 
+import {getComponentMessages} from '../util/config'
 import type {AppState, ManagerUserState} from '../../types/reducers'
 
 type AuthWrapperProps = {
@@ -29,6 +30,7 @@ export default function wrapComponentInAuthStrategy (
     const { user } = props
     const userIsLoggedIn: boolean = !!user.token
     const adminTestFailed = requireAdmin && !user.isCheckingLogin && !userHasAdminViewPrivileges(user)
+    const messages = getComponentMessages('WrapComponentInAuthStrategy')
 
     useEffect(() => {
       // Check admin privs. Redirect to landing page if logged-in user is not admin.
@@ -44,7 +46,7 @@ export default function wrapComponentInAuthStrategy (
       // If admin privileges are required, but the user is not authorized.
       return (
         <div>
-          <p>You have attempted to view a restricted page without proper credentials</p>
+          <p>{messages('adminTestFailed')}</p>
         </div>
       )
     } else {

--- a/lib/common/util/config.js
+++ b/lib/common/util/config.js
@@ -99,8 +99,10 @@ function initializeConfig () {
     // $FlowFixMe - assume file exists and make flow happy
     require('../../../i18n/english.yml'),
     // $FlowFixMe - assume file exists and make flow happy
-    require('../../../i18n/polish.yml')
-    // Add additional language files once translation files are available here.
+    require('../../../i18n/polish.yml'),
+    // $FlowFixMe - assume file exists and make flow happy
+    require('../../../i18n/german.yml')
+    // Add additional language files here.
     // E.g., require('../../../i18n/espanol.yml')
   ]
 

--- a/lib/editor/components/EditorFeedSourcePanel.js
+++ b/lib/editor/components/EditorFeedSourcePanel.js
@@ -69,7 +69,7 @@ export default class EditorFeedSourcePanel extends Component<Props> {
               {/* These are the available snapshots */}
               <Panel bsStyle='success'>
                 <Panel.Heading><Panel.Title componentClass='h3'>
-                  Available snapshots
+                  {this.messages('availableSnapshots')}
                 </Panel.Title></Panel.Heading>
                 <ListGroup>
                   {snapshots.length === 0
@@ -98,7 +98,7 @@ export default class EditorFeedSourcePanel extends Component<Props> {
             <Button
               block
               disabled={editDisabled}>
-              <Icon type='pencil' /> Edit feed
+              <Icon type='pencil' /> {this.messages('editFeed')}
             </Button>
           </LinkContainer>
           <Button
@@ -107,7 +107,7 @@ export default class EditorFeedSourcePanel extends Component<Props> {
             disabled={editDisabled}
             onClick={this._openModal}
             style={{marginBottom: '20px'}}>
-            <Icon type='camera' /> Take snapshot of latest changes
+            <Icon type='camera' /> {this.messages('snapshotLatest')}
           </Button>
           <Panel>
             <Panel.Heading><Panel.Title componentClass='h3'><Icon type='camera' /> {this.messages('help.title')}</Panel.Title></Panel.Heading>

--- a/lib/editor/components/EditorInput.js
+++ b/lib/editor/components/EditorInput.js
@@ -306,7 +306,7 @@ export default class EditorInput extends React.Component<Props> {
               {/* Add field for empty string value if that is not an allowable option so that user selection triggers onChange */}
               {options.findIndex(option => option.value === '') === -1 && (
                 <option disabled value=''>
-                  {field.required ? this.messages('selectOption') : this.messages('(optional)') }
+                  {field.required ? this.messages('selectOption') : this.messages('optional') }
                 </option>
               )}
               {field.options && field.options.map(o => (

--- a/lib/editor/components/EditorInput.js
+++ b/lib/editor/components/EditorInput.js
@@ -14,6 +14,7 @@ import {FIELD_PROPS} from '../util/types'
 import {doesNotExist} from '../util/validation'
 import TimezoneSelect from '../../common/components/TimezoneSelect'
 import LanguageSelect from '../../common/components/LanguageSelect'
+import {getComponentMessages} from '../../common/util/config'
 import toSentenceCase from '../../common/util/to-sentence-case'
 import type {Entity, Feed, GtfsSpecField, GtfsAgency, GtfsStop} from '../../types'
 import type {EditorTables} from '../../types/reducers'
@@ -55,6 +56,7 @@ const entityToOption = (entity: ?Entity, key: string) => {
 }
 
 export default class EditorInput extends React.Component<Props> {
+  messages = getComponentMessages('EditorInput')
   /**
    * Helper method for processing field value changes.
    */
@@ -193,12 +195,12 @@ export default class EditorInput extends React.Component<Props> {
             <FormGroup
               className='col-xs-12'
               key={`${editorField}-upload`}>
-              <ControlLabel>Upload {activeComponent} branding asset</ControlLabel>
+              <ControlLabel>{this.messages('uploadAsset').replace('%activeComponent%', activeComponent)}</ControlLabel>
               <Dropzone
                 accept='image/*'
                 multiple={false}
                 onDrop={this._uploadBranding}>
-                <div style={{marginBottom: '10px'}}>Drop {activeComponent} image here, or click to select image to upload.</div>
+                <div style={{marginBottom: '10px'}}>{this.messages('dropImage').replace('%activeComponent%', activeComponent)}</div>
                 {url
                   ? <img
                     alt={field.name}
@@ -252,7 +254,7 @@ export default class EditorInput extends React.Component<Props> {
         dateTimeProps.dateTime = currentValue ? +moment(currentValue) : defaultValue
         dateTimeProps.onChange = this._onDateChange
         if (!currentValue) {
-          dateTimeProps.defaultText = 'Please select a date'
+          dateTimeProps.defaultText = this.messages('selectDate')
         }
         return (
           <FormGroup {...formProps}>
@@ -274,7 +276,7 @@ export default class EditorInput extends React.Component<Props> {
           <span>
             <span>
               {editorField === 'monday' // insert label for entire category on first checkbox
-                ? <div className='col-xs-12'><ControlLabel>Days of service</ControlLabel></div>
+                ? <div className='col-xs-12'><ControlLabel>{this.messages('daysOfService')}</ControlLabel></div>
                 : null
               }
             </span>
@@ -304,7 +306,7 @@ export default class EditorInput extends React.Component<Props> {
               {/* Add field for empty string value if that is not an allowable option so that user selection triggers onChange */}
               {options.findIndex(option => option.value === '') === -1 && (
                 <option disabled value=''>
-                  {field.required ? '-- select an option --' : '(optional)' }
+                  {field.required ? this.messages('selectOption') : this.messages('(optional)') }
                 </option>
               )}
               {field.options && field.options.map(o => (
@@ -345,7 +347,7 @@ export default class EditorInput extends React.Component<Props> {
           <FormGroup {...formProps}>
             {basicLabel}
             <Select
-              placeholder='Select agency...'
+              placeholder={this.messages('selectAgency')}
               clearable
               value={agency
                 ? agencyToOption(agency)

--- a/lib/editor/components/EditorSidebar.js
+++ b/lib/editor/components/EditorSidebar.js
@@ -4,8 +4,8 @@ import React, {Component} from 'react'
 
 import ActiveSidebarNavItem from '../../common/containers/ActiveSidebarNavItem'
 import ActiveSidebar from '../../common/containers/ActiveSidebar'
+import {getComponentMessages} from '../../common/util/config'
 import { GTFS_ICONS } from '../util/ui'
-
 import type {Feed} from '../../types'
 import type {GtfsIcon} from '../util/ui'
 
@@ -16,6 +16,8 @@ type Props = {
 }
 
 export default class EditorSidebar extends Component<Props> {
+  messages = getComponentMessages('EditorSidebar')
+
   isActive (item: GtfsIcon, component: string) {
     return component === item.id || (component === 'scheduleexception' && item.id === 'calendar')
   }
@@ -28,7 +30,7 @@ export default class EditorSidebar extends Component<Props> {
         <ActiveSidebarNavItem
           data-test-id='nav-home-button'
           icon='home'
-          label='Back to Feed'
+          label={this.messages('backToFeed')}
           link={feedSource ? `/feed/${feedSource.id}` : `/home`}
           ref='backNav'
         />

--- a/lib/editor/components/EntityDetailsHeader.js
+++ b/lib/editor/components/EntityDetailsHeader.js
@@ -4,12 +4,12 @@ import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
 import {Badge, Button, ButtonGroup, Tooltip, OverlayTrigger, Nav, NavItem} from 'react-bootstrap'
 
+import {getComponentMessages} from '../../common/util/config'
 import * as activeActions from '../actions/active'
 import * as mapActions from '../actions/map'
 import {getEntityBounds, getEntityName} from '../util/gtfs'
 import {entityIsNew} from '../util/objects'
 import {GTFS_ICONS} from '../util/ui'
-
 import type {Entity, Feed, GtfsRoute, GtfsStop, Pattern} from '../../types'
 import type {MapState} from '../../types/reducers'
 import type {EditorValidationIssue} from '../util/validation'
@@ -36,6 +36,8 @@ type Props = {
 }
 
 export default class EntityDetailsHeader extends Component<Props> {
+  messages = getComponentMessages('EntityDetailsHeader')
+
   _onClickSave = () => {
     if (this.props.subComponent === 'trippattern') {
       this.props.saveActiveGtfsEntity('trippattern')
@@ -125,7 +127,7 @@ export default class EntityDetailsHeader extends Component<Props> {
     )
     const hasErrors = validationErrors.length > 0
     const entityName = activeComponent === 'feedinfo'
-      ? 'Feed Info'
+      ? this.messages('feedInfo')
       : getEntityName(activeEntity)
     const icon = GTFS_ICONS.find(i => i.id === activeComponent)
     const zoomDisabled = activeEntity && !subComponent
@@ -144,7 +146,7 @@ export default class EntityDetailsHeader extends Component<Props> {
               ? <OverlayTrigger
                 rootClose
                 placement='bottom'
-                overlay={<Tooltip id='tooltip'>Zoom to {activeComponent}</Tooltip>}>
+                overlay={<Tooltip id='tooltip'>{this.messages('zoomTo')} {activeComponent}</Tooltip>}>
                 <Button
                   bsSize='small'
                   disabled={zoomDisabled}
@@ -157,7 +159,7 @@ export default class EntityDetailsHeader extends Component<Props> {
             <OverlayTrigger
               rootClose
               placement='bottom'
-              overlay={<Tooltip id='tooltip'>Undo changes</Tooltip>}>
+              overlay={<Tooltip id='tooltip'>{this.messages('undoChanges')}</Tooltip>}>
               <Button
                 bsSize='small'
                 disabled={!entityEdited}
@@ -168,7 +170,7 @@ export default class EntityDetailsHeader extends Component<Props> {
             <OverlayTrigger
               rootClose
               placement='bottom'
-              overlay={<Tooltip id='tooltip'>Save changes</Tooltip>}>
+              overlay={<Tooltip id='tooltip'>{this.messages('saveChanges')}</Tooltip>}>
               <Button
                 bsSize='small'
                 data-test-id='save-entity-button'
@@ -216,7 +218,7 @@ export default class EntityDetailsHeader extends Component<Props> {
         {/* Validation issues */}
         <p style={{marginBottom: '2px'}}>
           <small style={{marginTop: '3px'}} className='pull-right'>
-            <em className='text-muted'>* denotes required field</em>
+            <em className='text-muted'>{this.messages('requiredField')}</em>
           </small>
           <small
             className={`${hasErrors ? ' text-danger' : ' text-success'}`}>
@@ -230,11 +232,11 @@ export default class EntityDetailsHeader extends Component<Props> {
                   placement='bottom'
                   overlay={validationTooltip}>
                   <span style={{borderBottom: '1px dotted #000'}}>
-                    {validationErrors.length} validation issue(s)
+                    {validationErrors.length} {this.messages('validationIssues')}
                   </span>
                 </OverlayTrigger>
               </span>
-              : <span><Icon type='check-circle' /> No validation issues</span>
+              : <span><Icon type='check-circle' /> {this.messages('noValidationIssues')}</span>
             }
           </small>
         </p>
@@ -245,7 +247,7 @@ export default class EntityDetailsHeader extends Component<Props> {
               eventKey={'route'}
               active={subComponent !== 'trippattern'}
               onClick={this._showRoute}>
-              Route details
+              {this.messages('routeDetails')}
             </NavItem>
             <OverlayTrigger placement='bottom' overlay={<Tooltip id='tooltip'>Trip patterns define a route&rsquo;s unique stop sequences and timings.</Tooltip>}>
               <NavItem
@@ -255,7 +257,7 @@ export default class EntityDetailsHeader extends Component<Props> {
                 eventKey={'trippattern'}
                 onClick={this._showTripPatterns}
               >
-                Trip patterns
+                {this.messages('tripPatterns')}
                 <Badge>{activeEntity.tripPatterns ? activeEntity.tripPatterns.length : 0}</Badge>
               </NavItem>
             </OverlayTrigger>
@@ -268,7 +270,7 @@ export default class EntityDetailsHeader extends Component<Props> {
                 eventKey={'fare'}
                 onClick={this._showFareAttributes}
               >
-                Attributes
+                {this.messages('attributes')}
               </NavItem>
               <NavItem
                 active={editFareRules}
@@ -277,7 +279,7 @@ export default class EntityDetailsHeader extends Component<Props> {
                 eventKey={'rules'}
                 onClick={this._showFareRules}
               >
-                Rules
+                {this.messages('rules')}
               </NavItem>
             </Nav>
             : null

--- a/lib/editor/components/EntityList.js
+++ b/lib/editor/components/EntityList.js
@@ -9,15 +9,15 @@ import {AutoSizer} from 'react-virtualized/dist/commonjs/AutoSizer'
 import * as activeActions from '../actions/active'
 import * as editorActions from '../actions/editor'
 import * as snapshotActions from '../actions/snapshots'
-import {getConfigProperty} from '../../common/util/config'
+import {getConfigProperty, getComponentMessages} from '../../common/util/config'
 import {componentToText, entityIsNew} from '../util/objects'
-import EntityListButtons from './EntityListButtons'
-import EntityListSecondaryActions from './EntityListSecondaryActions'
-
 import type {Props as ContainerProps} from '../containers/ActiveEntityList'
 import type {Entity, Feed} from '../../types'
 import type {DataStateSort, EditorTables} from '../../types/reducers'
 import type {ImmutableList} from '../selectors/index'
+
+import EntityListSecondaryActions from './EntityListSecondaryActions'
+import EntityListButtons from './EntityListButtons'
 
 type Props = ContainerProps & {
   activeEntity: Entity,
@@ -47,6 +47,8 @@ type State = {
 
 export default class EntityList extends Component<Props, State> {
   state = {}
+
+  messages = getComponentMessages('EntityList')
 
   componentWillReceiveProps (nextProps: Props) {
     if (nextProps.activeComponent !== this.props.activeComponent) {
@@ -165,7 +167,7 @@ export default class EntityList extends Component<Props, State> {
             onRowClick={this._onRowClick}
             rowGetter={this._getRow}>
             <Column
-              label='Name'
+              label={this.messages('name')}
               dataKey='name'
               className='small entity-list-row'
               style={{outline: 'none'}}
@@ -190,7 +192,7 @@ export default class EntityList extends Component<Props, State> {
           data-test-id='create-stop-instructions'
           style={{marginTop: '10px', marginRight: '5px', marginLeft: '5px'}}
         >
-          <small>Right-click a location on map to create a new stop</small>
+          <small>{this.messages('createStop')}</small>
         </div>
         : <div style={{marginTop: '20px'}} className='text-center'>
           <Button
@@ -199,7 +201,7 @@ export default class EntityList extends Component<Props, State> {
             disabled={createDisabled}
             onClick={this._onClickNew}>
             <Icon type='plus' />{' '}
-            Create first {componentToText(activeComponent)}
+            {this.messages('createFirst')} {componentToText(activeComponent)}
           </Button>
         </div>
     return (
@@ -226,7 +228,7 @@ export default class EntityList extends Component<Props, State> {
               block
               disabled={!hasRoutes}
               onClick={this._onClickTimetableEditor}>
-              <Icon type='calendar' /> Edit schedules
+              <Icon type='calendar' /> {this.messages('editSchedules')}
             </Button>
             : null
           }

--- a/lib/editor/components/FeedInfoPanel.js
+++ b/lib/editor/components/FeedInfoPanel.js
@@ -64,8 +64,8 @@ export default class FeedInfoPanel extends Component<Props, State> {
     const {editorSnapshots: snapshots} = this.props.feedSource
     const snapshot = snapshots && snapshots.find(s => s.id === key)
     snapshot && this.props.showConfirmModal({
-      title: `Restore ${key}?`,
-      body: `Are you sure you want to restore this snapshot?`,
+      title: this.messages('restoreSnapshot.title').replace('%key%', key),
+      body: this.messages('restoreSnapshot.body'),
       onConfirm: () => {
         this.props.restoreSnapshot(this.props.feedSource, snapshot)
       }
@@ -124,7 +124,7 @@ export default class FeedInfoPanel extends Component<Props, State> {
       ? feedSource.name.substr(0, 10) + '...'
       : feedSource && feedSource.name
         ? feedSource.name
-        : 'Unnamed'
+        : this.messages('unnamed')
 
     return (
       <div>
@@ -136,7 +136,7 @@ export default class FeedInfoPanel extends Component<Props, State> {
           />
           <ButtonGroup>
             {/* Hide toolbar toggle */}
-            <OverlayTrigger placement='top' overlay={<Tooltip id='hide-tooltip'>{toolbarVisible ? 'Hide toolbar' : 'Show toolbar'}</Tooltip>}>
+            <OverlayTrigger placement='top' overlay={<Tooltip id='hide-tooltip'>{toolbarVisible ? this.messages('toolbar.hide') : this.messages('toolbar.show')}</Tooltip>}>
               <Button
                 data-test-id='FeedInfoPanel-visibility-toggle'
                 onClick={this._onToggleHide}
@@ -147,11 +147,11 @@ export default class FeedInfoPanel extends Component<Props, State> {
             {/* Navigation dropdown */}
             <DropdownButton
               dropup
-              title={<span title={`Editing ${feedSource && feedSource.name}`}>Editing {feedName}</span>}
+              title={<span title={this.messages('editingFeed').replace('%feed%', feedSource && feedSource.name)}>{this.messages('editingFeed').replace('%feed%', feedName)}</span>}
               id='navigation-dropdown'
               onSelect={this._onNavigate}>
-              <MenuItem eventKey='1'><Icon type='reply' /> Back to project</MenuItem>
-              <MenuItem eventKey='2'><Icon type='reply' /> Back to feed source</MenuItem>
+              <MenuItem eventKey='1'><Icon type='reply' /> {this.messages('backToProject')}</MenuItem>
+              <MenuItem eventKey='2'><Icon type='reply' /> {this.messages('backToFeedSource')}</MenuItem>
             </DropdownButton>
             <Button
               onClick={this.showUploadFileModal}>
@@ -169,7 +169,7 @@ export default class FeedInfoPanel extends Component<Props, State> {
                   <MenuItem
                     key={c.id}
                     eventKey={c.id}>
-                    <Icon type={c.icon} /> Add {componentToText(c.id)}
+                    <Icon type={c.icon} /> {this.messages('add').replace('%id%', componentToText(c.id))}
                   </MenuItem>
                 )
               })}
@@ -183,7 +183,7 @@ export default class FeedInfoPanel extends Component<Props, State> {
                 onSelect={this._onSelectSnapshot}>
                 <OverlayTrigger
                   placement='top'
-                  overlay={<Tooltip id='snapshot-tooltip'>Take snapshot</Tooltip>}>
+                  overlay={<Tooltip id='snapshot-tooltip'>{this.messages('takeSnapshot')}</Tooltip>}>
                   <Button
                     bsStyle='primary'
                     data-test-id='take-snapshot-button'
@@ -203,14 +203,14 @@ export default class FeedInfoPanel extends Component<Props, State> {
                         <MenuItem
                           key={snapshot.id}
                           eventKey={snapshot.id}>
-                          <Icon type='reply' /> Revert to {snapshot.name}
+                          <Icon type='reply' /> {this.messages('revert').replace('%snapshot%', snapshot.name)}
                         </MenuItem>
                       )
                     })
                     : <MenuItem
                       disabled
                       eventKey={null}>
-                      <em>No snapshots created</em>
+                      <em>{this.messages('noSnapshot')}</em>
                     </MenuItem>
                   }
                 </Dropdown.Menu>

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -5,6 +5,7 @@ import objectPath from 'object-path'
 import React, {Component} from 'react'
 import {Button} from 'react-bootstrap'
 
+import {getComponentMessages} from '../../../common/util/config'
 import {camelCaseKeys} from '../../../common/util/map-keys'
 import * as activeActions from '../../actions/active'
 import * as tripActions from '../../actions/trip'
@@ -59,6 +60,7 @@ type State = {
 }
 
 export default class TimetableEditor extends Component<Props, State> {
+  messages = getComponentMessages('TimetableEditor')
   // State is used to track height/width of the window to dynamically adjust
   // height of Grid as well as the visibility of the help modal.
   state = {
@@ -295,10 +297,10 @@ export default class TimetableEditor extends Component<Props, State> {
       return
     }
     showConfirmModal({
-      title: `Delete trips?`,
-      body: `Are you sure you want to permanently delete ${selectedCount} selected trip${selectedCount > 1 ? 's' : ''}?`,
+      title: this.messages('deleteTripsQuestion'),
+      body: this.messages(selectedCount > 1 ? 'deleteSelectedTrip' : 'deleteSelectedTrips').replace('%count%', selectedCount.toString()),
       confirmButtonStyle: 'danger',
-      confirmButtonText: 'Delete trips',
+      confirmButtonText: this.messages('deleteTrips'),
       onConfirm: () => {
         const indexes = []
         const tripsToDelete = []
@@ -414,10 +416,10 @@ export default class TimetableEditor extends Component<Props, State> {
                 <Button
                   bsStyle='success'
                   onClick={this._createNewCalendar}>
-                  create a new one
+                  {this.messages('createNew')}
                 </Button>
               </span>
-              : <span>Choose a trip pattern.</span>
+              : <span>{this.messages('choosePattern')}</span>
             }
           </p>
         }

--- a/lib/editor/components/timetable/TimetableHelpModal.js
+++ b/lib/editor/components/timetable/TimetableHelpModal.js
@@ -63,9 +63,9 @@ export default class TimetableHelpModal extends Component<Props, State> {
         </Body>
         <Footer>
           <span className='pull-left'>
-            <small>Press <kbd>?</kbd> to view shortcuts</small>
+            <small>{this.messages('pressQuestionmark')}</small>
           </span>
-          <Button onClick={this._close}>Close</Button>
+          <Button onClick={this._close}>{this.messages('close')}</Button>
         </Footer>
       </Modal>
     )

--- a/lib/editor/util/ui.js
+++ b/lib/editor/util/ui.js
@@ -1,5 +1,6 @@
 // @flow
 
+import {getComponentMessages} from '../../common/util/config'
 import type { Feed } from '../../types'
 import type { ManagerUserState } from '../../types/reducers'
 
@@ -13,46 +14,48 @@ export type GtfsIcon = {
   title: string
 }
 
+const messages = getComponentMessages('GtfsIcons')
+
 export const GTFS_ICONS = [
   {
     id: 'feedinfo',
     tableName: 'feedinfo',
     icon: 'info',
     addable: false,
-    title: 'Edit feed info',
-    label: 'Feed Info'
+    title: messages('feedinfo.title'),
+    label: messages('feedinfo.label')
   },
   {
     id: 'agency',
     tableName: 'agency',
     icon: 'building',
     addable: true,
-    title: 'Edit agencies',
-    label: 'Agencies'
+    title: messages('agency.title'),
+    label: messages('agency.label')
   },
   {
     id: 'route',
     tableName: 'routes',
     icon: 'bus',
     addable: true,
-    title: 'Edit routes',
-    label: 'Routes'
+    title: messages('route.title'),
+    label: messages('route.label')
   },
   {
     id: 'stop',
     tableName: 'stops',
     icon: 'map-marker',
     addable: true,
-    title: 'Edit stops',
-    label: 'Stops'
+    title: messages('stop.title'),
+    label: messages('stop.label')
   },
   {
     id: 'calendar',
     tableName: 'calendar',
     icon: 'calendar',
     addable: true,
-    title: 'Edit calendars',
-    label: 'Calendars'
+    title: messages('calendar.title'),
+    label: messages('calendar.label')
   },
   {
     id: 'scheduleexception',
@@ -60,16 +63,16 @@ export const GTFS_ICONS = [
     icon: 'ban',
     addable: true,
     hideSidebar: true,
-    title: 'Edit schedule exceptions',
-    label: 'Schedule Exceptions'
+    title: messages('scheduleexception.title'),
+    label: messages('scheduleexception.label')
   },
   {
     id: 'fare',
     tableName: 'fare',
     icon: 'ticket',
     addable: true,
-    title: 'Edit fares',
-    label: 'Fares'
+    title: messages('fare.title'),
+    label: messages('fare.label')
   }
 ]
 

--- a/lib/manager/components/CreateProject.js
+++ b/lib/manager/components/CreateProject.js
@@ -5,6 +5,7 @@ import { Col, Grid, Row } from 'react-bootstrap'
 
 import { createProject } from '../actions/projects'
 import ManagerPage from '../../common/components/ManagerPage'
+import {getComponentMessages} from '../../common/util/config'
 import type { ManagerUserState } from '../../types/reducers'
 
 import ProjectSettingsForm from './ProjectSettingsForm'
@@ -18,6 +19,8 @@ type Props = {
  * A component to facilitate the creation of a new project.
  */
 export default class CreateProject extends Component<Props> {
+  messages = getComponentMessages('CreateProject')
+
   _saveProject = (projectId: string, data: Object) => {
     return this.props.createProject(data)
   }
@@ -28,11 +31,11 @@ export default class CreateProject extends Component<Props> {
     return (
       <ManagerPage
         ref='page'
-        title={'Create New Project'}>
+        title={this.messages('new')}>
         <Grid fluid>
           <Row>
             <Col xs={12} sm={8}>
-              <h2>Create New Project</h2>
+              <h2>{this.messages('new')}</h2>
               <ProjectSettingsForm
                 onCancelUrl='/project'
                 // Initialize project with empty object.

--- a/lib/manager/components/FeedSourcePanel.js
+++ b/lib/manager/components/FeedSourcePanel.js
@@ -8,7 +8,6 @@ import {Link} from 'react-router'
 import * as visibilityFilterActions from '../actions/visibilityFilter'
 import OptionButton from '../../common/components/OptionButton'
 import {getComponentMessages} from '../../common/util/config'
-import toSentenceCase from '../../common/util/to-sentence-case'
 import {getAbbreviatedProjectName} from '../../common/util/util'
 import type {Feed, Project} from '../../types'
 import type {ManagerUserState} from '../../types/reducers'
@@ -26,7 +25,7 @@ export default class FeedSourcePanel extends Component<Props> {
 
   _feedVisibilityFilter = (feed: Feed) => {
     const {visibilityFilter} = this.props
-    const name = feed.name || 'unnamed'
+    const name = feed.name || this.messages('unnamed')
     const searchText = (visibilityFilter.searchText || '').toLowerCase()
     const visible = name.toLowerCase().indexOf(searchText) !== -1
     switch (visibilityFilter.filter) {
@@ -76,10 +75,10 @@ export default class FeedSourcePanel extends Component<Props> {
       )
     return (
       <Panel>
-        <Panel.Heading><Panel.Title componentClass='h3'>Feeds for{' '}
+        <Panel.Heading><Panel.Title componentClass='h3'>{this.messages('forFeed')}{' '}
           {activeProject
             ? getAbbreviatedProjectName(activeProject)
-            : '[choose project]'
+            : this.messages('chooseProject')
           }{' '}
           {activeProject && activeProject.feedSources &&
             <Badge>{activeProject.feedSources.length}</Badge>
@@ -99,7 +98,7 @@ export default class FeedSourcePanel extends Component<Props> {
                   href='#'
                   key={b}
                   onClick={setVisibilityFilter}
-                  value={b}>{toSentenceCase(b)}</OptionButton>
+                  value={b}>{this.messages('filters' + '.' + b)}</OptionButton>
               ))}
             </ButtonGroup>
           </ListGroupItem>
@@ -110,15 +109,15 @@ export default class FeedSourcePanel extends Component<Props> {
             : activeProject
               ? <ListGroupItem>
                 <p className='lead text-center'>
-                  No feeds yet.{' '}
+                  {this.messages('noFeedsYet')}{' '}
                   {isProjectAdmin &&
-                    <Link to={`/project/${activeProject.id}`}>Create one.</Link>
+                    <Link to={`/project/${activeProject.id}`}>{this.messages('createOne')}</Link>
                   }
                 </p>
               </ListGroupItem>
               : <ListGroupItem>
                 <p className='lead text-center'>
-                  Choose a project to view feeds
+                  {this.messages('chooseProjectToView')}
                 </p>
               </ListGroupItem>
           }

--- a/lib/manager/components/FeedSourceSettings.js
+++ b/lib/manager/components/FeedSourceSettings.js
@@ -11,7 +11,7 @@ import {
 import {LinkContainer} from 'react-router-bootstrap'
 
 import * as feedsActions from '../actions/feeds'
-import {isExtensionEnabled} from '../../common/util/config'
+import {getComponentMessages, isExtensionEnabled} from '../../common/util/config'
 import toSentenceCase from '../../common/util/to-sentence-case'
 import type {Feed, Project} from '../../types'
 import type {ManagerUserState} from '../../types/reducers'
@@ -33,6 +33,7 @@ type Props = {
 }
 
 export default class FeedSourceSettings extends Component<Props> {
+  messages = getComponentMessages('FeedSourceSettings')
   render () {
     const {
       activeComponent,
@@ -54,7 +55,7 @@ export default class FeedSourceSettings extends Component<Props> {
       return (
         <Row>
           <Col xs={6} mdOffset={3}>
-            <p className='lead text-center'><strong>Warning!</strong> You do not have permission to edit details for this feed source.</p>
+            <p className='lead text-center'><strong>{this.messages('warning')}</strong> {this.messages('noPermission')}</p>
           </Col>
         </Row>
       )
@@ -74,7 +75,7 @@ export default class FeedSourceSettings extends Component<Props> {
           />
         ),
         subPath: '',
-        title: 'General'
+        title: this.messages('general')
       },
       {
         condition: true,
@@ -88,7 +89,7 @@ export default class FeedSourceSettings extends Component<Props> {
           />
         ),
         subPath: 'transformations',
-        title: 'Feed Transformations'
+        title: this.messages('feedTransformations')
       },
       {
         condition: isExtensionEnabled('mtc'),
@@ -100,7 +101,7 @@ export default class FeedSourceSettings extends Component<Props> {
           />
         ),
         subPath: 'autopublish',
-        title: 'Auto-publish'
+        title: this.messages('autoPublish')
       },
       ...Object.keys(feedSource.externalProperties || {}).map(resourceType => {
         const resourceLowerCase = resourceType.toLowerCase()
@@ -121,7 +122,7 @@ export default class FeedSourceSettings extends Component<Props> {
             </Col>
           ),
           subPath: resourceLowerCase,
-          title: `${toSentenceCase(resourceType)} properties`
+          title: `${toSentenceCase(resourceType)} ${this.messages('properties')}`
         }
       })
     ]

--- a/lib/manager/components/FeedSourceTable.js
+++ b/lib/manager/components/FeedSourceTable.js
@@ -41,7 +41,7 @@ export default class FeedSourceTable extends PureComponent<Props> {
               </th>
             }
             <th className='feed-version-column top-row' colSpan={3}>
-              <h4>Latest Version</h4>
+              <h4>{this.messages('latestVersion')}</h4>
             </th>
             <th />
           </tr>
@@ -49,33 +49,33 @@ export default class FeedSourceTable extends PureComponent<Props> {
             <th>
               <h4>
                 <Icon type='info-circle' />
-                Feed Info
+                {this.messages('feedInfo')}
               </h4>
             </th>
             {comparisonColumn &&
               <th className='comparison-column'>
                 <h4>
                   <Icon type='heartbeat' />
-                  Status
+                  {this.messages('status')}
                 </h4>
               </th>
             }
             <th className='feed-version-column'>
               <h4>
                 <Icon type='heartbeat' />
-                Status
+                {this.messages('status')}
               </h4>
             </th>
             <th className='feed-version-column'>
               <h4>
                 <Icon type='calendar-check-o' />
-                Dates Valid
+                {this.messages('datesValid')}
               </h4>
             </th>
             <th className='feed-version-column'>
               <h4>
                 <Icon type='exclamation-triangle' />
-                Issues
+                {this.messages('issues')}
               </h4>
             </th>
             <th />

--- a/lib/manager/components/FeedSourceTableRow.js
+++ b/lib/manager/components/FeedSourceTableRow.js
@@ -43,8 +43,6 @@ type Props = ContainerProps & {
   user: ManagerUserState
 }
 
-const dateFormat = 'MMM D, YYYY'
-
 const statusAttributeLookup = {
   'active': {
     className: 'status-active',
@@ -83,37 +81,6 @@ function wrapLookupStatus (status, data = {}) {
   }
 }
 
-/**
- * Get some UI data from a ValidationSummary
- */
-function getVersionDisplayData (
-  validationSummary: ?ValidationSummary
-) {
-  if (validationSummary) {
-    const errorCount = validationSummary.errorCount || 'None'
-    const endMoment = moment(validationSummary.endDate)
-    const startMoment = moment(validationSummary.startDate)
-    return wrapLookupStatus(
-      endMoment.isBefore(moment())
-        ? 'expired'
-        : endMoment.isBefore(moment().add(5, 'days'))
-          ? 'expiring-within-5-days'
-          : endMoment.isBefore(moment().add(20, 'days'))
-            ? 'expiring-within-20-days'
-            : startMoment.isBefore(moment())
-              ? 'active'
-              : 'future',
-      {
-        endDate: endMoment.format(dateFormat),
-        errorCount,
-        startDate: startMoment.format(dateFormat)
-      }
-    )
-  } else {
-    return wrapLookupStatus('no-version')
-  }
-}
-
 function relativeDuration (time: any) {
   return humanizeDuration(
     (moment().unix() - moment(time).unix()) * 1000,
@@ -121,52 +88,81 @@ function relativeDuration (time: any) {
   )
 }
 
-/**
- * This method generates the variables and used to live in the render method,
- * but was extracted to appease the eslint complexity rule
- */
-function generateFeedSourceLabelRenderVars (feedSource: Feed, comparisonValidationSummary: ?ValidationSummary) {
-  // data for feed source info column
-  let lastVersionUpdate = !!feedSource.lastUpdated &&
-      relativeDuration(feedSource.lastUpdated)
-  lastVersionUpdate = lastVersionUpdate
-    ? `Last updated ${lastVersionUpdate} ago`
-    : ''
+export default class FeedSourceTableRow extends PureComponent<Props> {
+  messages = getComponentMessages('FeedSourceTableRow')
+  dateFormat = this.messages('dateFormat')
 
-  // data for comparison column
-  const comparisonData = comparisonValidationSummary &&
-      getVersionDisplayData(comparisonValidationSummary)
-
-  let comparisonSubtext, comparisonSubtextDate
-  if (comparisonData && comparisonValidationSummary) {
-    if (comparisonData.status === 'future') {
-      comparisonSubtext = `Starting in ${
-        relativeDuration(comparisonValidationSummary.startDate)
-      }`
-      comparisonSubtextDate = comparisonValidationSummary.startDate
-    } else if (comparisonData.status === 'expired') {
-      comparisonSubtext = `Expired ${
-        relativeDuration(comparisonValidationSummary.endDate)
-      } ago`
-      comparisonSubtextDate = comparisonValidationSummary.endDate
+  /**
+   * Get some UI data from a ValidationSummary
+   */
+  getVersionDisplayData (
+    validationSummary: ?ValidationSummary
+  ) {
+    if (validationSummary) {
+      const errorCount = validationSummary.errorCount || this.messages('none')
+      const endMoment = moment(validationSummary.endDate)
+      const startMoment = moment(validationSummary.startDate)
+      return wrapLookupStatus(
+        endMoment.isBefore(moment())
+          ? 'expired'
+          : endMoment.isBefore(moment().add(5, 'days'))
+            ? 'expiring-within-5-days'
+            : endMoment.isBefore(moment().add(20, 'days'))
+              ? 'expiring-within-20-days'
+              : startMoment.isBefore(moment())
+                ? 'active'
+                : 'future',
+        {
+          endDate: endMoment.format(this.dateFormat),
+          errorCount,
+          startDate: startMoment.format(this.dateFormat)
+        }
+      )
     } else {
-      comparisonSubtext = `Valid for another ${
-        relativeDuration(comparisonValidationSummary.endDate)
-      }`
-      comparisonSubtextDate = comparisonValidationSummary.endDate
+      return wrapLookupStatus('no-version')
     }
   }
 
-  return {
-    lastVersionUpdate,
-    comparisonSubtext,
-    comparisonSubtextDate,
-    comparisonData
-  }
-}
+  /**
+   * This method generates the variables and used to live in the render method,
+   * but was extracted to appease the eslint complexity rule
+   */
+  generateFeedSourceLabelRenderVars (feedSource: Feed, comparisonValidationSummary: ?ValidationSummary) {
+    // data for feed source info column
+    let lastVersionUpdate = !!feedSource.lastUpdated &&
+        relativeDuration(feedSource.lastUpdated)
+    lastVersionUpdate = lastVersionUpdate
+      ? this.messages('lastUpdated').replace('%lastVersionUpdate%', lastVersionUpdate)
+      : ''
 
-export default class FeedSourceTableRow extends PureComponent<Props> {
-  messages = getComponentMessages('FeedSourceTableRow')
+    // data for comparison column
+    const comparisonData = comparisonValidationSummary &&
+        this.getVersionDisplayData(comparisonValidationSummary)
+
+    let comparisonSubtext, comparisonSubtextDate
+    if (comparisonData && comparisonValidationSummary) {
+      if (comparisonData.status === 'future') {
+        comparisonSubtext = this.messages('startingIn').replace('%duration%',
+          relativeDuration(comparisonValidationSummary.startDate))
+        comparisonSubtextDate = comparisonValidationSummary.startDate
+      } else if (comparisonData.status === 'expired') {
+        comparisonSubtext = this.messages('expired').replace('%duration%',
+          relativeDuration(comparisonValidationSummary.endDate))
+        comparisonSubtextDate = comparisonValidationSummary.endDate
+      } else {
+        comparisonSubtext = this.messages('validFor').replace('%duration%',
+          relativeDuration(comparisonValidationSummary.endDate))
+        comparisonSubtextDate = comparisonValidationSummary.endDate
+      }
+    }
+
+    return {
+      lastVersionUpdate,
+      comparisonSubtext,
+      comparisonSubtextDate,
+      comparisonData
+    }
+  }
 
   render () {
     const {
@@ -182,13 +178,13 @@ export default class FeedSourceTableRow extends PureComponent<Props> {
       comparisonSubtext,
       comparisonData,
       comparisonSubtextDate
-    } = generateFeedSourceLabelRenderVars(
+    } = this.generateFeedSourceLabelRenderVars(
       feedSource,
       comparisonValidationSummary
     )
 
     // data for latest validation columns
-    const currentVersionData = getVersionDisplayData(feedSource.latestValidation)
+    const currentVersionData = this.getVersionDisplayData(feedSource.latestValidation)
 
     if (
       feedSource.latestVersionId &&
@@ -211,6 +207,7 @@ export default class FeedSourceTableRow extends PureComponent<Props> {
               ? (
                 <Status
                   icon={comparisonData.icon}
+                  dateFormat={this.dateFormat}
                   statusSpanClass={comparisonData.className}
                   statusText={this.messages(`status.${comparisonData.status}`)}
                   subtext={comparisonSubtext}
@@ -228,6 +225,7 @@ export default class FeedSourceTableRow extends PureComponent<Props> {
         <td className='feed-version-column'>
           <Status
             icon={currentVersionData.icon}
+            dateFormat={this.dateFormat}
             statusSpanClass={currentVersionData.className}
             statusText={this.messages(`status.${currentVersionData.status}`)}
             subtext={lastVersionUpdate}
@@ -262,8 +260,8 @@ class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user:
     )
 
     const lastUpdateText = feedSource.lastUpdated
-      ? `Last updated ${moment(feedSource.lastUpdated).format(dateFormat)}`
-      : 'No updates yet'
+      ? this.messages('lastUpdatedDate').replace('%date%', moment(feedSource.lastUpdated).format(this.messages('dateFormat')))
+      : this.messages('noUpdates')
 
     return (
       <div>
@@ -335,6 +333,7 @@ class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user:
 }
 
 class Status extends PureComponent<{
+  dateFormat: string,
   icon: string,
   statusSpanClass: string,
   statusText: string,
@@ -342,7 +341,7 @@ class Status extends PureComponent<{
   subtextDate?: string
 }> {
   render () {
-    const {icon, subtext, statusSpanClass, statusText, subtextDate} = this.props
+    const {icon, dateFormat, subtext, statusSpanClass, statusText, subtextDate} = this.props
     return (
       <div>
         <span className={`feed-status ${statusSpanClass}`}>
@@ -360,6 +359,8 @@ class Status extends PureComponent<{
 }
 
 class FeedActionsDropdown extends PureComponent<Props> {
+  messages = getComponentMessages('FeedActionsDropdown')
+
   _onClickDelete = () => {
     // Delete immediately if feed source is being created.
     if (this.props.feedSource.isCreating) return this._onConfirmDelete()
@@ -436,17 +437,17 @@ class FeedActionsDropdown extends PureComponent<Props> {
     return (
       <DropdownButton
         id={`feed-source-action-button-${feedSource.id}`}
-        title='Menu'
+        title={this.messages('menu')}
       >
         <ConfirmModal
           ref='deleteModal'
-          title='Delete Feed Source?'
+          title={this.messages('deleteFeedSource')}
           body={`Are you sure you want to delete the feed source ${feedSource.name}?`}
           onConfirm={this._onConfirmDelete}
         />
         <SelectFileModal
           ref='uploadModal'
-          title='Upload Feed'
+          title={this.messages('uploadFeed')}
           body='Select a GTFS feed to upload:'
           onConfirm={this._onConfirmUpload}
           errorMessage='Uploaded file must be a valid zip file (.zip).'
@@ -455,19 +456,19 @@ class FeedActionsDropdown extends PureComponent<Props> {
           disabled={editGtfsDisabled}
           onClick={this._onClickEdit}
         >
-          <Glyphicon glyph='pencil' /> Open in Editor
+          <Glyphicon glyph='pencil' /> {this.messages('openInEditor')}
         </MenuItem>
         <MenuItem
           disabled={disabled || !feedSource.url}
           onClick={this._onClickFetch}
         >
-          <Glyphicon glyph='refresh' /> Fetch
+          <Glyphicon glyph='refresh' /> {this.messages('fetch')}
         </MenuItem>
         <MenuItem
           disabled={disabled}
           onClick={this._onClickUpload}
         >
-          <Glyphicon glyph='upload' /> Upload
+          <Glyphicon glyph='upload' /> {this.messages('upload')}
         </MenuItem>
         {/* show divider only if deployments and notifications are enabled (otherwise, we don't need it) */}
         {isModuleEnabled('deployment') || getConfigProperty('application.notifications_enabled')
@@ -478,16 +479,16 @@ class FeedActionsDropdown extends PureComponent<Props> {
           ? <MenuItem
             disabled={disabled || !feedSource.deployable || !feedSource.latestValidation}
             title={disabled
-              ? 'You do not have permission to deploy feed'
+              ? this.messages('deployNoPermission')
               : !feedSource.deployable
-                ? 'Feed source is not deployable. Change in feed source settings.'
+                ? this.messages('notDeployable')
                 : !feedSource.latestValidation
-                  ? 'No versions exist. Create new version to deploy feed'
-                  : 'Deploy feed source.'
+                  ? this.messages('noVersions')
+                  : this.messages('deployFeed')
             }
             onClick={this._onClickDeploy}
           >
-            <Glyphicon glyph='globe' /> Deploy
+            <Glyphicon glyph='globe' /> {this.messages('deploy')}
           </MenuItem>
           : null
         }
@@ -504,7 +505,7 @@ class FeedActionsDropdown extends PureComponent<Props> {
           disabled={!feedSource.isPublic}
           onClick={this._onClickPublic}
         >
-          <Glyphicon glyph='link' /> View public page
+          <Glyphicon glyph='link' /> {this.messages('view')}
         </MenuItem>
         <MenuItem divider />
         <MenuItem
@@ -512,7 +513,7 @@ class FeedActionsDropdown extends PureComponent<Props> {
           disabled={disabled}
           onClick={this._onClickDelete}
         >
-          <Icon type='trash' /> Delete
+          <Icon type='trash' /> {this.messages('delete')}
         </MenuItem>
       </DropdownButton>
     )

--- a/lib/manager/components/GeneralSettings.js
+++ b/lib/manager/components/GeneralSettings.js
@@ -17,6 +17,7 @@ import {
 
 import * as feedsActions from '../actions/feeds'
 import { FREQUENCY_INTERVALS } from '../../common/constants'
+import {getComponentMessages} from '../../common/util/config'
 import LabelAssigner from '../components/LabelAssigner'
 import type { Feed, FetchFrequency, Project } from '../../types'
 import type { ManagerUserState } from '../../types/reducers'
@@ -38,6 +39,7 @@ type State = {
 }
 
 export default class GeneralSettings extends Component<Props, State> {
+  messages = getComponentMessages('GeneralSettings')
   state = {}
 
   _onChange = ({target}: SyntheticInputEvent<HTMLInputElement>) => {
@@ -122,11 +124,11 @@ export default class GeneralSettings extends Component<Props, State> {
       <Col xs={7}>
         {/* Settings */}
         <Panel>
-          <Panel.Heading><Panel.Title componentClass='h3'>Settings</Panel.Title></Panel.Heading>
+          <Panel.Heading><Panel.Title componentClass='h3'>{this.messages('title')}</Panel.Title></Panel.Heading>
           <ListGroup>
             <ListGroupItem>
               <FormGroup>
-                <ControlLabel>Feed source name</ControlLabel>
+                <ControlLabel>{this.messages('feedSourceName')}</ControlLabel>
                 <InputGroup>
                   <FormControl
                     disabled={disabled}
@@ -138,7 +140,7 @@ export default class GeneralSettings extends Component<Props, State> {
                       // disable if no change or no value (name is required).
                       disabled={disabled || !name || name === feedSource.name}
                       onClick={this._onNameSaved}>
-                      Rename
+                      {this.messages('rename')}
                     </Button>
                   </InputGroup.Button>
                 </InputGroup>
@@ -150,19 +152,19 @@ export default class GeneralSettings extends Component<Props, State> {
                   checked={feedSource.deployable}
                   data-test-id='make-feed-source-deployable-button'
                   onChange={this._onToggleDeployable}>
-                  <strong>Make feed source deployable</strong>
+                  <strong>{this.messages('makeDeployable')}</strong>
                 </Checkbox>
-                <small>Enable this feed source to be deployed to an OpenTripPlanner (OTP) instance (defined in organization settings) as part of a collection of feed sources or individually.</small>
+                <small>{this.messages('makeDeployableHint')}</small>
               </FormGroup>
             </ListGroupItem>
           </ListGroup>
         </Panel>
         <Panel>
-          <Panel.Heading><Panel.Title componentClass='h3'>Automatic Fetch</Panel.Title></Panel.Heading>
+          <Panel.Heading><Panel.Title componentClass='h3'>{this.messages('autoFetch.title')}</Panel.Title></Panel.Heading>
           <ListGroup>
             <ListGroupItem>
               <FormGroup>
-                <ControlLabel>Feed source fetch URL</ControlLabel>
+                <ControlLabel>{this.messages('autoFetch.url')}</ControlLabel>
                 <InputGroup data-test-id='feed-source-url-input-group'>
                   <FormControl
                     disabled={disabled}
@@ -175,7 +177,7 @@ export default class GeneralSettings extends Component<Props, State> {
                       // Disable if no change or field has not been edited.
                       disabled={disabled || typeof url === 'undefined' || url === feedSource.url}
                       onClick={this._onSaveUrl}>
-                      Change URL
+                      {this.messages('autoFetch.urlButton')}
                     </Button>
                   </InputGroup.Button>
                 </InputGroup>
@@ -188,9 +190,9 @@ export default class GeneralSettings extends Component<Props, State> {
                   checked={autoFetchFeed}
                   disabled={disabled}
                   onChange={this._onToggleAutoFetch}>
-                  <strong>Auto fetch feed source</strong>
+                  <strong>{this.messages('autoFetch.checkbox')}</strong>
                 </Checkbox>
-                <small>Set this feed source to fetch automatically. (Feed source URL must be specified and project auto fetch must be enabled.)</small>
+                <small>{this.messages('autoFetch.hint')}</small>
               </FormGroup>
               {autoFetchFeed
                 ? <FeedFetchFrequency
@@ -205,23 +207,23 @@ export default class GeneralSettings extends Component<Props, State> {
           </ListGroup>
         </Panel>
         <Panel>
-          <Panel.Heading><Panel.Title componentClass='h3'>Labels</Panel.Title></Panel.Heading>
+          <Panel.Heading><Panel.Title componentClass='h3'>{this.messages('labels.title')}</Panel.Title></Panel.Heading>
           <Panel.Body>
             <LabelAssigner feedSource={feedSource} project={project} />
           </Panel.Body>
         </Panel>
         <Panel bsStyle='danger'>
-          <Panel.Heading><Panel.Title componentClass='h3'>Danger Zone</Panel.Title></Panel.Heading>
+          <Panel.Heading><Panel.Title componentClass='h3'>{this.messages('dangerZone')}</Panel.Title></Panel.Heading>
           <ListGroup>
             <ListGroupItem>
               <Button
                 className='pull-right'
                 disabled={disabled}
                 onClick={this._onTogglePublic}>
-                Make {feedSource.isPublic ? 'private' : 'public'}
+                {this.messages(`make.${feedSource.isPublic ? 'private' : 'public'}`)}
               </Button>
-              <h4>Make this feed source {feedSource.isPublic ? 'private' : 'public'}.</h4>
-              <p>This feed source is currently {feedSource.isPublic ? 'public' : 'private'}.</p>
+              <h4>{this.messages(`make.${feedSource.isPublic ? 'private' : 'public'}Desc`)}</h4>
+              <p>{this.messages(`make.${feedSource.isPublic ? 'public' : 'private'}State`)}</p>
             </ListGroupItem>
             <ListGroupItem>
               <Button
@@ -229,10 +231,10 @@ export default class GeneralSettings extends Component<Props, State> {
                 className='pull-right'
                 disabled={disabled}
                 onClick={confirmDeleteFeedSource}>
-                <Icon type='trash' /> Delete feed source
+                <Icon type='trash' /> {this.messages('deleteFeedSource')}
               </Button>
-              <h4>Delete this feed source.</h4>
-              <p>Once you delete a feed source, it cannot be recovered.</p>
+              <h4>{this.messages('deleteFeedSourceDesc')}</h4>
+              <p>{this.messages('deleteFeedSourceHint')}</p>
             </ListGroupItem>
           </ListGroup>
         </Panel>

--- a/lib/manager/components/HomeProjectDropdown.js
+++ b/lib/manager/components/HomeProjectDropdown.js
@@ -8,6 +8,7 @@ import { LinkContainer } from 'react-router-bootstrap'
 import Select from 'react-select'
 
 import {getAbbreviatedProjectName} from '../../common/util/util'
+import {getComponentMessages} from '../../common/util/config'
 import type {Project, ReactSelectOption} from '../../types'
 import type {ManagerUserState} from '../../types/reducers'
 
@@ -18,6 +19,8 @@ type Props = {
 }
 
 export default class HomeProjectDropdown extends Component<Props> {
+  messages = getComponentMessages('HomeProjectDropdown')
+
   handleChange = (option: ReactSelectOption) => {
     browserHistory.push(`/home/${option ? option.value : ''}`)
   }
@@ -41,7 +44,7 @@ export default class HomeProjectDropdown extends Component<Props> {
     if (!profile) return null
     const abbreviatedProjectName = getAbbreviatedProjectName(activeProject)
     const options = visibleProjects.map(
-      project => ({value: project.id, label: project.name || '[No name]'})
+      project => ({label: project.name || '[No name]', value: project.id})
     )
     return (
       <div style={{marginBottom: '20px'}}>
@@ -49,7 +52,7 @@ export default class HomeProjectDropdown extends Component<Props> {
           isAdmin && (
             <LinkContainer to='/project/new'>
               <Button bsStyle='link' style={{paddingLeft: 0}}>
-                <Icon type='plus' /> New project
+                <Icon type='plus' /> {this.messages('new')}
               </Button>
             </LinkContainer>
           )
@@ -61,7 +64,7 @@ export default class HomeProjectDropdown extends Component<Props> {
               onChange={this.handleChange}
               optionRenderer={this._optionRenderer}
               options={options}
-              placeholder='Select project...'
+              placeholder={this.messages('select') + '...'}
               value={options.find(o =>
                 activeProject && o.value === activeProject.id
               )}
@@ -74,12 +77,12 @@ export default class HomeProjectDropdown extends Component<Props> {
             <Button
               disabled={!activeProject}
               style={{width: '30%'}}
-              title={activeProject ? `View ${activeProject.name}` : ''}
+              title={activeProject ? this.messages('view').replace('%name%', activeProject.name) : ''}
               bsStyle='primary'
             >
               {activeProject
-                ? `View ${abbreviatedProjectName}`
-                : 'Select project'
+                ? this.messages('view').replace('%name%', abbreviatedProjectName)
+                : this.messages('select')
               }
             </Button>
           </LinkContainer>

--- a/lib/manager/components/LabelPanel.js
+++ b/lib/manager/components/LabelPanel.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { Panel } from 'react-bootstrap'
 
 import FeedLabel from '../../common/components/FeedLabel'
+import {getComponentMessages} from '../../common/util/config'
 import type { ManagerUserState } from '../../types/reducers'
 
 import LabelEditorModal from './LabelEditorModal'
@@ -15,6 +16,8 @@ export type Props = {
 };
 
 export default class LabelPanel extends Component<Props> {
+  messages = getComponentMessages('LabelPanel')
+
   _onClickNewLabel = () => this.refs.newLabelModal.open();
 
   render () {
@@ -33,7 +36,7 @@ export default class LabelPanel extends Component<Props> {
 
     let labelBody = (
       <div className='noLabelsMessage'>
-        There are no labels in this project.
+        {this.messages('noLabels')}
       </div>
     )
     if (labels.length > 0) {
@@ -43,7 +46,7 @@ export default class LabelPanel extends Component<Props> {
 
     return (
       <Panel>
-        <Panel.Heading><Panel.Title componentClass='h3'><Icon type={'tag'} />{' '}Labels</Panel.Title></Panel.Heading>
+        <Panel.Heading><Panel.Title componentClass='h3'><Icon type={'tag'} />{' '}{this.messages('labels')}</Panel.Title></Panel.Heading>
         <Panel.Body>
           <div className={`feedLabelContainer ${large ? 'large' : ''} grid`}>
             <LabelEditorModal projectId={projectId} ref='newLabelModal' />
@@ -52,7 +55,7 @@ export default class LabelPanel extends Component<Props> {
                 className='labelActionButton'
                 onClick={this._onClickNewLabel}
               >
-                Add a new label
+                {this.messages('new')}
               </button>
             )}
             {labelBody}

--- a/lib/manager/components/ManagerHeader.js
+++ b/lib/manager/components/ManagerHeader.js
@@ -9,7 +9,7 @@ import numeral from 'numeral'
 
 import WatchButton from '../../common/containers/WatchButton'
 import StarButton from '../../common/containers/StarButton'
-import { getConfigProperty } from '../../common/util/config'
+import { getComponentMessages, getConfigProperty } from '../../common/util/config'
 import type {Feed, FeedVersionSummary, Project} from '../../types'
 import type {ManagerUserState} from '../../types/reducers'
 
@@ -20,6 +20,8 @@ type Props = {
 }
 
 export default class ManagerHeader extends Component<Props> {
+  messages = getComponentMessages('ManagerHeader')
+
   getAverageFileSize (feedVersionSummaries: ?Array<FeedVersionSummary>) {
     let sum = 0
     let avg
@@ -59,7 +61,7 @@ export default class ManagerHeader extends Component<Props> {
               ? null
               : <Icon
                 className='text-warning'
-                title='This feed source and all its versions are private.'
+                title={this.messages('private')}
                 type='lock' />
             }
             {' '}
@@ -89,10 +91,10 @@ export default class ManagerHeader extends Component<Props> {
               <Icon type='clock-o' />{' '}
               {feedSource.lastUpdated
                 ? moment(feedSource.lastUpdated).format(dateFormat)
-                : 'n/a'
+                : this.messages('noUpdateYet')
               }
             </li>
-            <li><Icon type='link' /> {feedSource.url || '(none)'}
+            <li><Icon type='link' /> {feedSource.url || this.messages('noUrl')}
             </li>
             <li>
               <Icon type='file-archive-o' />{' '}

--- a/lib/manager/components/ProjectFeedListToolbar.js
+++ b/lib/manager/components/ProjectFeedListToolbar.js
@@ -114,86 +114,86 @@ export default class ProjectFeedListToolbar extends PureComponent<Props> {
     // of the feed or a function to return data from either the feed or the
     // comparison validation summary
     const columns = [{
-      label: 'Name',
+      label: this.messages('name'),
       key: 'name'
     }, {
-      label: 'Is Public',
+      label: this.messages('isPublic'),
       key: (feed, comparisonValidation) => yn(feed.isPublic)
     }, {
-      label: 'Last Time Data Fetched from Feed URL',
+      label: this.messages('lastFetched'),
       key: (feed, comparisonValidation) => formattedDate(feed.lastFetched)
     }, {
-      label: 'Last Updated',
+      label: this.messages('lastUpdated'),
       key: (feed, comparisonValidation) => formattedDate(feed.lastUpdated)
     }, {
-      label: 'Feed download URL',
+      label: this.messages('url'),
       key: 'url'
     }, {
-      label: 'Has a latest version?',
+      label: this.messages('hasLatestVersion'),
       key: (feed, comparisonValidation) => yn(feed.latestValidation)
     }, {
-      label: 'Latest Version: Start Date',
+      label: this.messages('latestValidation.startDate'),
       key: (feed, comparisonValidation) => formattedDate(
         get(feed, 'latestValidation.startDate')
       )
     }, {
-      label: 'Latest Version: End Date',
+      label: this.messages('latestValidation.endDate'),
       key: (feed, comparisonValidation) => formattedDate(
         get(feed, 'latestValidation.endDate')
       )
     }, {
-      label: 'Latest Version: Number of Issues',
+      label: this.messages('latestValidation.errorCount'),
       key: 'latestValidation.errorCount'
     }, {
-      label: 'Latest Version: Number of Routes',
+      label: this.messages('latestValidation.routeCount'),
       key: 'latestValidation.routeCount'
     }, {
-      label: 'Latest Version: Number of Stops',
+      label: this.messages('latestValidation.stopCount'),
       key: 'latestValidation.stopCount'
     }, {
-      label: 'Latest Version: Number of Trips',
+      label: this.messages('latestValidation.tripCount'),
       key: 'latestValidation.tripCount'
     }, {
-      label: 'Latest Version: Number of Stop Times',
+      label: this.messages('latestValidation.stopTimesCount'),
       key: 'latestValidation.stopTimesCount'
     }]
 
     // add comparison columns if needed
     if (filter.feedSourceTableComparisonColumn) {
       const labelPrefix = filter.feedSourceTableComparisonColumn === 'DEPLOYED'
-        ? 'Deployed Version:'
-        : 'Published Version:'
+        ? this.messages('deployedVersion')
+        : this.messages('publishedVersion')
 
       columns.push({
         label: filter.feedSourceTableComparisonColumn === 'DEPLOYED'
-          ? 'Has Deployed Version?'
-          : 'Has Published Version?',
+          ? this.messages('hasDeployedVersion')
+          : this.messages('hasPublishedVersion'),
         key: (feed, comparisonValidation) => yn(comparisonValidation)
       })
       columns.push(...[{
-        label: `${labelPrefix} Start Date`,
+        label: this.messages('labelStartDate').replace('%labelPrefix%', labelPrefix),
         key: (feed, comparisonValidation) => formattedDate(
           get(comparisonValidation, 'startDate')
         )
       }, {
-        label: `${labelPrefix} End Date`,
+        label: this.messages('labelEndDate').replace('%labelPrefix%', labelPrefix),
         key: (feed, comparisonValidation) => formattedDate(
           get(comparisonValidation, 'endDate')
         )
       }, {
-        label: `${labelPrefix} Number of Issues`,
+        label: this.messages('labelNumberIssues').replace('%labelPrefix%', labelPrefix),
         key: (feed, comparisonValidation) => get(comparisonValidation, 'errorCount')
       }, {
-        label: `${labelPrefix} Number of Routes`,
+        label: this.messages('labelNumberRoutes').replace('%labelPrefix%', labelPrefix),
         key: (feed, comparisonValidation) => get(comparisonValidation, 'routeCount')
       }, {
-        label: `${labelPrefix} Number of Stops`,
+        label: this.messages('labelNumberStops').replace('%labelPrefix%', labelPrefix),
         key: (feed, comparisonValidation) => get(comparisonValidation, 'stopCount')
       }, {
-        label: `${labelPrefix} Number of Trips`,
+        label: this.messages('labelNumberTrips').replace('%labelPrefix%', labelPrefix),
         key: (feed, comparisonValidation) => get(comparisonValidation, 'tripCount')
       }, {
-        label: `${labelPrefix} Number of Stop Times`,
+        label: this.messages('labelNumberStopTimes').replace('%labelPrefix%', labelPrefix),
         key: (feed, comparisonValidation) => get(comparisonValidation, 'stopTimesCount')
       }])
     }
@@ -286,7 +286,7 @@ export default class ProjectFeedListToolbar extends PureComponent<Props> {
   _renderSortOptions () {
     const options = [
       <MenuItem header key='sort-header-note'>
-        Note: sorting only available on latest version data
+        {this.messages('noteSorting')}
       </MenuItem>
     ]
     const sortOptions = [...new Set(
@@ -319,7 +319,7 @@ export default class ProjectFeedListToolbar extends PureComponent<Props> {
     return (
       <MenuItem header style={{ width: 275 }}>
         <h5>
-          Show feeds with
+          {this.messages('showFeedsWith')}
           <select
             name='anyall'
             id='anyall'
@@ -327,10 +327,10 @@ export default class ProjectFeedListToolbar extends PureComponent<Props> {
             onChange={this._onLabelModeSelectorClick}
             style={{margin: '0 3px'}}
           >
-            <option value='any'>any</option>
-            <option value='all'>all</option>
+            <option value='any'>{this.messages('any')}</option>
+            <option value='all'>{this.messages('all')}</option>
           </select>
-          of the labels:
+          {this.messages('ofTheLabels')}
         </h5>
         <div className='feedLabelContainer grid'>
           {project.labels.map((label) => (
@@ -371,9 +371,9 @@ export default class ProjectFeedListToolbar extends PureComponent<Props> {
 
     return (
       <ControlLabel style={{ display: 'block' }}>
-        Filter feed sources on
+        { this.messages('filterFeedSources')}
         {strategySelect}
-        version
+        { this.messages('version')}
       </ControlLabel>
     )
   }
@@ -410,7 +410,7 @@ export default class ProjectFeedListToolbar extends PureComponent<Props> {
             bsSize='small'
             id='project-feedsource-table-sort-button'
             style={{ marginLeft: 20 }}
-            title='Sort By'
+            title={this.messages('sortBy')}
           >
             {this._renderSortOptions()}
           </DropdownButton>
@@ -439,7 +439,7 @@ export default class ProjectFeedListToolbar extends PureComponent<Props> {
               bsSize='small'
               id='project-feedsource-label-filter-button'
               title={
-                <span title='Filter feeds by labels'>
+                <span title={this.messages('filterByLabels')}>
                   <Icon type={'tag'} />{' '}
                   <Badge style={badgeStyle}>
                     {activeFilterLabelCount}
@@ -458,7 +458,7 @@ export default class ProjectFeedListToolbar extends PureComponent<Props> {
             data-test-id='project-header-action-dropdown-button'
             id='project-header-actions'
             style={{ marginLeft: 20 }}
-            title='Actions'
+            title={this.messages('actions')}
           >
             {!projectEditDisabled && (
               <MenuItem

--- a/lib/manager/components/ProjectSettingsForm.js
+++ b/lib/manager/components/ProjectSettingsForm.js
@@ -133,7 +133,7 @@ export default class ProjectSettingsForm extends Component<Props, State> {
     const autoFetchFeeds = evt.target.checked
     this.setState(update(this.state, {
       model: {
-        $merge: {autoFetchFeeds, autoFetchMinute, autoFetchHour}
+        $merge: {autoFetchFeeds, autoFetchHour, autoFetchMinute}
       }
     }))
   }
@@ -171,8 +171,8 @@ export default class ProjectSettingsForm extends Component<Props, State> {
     this.setState(update(this.state, {
       model: {
         $merge: {
-          autoFetchMinute: time.minutes(),
-          autoFetchHour: time.hours()
+          autoFetchHour: time.hours(),
+          autoFetchMinute: time.minutes()
         }
       }
     }))
@@ -231,8 +231,8 @@ export default class ProjectSettingsForm extends Component<Props, State> {
     if (editDisabled) {
       return (
         <p className='lead text-center'>
-          <strong>Warning!</strong>{' '}
-          You do not have permission to edit details for this feed source.
+          <strong>{this.messages('warning')}</strong>{' '}
+          {this.messages('noPermissions')}
         </p>
       )
     }
@@ -254,7 +254,7 @@ export default class ProjectSettingsForm extends Component<Props, State> {
                   value={model.name || ''}
                 />
                 <FormControl.Feedback />
-                <HelpBlock>Required.</HelpBlock>
+                <HelpBlock>{this.messages('required')}</HelpBlock>
               </FormGroup>
             </ListGroupItem>
           </ListGroup>
@@ -325,11 +325,11 @@ export default class ProjectSettingsForm extends Component<Props, State> {
           </ListGroup>
         </Panel>
         <Panel>
-          <Panel.Heading><Panel.Title componentClass='h4'>Local Places Index</Panel.Title></Panel.Heading>
+          <Panel.Heading><Panel.Title componentClass='h4'>{this.messages('fields.localPlacesIndex.title')}</Panel.Title></Panel.Heading>
           <ListGroup>
             <ListGroupItem>
               <FormGroup validationState={validationState(validation.webhookUrl)}>
-                <ControlLabel>Webhook URL</ControlLabel>
+                <ControlLabel>{this.messages('fields.localPlacesIndex.webhookUrl')}</ControlLabel>
                 <FormControl
                   name={'peliasWebhookUrl'}
                   onChange={this._onChangeTextInput}
@@ -342,7 +342,7 @@ export default class ProjectSettingsForm extends Component<Props, State> {
         </Panel>
         {showDangerZone &&
           <Panel bsStyle='danger'>
-            <Panel.Heading><Panel.Title componentClass='h3'>Danger Zone</Panel.Title></Panel.Heading>
+            <Panel.Heading><Panel.Title componentClass='h3'>{this.messages('dangerZone')}</Panel.Title></Panel.Heading>
             <ListGroup>
               <ListGroupItem>
                 <Button
@@ -351,10 +351,10 @@ export default class ProjectSettingsForm extends Component<Props, State> {
                   data-test-id='delete-project-button'
                   onClick={this._onDeleteProject}
                 >
-                  <Icon type='trash' /> Delete project
+                  <Icon type='trash' /> {this.messages('deleteProject')}
                 </Button>
-                <h4>Delete this project.</h4>
-                <p>Once you delete an project, the project and all feed sources it contains cannot be recovered.</p>
+                <h4>{this.messages('deleteThisProject')}</h4>
+                <p>{this.messages('deleteWarning')}</p>
               </ListGroupItem>
             </ListGroup>
           </Panel>

--- a/lib/manager/components/ProjectViewer.js
+++ b/lib/manager/components/ProjectViewer.js
@@ -111,8 +111,9 @@ export default class ProjectViewer extends Component<Props, State> {
         </Button>
         {s3Bucket &&
           <p className='small'>
-            <strong>Note:</strong> Public feeds page can be viewed{' '}
-            <a href={publicFeedsLink} target='_blank'>here</a>.
+            <strong>{this.messages('note')}</strong>
+            {this.messages('publicViewed')}
+            <a href={publicFeedsLink} target='_blank'>{this.messages('here')}</a>.
           </p>
         }
       </div>
@@ -165,9 +166,9 @@ export default class ProjectViewer extends Component<Props, State> {
             <Row>
               <Col xs={12}>
                 <p className='project-not-found'>
-                  No project found for <strong>{this.props.projectId}</strong>
+                  {this.messages('noProjectFound')} <strong>{this.props.projectId}</strong>
                 </p>
-                <p><Link to='/project'>Return to list of projects</Link></p>
+                <p><Link to='/project'>{this.messages('returnToProjects')}</Link></p>
               </Col>
             </Row>
           </Grid>
@@ -204,7 +205,7 @@ export default class ProjectViewer extends Component<Props, State> {
                         ? '0' + project.autoFetchMinute
                         : project.autoFetchMinute
                     }`
-                    : 'Auto fetch disabled'}
+                    : this.messages('autoFetchDisabled')}
                 </li>
               </ul>
             </Col>
@@ -278,6 +279,8 @@ export default class ProjectViewer extends Component<Props, State> {
 }
 
 class ProjectSummaryPanel extends Component<{feedSources: Array<Feed>, project: Project}> {
+  messages = getComponentMessages('ProjectSummaryPanel')
+
   render () {
     const { feedSources, project } = this.props
     const errorCount = feedSources
@@ -289,14 +292,14 @@ class ProjectSummaryPanel extends Component<{feedSources: Array<Feed>, project: 
       .reduce((a, b) => a + b, 0)
     return (
       <Panel>
-        <Panel.Heading><Panel.Title componentClass='h3'>{project.name} summary</Panel.Title></Panel.Heading>
+        <Panel.Heading><Panel.Title componentClass='h3'>{project.name} {this.messages('summary')}</Panel.Title></Panel.Heading>
         <ListGroup>
-          <ListGroupItem>Number of feeds: {feedSources.length}</ListGroupItem>
-          <ListGroupItem>Total errors: {errorCount}</ListGroupItem>
+          <ListGroupItem>{this.messages('numberOfFeeds')} {feedSources.length}</ListGroupItem>
+          <ListGroupItem>{this.messages('totalErrors')} {errorCount}</ListGroupItem>
           <ListGroupItem>
-            Total service:{' '}
+            {this.messages('totalService')}{' '}
             {Math.floor(serviceSeconds / 60 / 60 * 100) / 100}{' '}
-            hours per weekday
+            {this.messages('hoursPerWeekday')}
           </ListGroupItem>
         </ListGroup>
       </Panel>
@@ -305,15 +308,15 @@ class ProjectSummaryPanel extends Component<{feedSources: Array<Feed>, project: 
 }
 
 const ExplanatoryPanel = ({ project }) => {
-  // If user has more than 3 labels, hide the feed source instruction
+  const messages = getComponentMessages('ProjectViewer')
+
+  // If project has more than 3 labels, hide the feed source instruction
   if (project.labels.length <= 3) {
     return (
       <Panel>
-        <Panel.Heading><Panel.Title componentClass='h3'>What is a feed source?</Panel.Title></Panel.Heading>
+        <Panel.Heading><Panel.Title componentClass='h3'>{messages('feedSourceTitle')}</Panel.Title></Panel.Heading>
         <Panel.Body>
-          A feed source defines the location or upstream source of a GTFS feed.
-          GTFS can be populated via automatic fetch, directly editing or uploading
-          a zip file.
+          {messages('feedSourceDesc')}
         </Panel.Body>
       </Panel>
     )

--- a/lib/manager/components/ProjectViewer.js
+++ b/lib/manager/components/ProjectViewer.js
@@ -111,7 +111,7 @@ export default class ProjectViewer extends Component<Props, State> {
         </Button>
         {s3Bucket &&
           <p className='small'>
-            <strong>{this.messages('note')}</strong>
+            <strong>{this.messages('note')}</strong>{' '}
             {this.messages('publicViewed')}
             <a href={publicFeedsLink} target='_blank'>{this.messages('here')}</a>.
           </p>

--- a/lib/manager/components/UserAccountInfoPanel.js
+++ b/lib/manager/components/UserAccountInfoPanel.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import { Panel, Badge, Row, Col } from 'react-bootstrap'
 
 import * as userActions from '../actions/user'
+import {getComponentMessages} from '../../common/util/config'
 import UserButtons from '../../common/components/UserButtons'
 import type {ManagerUserState} from '../../types/reducers'
 
@@ -13,6 +14,8 @@ type Props = {
 }
 
 export default class UserAccountInfoPanel extends Component<Props> {
+  messages = getComponentMessages('UserAccountInfoPanel')
+
   render () {
     const {
       user,
@@ -29,22 +32,22 @@ export default class UserAccountInfoPanel extends Component<Props> {
           <Row>
             <Col xs={4}>
               <img
-                alt='Profile'
+                alt={this.messages('profile')}
                 style={{ width: '100%', borderRadius: '50%' }}
                 src={profile.picture} />
             </Col>
             <Col md={8}>
               <h4 style={{marginTop: 0, marginBottom: 15}}>
-              Hello, {profile.nickname}.
+                {this.messages('hello')}, {profile.nickname}.
               </h4>
               <div className='text-muted'>{profile.email}</div>
               <div>
                 <Badge className='text-muted'>
                   {permissions.isApplicationAdmin()
-                    ? 'Application admin'
+                    ? this.messages('roles.applicationAdmin')
                     : permissions.canAdministerAnOrganization()
-                      ? 'Organization admin'
-                      : 'Standard user'
+                      ? this.messages('roles.organizationAdmin')
+                      : this.messages('roles.standardUser')
                   }
                 </Badge>
                 {/* TODO: fetch organization for user and show badge here */}

--- a/lib/manager/components/UserHomePage.js
+++ b/lib/manager/components/UserHomePage.js
@@ -11,7 +11,7 @@ import * as userActions from '../actions/user'
 import * as visibilityFilterActions from '../actions/visibilityFilter'
 import ManagerPage from '../../common/components/ManagerPage'
 import { DEFAULT_DESCRIPTION, DEFAULT_TITLE } from '../../common/constants'
-import {getConfigProperty} from '../../common/util/config'
+import {getConfigProperty, getComponentMessages} from '../../common/util/config'
 import {defaultSorter} from '../../common/util/util'
 import type {Props as ContainerProps} from '../containers/ActiveUserHomePage'
 import type {Project} from '../../types'
@@ -50,6 +50,8 @@ export default class UserHomePage extends Component<Props, State> {
   state = {
     showLoading: false
   }
+
+  messages = getComponentMessages('UserHomePage')
 
   componentWillMount () {
     const {onUserHomeMount, projectId, user} = this.props
@@ -94,7 +96,7 @@ export default class UserHomePage extends Component<Props, State> {
             <Col md={8} xs={12}>
               {/* Top Welcome Box */}
               <Jumbotron style={{ padding: 30 }}>
-                <h2>Welcome to {getConfigProperty('application.title') || DEFAULT_TITLE}!</h2>
+                <h2>{this.messages('welcomeTo')} {getConfigProperty('application.title') || DEFAULT_TITLE}!</h2>
                 <p>{getConfigProperty('application.description') || DEFAULT_DESCRIPTION}</p>
                 <ButtonToolbar>
                   <Button
@@ -102,19 +104,19 @@ export default class UserHomePage extends Component<Props, State> {
                     bsSize='large'
                     href={getConfigProperty('application.docs_url')}
                   >
-                    <Icon type='info-circle' /> User docs
+                    <Icon type='info-circle' /> {this.messages('userDocs')}
                   </Button>
                 </ButtonToolbar>
               </Jumbotron>
               {/* Recent Activity List */}
               <h3 style={{ borderBottom: '2px solid #ddd', marginTop: 0, paddingBottom: 5 }}>
-                <Icon type='comments-o' /> Recent Activity
+                <Icon type='comments-o' /> {this.messages('recentActivity')}
               </h3>
               {user.recentActivity && user.recentActivity.length
                 ? user.recentActivity.sort(sortByDate).map((item, k) => {
                   return <RecentActivityBlock currentUser={user} item={item} key={k} />
                 })
-                : <span>No Recent Activity for your subscriptions.</span>
+                : <span>{this.messages('recentActivityNone')}</span>
               }
             </Col>
             <Col md={4} xs={12}>

--- a/lib/manager/components/transform/NormalizeField.js
+++ b/lib/manager/components/transform/NormalizeField.js
@@ -14,16 +14,17 @@ import {
 } from 'react-bootstrap'
 import Select from 'react-select'
 
+import { getComponentMessages } from '../../../common/util/config'
 import GtfsFieldSelector from '../GtfsFieldSelector'
-import SubstitutionRow from './SubstitutionRow'
 import { isSubstitutionBlank, isSubstitutionInvalid } from '../../util/transform'
-
 import type {
   NormalizeFieldFields,
   ReactSelectOption,
   Substitution,
   TransformProps
 } from '../../../types'
+
+import SubstitutionRow from './SubstitutionRow'
 
 type State = {
   activeEditingIndex: number,
@@ -59,6 +60,8 @@ function areSubstitutionsEqual (sub1: ?Substitution, sub2: ?Substitution): boole
  * Component that renders input fields for the NormalizeFieldTransformation.
  */
 export default class NormalizeField extends Component<TransformProps<NormalizeFieldFields>, State> {
+  messages = getComponentMessages('NormalizeField')
+
   state = {
     activeEditingIndex: -1,
     activeSubstitution: null,
@@ -131,17 +134,17 @@ export default class NormalizeField extends Component<TransformProps<NormalizeFi
 
     // fieldName must be defined.
     if (!fieldName || fieldName.length === 0) {
-      issues.push('Field to normalize must be defined.')
+      issues.push(this.messages('issues.fieldUndefined'))
     }
 
     // The pattern for substitutions must not be null or empty.
     if (substitutions.filter(isSubstitutionBlank).length > 0) {
-      issues.push('Substitution patterns must be defined.')
+      issues.push(this.messages('issues.substitutionUndefined'))
     }
 
     // The pattern for substitutions must be valid.
     if (substitutions.filter(isSubstitutionInvalid).length > 0) {
-      issues.push('Some substitution patterns are invalid.')
+      issues.push(this.messages('issues.substitutionInvalid'))
     }
 
     return issues

--- a/lib/manager/components/version/FeedVersionNavigator.js
+++ b/lib/manager/components/version/FeedVersionNavigator.js
@@ -180,10 +180,10 @@ export default class FeedVersionNavigator extends Component<Props, State> {
     return (
       <div>
         <SelectFileModal ref='uploadModal'
-          title='Upload Feed'
-          body='Select a GTFS feed to upload:'
+          title={this.messages('uploadFeed')}
+          body={this.messages('selectFeed')}
           onConfirm={this._onConfirmUpload}
-          errorMessage='Uploaded file must be a valid zip file (.zip).' />
+          errorMessage={this.messages('zipWarning')} />
         <Row style={{marginBottom: '20px'}}>
           {/* Version Navigation Widget and Name Editor */}
           <Col xs={12} style={versionTitleStyle}>
@@ -221,7 +221,7 @@ export default class FeedVersionNavigator extends Component<Props, State> {
                         id: 'versionSelector',
                         onSelect: this._onSelectVersion
                       }}
-                      header='Select a version to view summary'
+                      header={this.messages('selectVersion')}
                       title={dropdownTitle}
                       version={version}
                       versions={versionSummaries}
@@ -262,7 +262,7 @@ export default class FeedVersionNavigator extends Component<Props, State> {
                       data-test-id='deploy-feed-version-button'
                       disabled={disabled || !hasVersions}
                       onClick={this._createDeployment}>
-                      <Icon type='globe' /> Deploy feed
+                      <Icon type='globe' /> {this.messages('deployFeed')}
                     </Button>
                     : null
                   }
@@ -271,7 +271,7 @@ export default class FeedVersionNavigator extends Component<Props, State> {
                       <Button
                         data-test-id='edit-feed-version-button'
                         disabled={editDisabled}>
-                        <Glyphicon glyph='pencil' /> Edit feed
+                        <Glyphicon glyph='pencil' /> {this.messages('editFeed')}
                       </Button>
                     </LinkContainer>
                     : null
@@ -283,7 +283,7 @@ export default class FeedVersionNavigator extends Component<Props, State> {
                     disabled={disabled}
                     title={
                       <span>
-                        <Icon type='plus' /> Create new version
+                        <Icon type='plus' /> {this.messages('newVersion')}
                       </span>
                     }
                     id='bg-nested-dropdown'
@@ -293,14 +293,14 @@ export default class FeedVersionNavigator extends Component<Props, State> {
                       disabled={disabled || !feedSource.url}
                       eventKey='fetch'
                     >
-                      <Glyphicon glyph='refresh' /> Fetch
+                      <Glyphicon glyph='refresh' /> {this.messages('fetch')}
                     </MenuItem>
                     <MenuItem
                       data-test-id='upload-feed-button'
                       disabled={disabled}
                       eventKey='upload'
                     >
-                      <Glyphicon glyph='upload' /> Upload
+                      <Glyphicon glyph='upload' /> {this.messages('upload')}
                     </MenuItem>
                     <MenuItem divider />
                     <MenuItem
@@ -309,7 +309,7 @@ export default class FeedVersionNavigator extends Component<Props, State> {
                         feedSource.editorSnapshots.length === 0
                       }
                       eventKey='snapshot'>
-                      <Glyphicon glyph='camera' /> From snapshot
+                      <Glyphicon glyph='camera' /> {this.messages('fromSnapshot')}
                     </MenuItem>
                   </DropdownButton>
                   : null

--- a/lib/manager/components/version/VersionComparisonDropdown.js
+++ b/lib/manager/components/version/VersionComparisonDropdown.js
@@ -5,6 +5,7 @@ import {MenuItem} from 'react-bootstrap'
 import {connect} from 'react-redux'
 
 import * as versionsActions from '../../actions/versions'
+import {getComponentMessages} from '../../../common/util/config'
 import type {Feed, FeedVersion, FeedVersionSummary} from '../../../types'
 
 import VersionSelectorDropdown, {DefaultItemFormatter} from './VersionSelectorDropdown'
@@ -22,6 +23,8 @@ type Props = {
  * active version.
  */
 class VersionComparisonDropdown extends Component<Props> {
+  messages = getComponentMessages('VersionComparisonDropdown')
+
   _onSelectComparedVersion = (index: number) => {
     const {comparedVersion, feedSource, setComparedVersion} = this.props
     const comparedVersionIndex = comparedVersion ? comparedVersion.version : -1
@@ -51,8 +54,8 @@ class VersionComparisonDropdown extends Component<Props> {
       versionSummaries
     } = this.props
     const title = comparedVersion
-      ? `Comparing to version ${comparedVersion.version}`
-      : 'Compare versions'
+      ? this.messages('compareToVersion').replace('%version%', comparedVersion.version.toString())
+      : this.messages('compareVersions')
 
     return (
       <VersionSelectorDropdown
@@ -62,11 +65,11 @@ class VersionComparisonDropdown extends Component<Props> {
         }}
         extraOptions={comparedVersion && [{
           onClick: this._onClearComparedVersion,
-          text: 'Exit compare mode'
+          text: this.messages('exit')
         }]}
         header={versionSummaries.length < 2
-          ? 'Load another version to enable comparison'
-          : 'Select a version to compare with'
+          ? this.messages('loadAnother')
+          : this.messages('selectVersion')
         }
         itemFormatter={this.itemFormatter}
         title={title}

--- a/lib/manager/components/version/VersionSelectorDropdown.js
+++ b/lib/manager/components/version/VersionSelectorDropdown.js
@@ -5,6 +5,7 @@ import * as React from 'react'
 import { Dropdown, MenuItem as BsMenuItem } from 'react-bootstrap'
 
 import MenuItem from '../../../common/components/MenuItem'
+import {getComponentMessages} from '../../../common/util/config'
 import type { FeedVersionSummary } from '../../../types'
 
 import VersionRetrievalBadge from './VersionRetrievalBadge'
@@ -51,6 +52,9 @@ export default function VersionSelectorDropdown (props: Props) {
     version,
     versions
   } = props
+
+  const messages = getComponentMessages('VersionSelectorDropdown')
+
   const versionsSorted = versions
     ? versions.slice(0).reverse()
     : []
@@ -65,7 +69,7 @@ export default function VersionSelectorDropdown (props: Props) {
         {header ? <MenuItem header>{header}</MenuItem> : null}
         {versionsSorted.length > 0
           ? versionsSorted.map((v, i) => itemFormatter(v, version))
-          : <MenuItem disabled>No versions available</MenuItem>}
+          : <MenuItem disabled>{messages('noVersions')}</MenuItem>}
 
         {extraOptions && <BsMenuItem divider />}
         {extraOptions && extraOptions.map((option, i) => (

--- a/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
@@ -4164,6 +4164,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                         <strong>
                                                           Note:
                                                         </strong>
+                                                         
                                                         Public feeds page can be viewed
                                                         <a
                                                           href="https://s3.amazonaws.com/bucket-name/public/index.html"

--- a/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
@@ -1119,7 +1119,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                         className="fa fa-times-circle fa-fw "
                                       />
                                     </Icon>
-                                     Clear completed
+                                    Clear completed
                                   </button>
                                 </Button>
                                 <div
@@ -1362,7 +1362,8 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                           className="fa fa-user fa-fw "
                                         />
                                       </Icon>
-                                       My account
+                                       
+                                      My account
                                     </button>
                                   </Button>
                                 </LinkContainer>
@@ -1405,7 +1406,8 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                           className="fa fa-cog fa-fw "
                                         />
                                       </Icon>
-                                       Admin
+                                       
+                                      Admin
                                     </button>
                                   </Button>
                                 </LinkContainer>
@@ -1441,7 +1443,8 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                         className="fa fa-sign-out fa-fw "
                                       />
                                     </Icon>
-                                     Log out
+                                     
+                                    Log out
                                   </button>
                                 </Button>
                               </div>
@@ -4161,8 +4164,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                         <strong>
                                                           Note:
                                                         </strong>
-                                                         Public feeds page can be viewed
-                                                         
+                                                        Public feeds page can be viewed
                                                         <a
                                                           href="https://s3.amazonaws.com/bucket-name/public/index.html"
                                                           target="_blank"
@@ -4238,7 +4240,8 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                                     className="panel-title"
                                                                   >
                                                                     mock-project
-                                                                     summary
+                                                                     
+                                                                    summary
                                                                   </h3>
                                                                 </PanelTitle>
                                                               </div>
@@ -4257,7 +4260,8 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                                   <li
                                                                     className="list-group-item"
                                                                   >
-                                                                    Number of feeds: 
+                                                                    Number of feeds:
+                                                                     
                                                                     0
                                                                   </li>
                                                                 </ListGroupItem>
@@ -4269,7 +4273,8 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                                   <li
                                                                     className="list-group-item"
                                                                   >
-                                                                    Total errors: 
+                                                                    Total errors:
+                                                                     
                                                                     0
                                                                   </li>
                                                                 </ListGroupItem>

--- a/lib/manager/containers/__tests__/__snapshots__/FeedSourceTable.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/FeedSourceTable.js.snap
@@ -4219,6 +4219,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                             className="comparison-column"
                           >
                             <Status
+                              dateFormat="MMM D, YYYY"
                               icon="check-circle"
                               statusSpanClass="status-active"
                               statusText="Active"
@@ -4252,6 +4253,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                             className="feed-version-column"
                           >
                             <Status
+                              dateFormat="MMM D, YYYY"
                               icon="check-circle"
                               statusSpanClass="status-active"
                               statusText="Same as Deployed"
@@ -4885,7 +4887,8 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                                           className="glyphicon glyphicon-pencil"
                                                         />
                                                       </Glyphicon>
-                                                       Open in Editor
+                                                       
+                                                      Open in Editor
                                                     </a>
                                                   </SafeAnchor>
                                                 </li>
@@ -4926,7 +4929,8 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                                           className="glyphicon glyphicon-refresh"
                                                         />
                                                       </Glyphicon>
-                                                       Fetch
+                                                       
+                                                      Fetch
                                                     </a>
                                                   </SafeAnchor>
                                                 </li>
@@ -4967,7 +4971,8 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                                           className="glyphicon glyphicon-upload"
                                                         />
                                                       </Glyphicon>
-                                                       Upload
+                                                       
+                                                      Upload
                                                     </a>
                                                   </SafeAnchor>
                                                 </li>
@@ -5026,7 +5031,8 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                                           className="glyphicon glyphicon-globe"
                                                         />
                                                       </Glyphicon>
-                                                       Deploy
+                                                       
+                                                      Deploy
                                                     </a>
                                                   </SafeAnchor>
                                                 </li>
@@ -5067,7 +5073,8 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                                           className="glyphicon glyphicon-link"
                                                         />
                                                       </Glyphicon>
-                                                       View public page
+                                                       
+                                                      View public page
                                                     </a>
                                                   </SafeAnchor>
                                                 </li>
@@ -5125,7 +5132,8 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                                           className="fa fa-trash fa-fw "
                                                         />
                                                       </Icon>
-                                                       Delete
+                                                       
+                                                      Delete
                                                     </a>
                                                   </SafeAnchor>
                                                 </li>

--- a/lib/manager/reducers/status.js
+++ b/lib/manager/reducers/status.js
@@ -4,6 +4,7 @@ import update from 'react-addons-update'
 
 import type {Action} from '../../types/actions'
 import type {StatusState} from '../../types/reducers'
+import {getComponentMessages} from '../../common/util/config'
 
 export const defaultState = {
   message: null,
@@ -19,102 +20,58 @@ export const defaultState = {
   }
 }
 
+const messages = getComponentMessages('Status')
+
 /* eslint-disable complexity */
 const config = (state: StatusState = defaultState, action: Action): StatusState => {
   switch (action.type) {
     // Status Messages
     case 'REQUESTING_PROJECTS':
-      return {...state, message: 'Loading projects...'}
     case 'REQUESTING_PROJECT':
-      return {...state, message: 'Loading project...'}
     case 'SAVING_PROJECT':
-      return {...state, message: 'Saving project...'}
     case 'REQUESTING_FEEDSOURCES':
-      return {...state, message: 'Loading feeds...'}
     case 'REQUESTING_FEEDSOURCE':
-      return {...state, message: 'Loading feed...'}
     case 'SAVING_FEEDSOURCE':
-      return {...state, message: 'Saving feed...'}
     case 'DELETING_FEEDSOURCE':
-      return {...state, message: 'Deleting feed...'}
     case 'RUNNING_FETCH_FEED':
-      return {...state, message: 'Updating feed...'}
     case 'REQUESTING_FEEDVERSIONS':
-      return {...state, message: 'Loading feed versions...'}
     case 'DELETING_FEEDVERSION':
-      return {...state, message: 'Deleting feed version...'}
     case 'UPLOADING_FEED':
-      return {...state, message: 'Uploading feed...'}
     case 'REQUESTING_SYNC':
-      return {...state, message: 'Syncing feeds...'}
     case 'RUNNING_FETCH_FEED_FOR_PROJECT':
-      return {...state, message: 'Updating feeds for project...'}
     case 'REQUESTING_PUBLIC_FEEDS':
-      return {...state, message: 'Loading public feeds...'}
     case 'REQUESTING_VALIDATION_ISSUE_COUNT':
-      return {...state, message: 'Loading validation result...'}
     case 'REQUESTING_NOTES':
-      return {...state, message: 'Loading comments...'}
     case 'REQUESTING_GTFSPLUS_CONTENT':
-      return {...state, message: 'Loading GTFS+ data...'}
     case 'UPLOADING_GTFSPLUS_FEED':
-      return {...state, message: 'Saving GTFS+ data...'}
     case 'PUBLISHING_GTFSPLUS_FEED':
-      return {...state, message: 'Publishing GTFS+ feed...'}
     case 'VALIDATING_GTFSPLUS_FEED':
-      return {...state, message: 'Updating GTFS+ validation...'}
     case 'REQUESTING_FEEDVERSION_ISOCHRONES':
-      return {...state, message: 'Calculating access shed...'}
     case 'REQUESTING_DEPLOYMENTS':
-      return {...state, message: 'Loading deployments...'}
     case 'REQUESTING_DEPLOYMENT':
-      return {...state, message: 'Loading deployment...'}
     case 'REQUESTING_USERS':
-      return {...state, message: 'Loading users...'}
     case 'UPDATING_USER_DATA':
-      return {...state, message: 'Updating user...'}
     case 'SAVING_DEPLOYMENT':
-      return {...state, message: 'Saving deployment...'}
     case 'REQUESTING_GTFSEDITOR_SNAPSHOTS':
-      return {...state, message: 'Loading snapshots...'}
     case 'SAVING_AGENCY':
-      return {...state, message: 'Saving agency...'}
     case 'SAVING_STOP':
-      return {...state, message: 'Saving stop...'}
     case 'SAVING_ROUTE':
-      return {...state, message: 'Saving route...'}
     case 'REQUESTING_AGENCIES':
-      return {...state, message: 'Loading agencies...'}
     case 'REQUESTING_STOPS':
-      return {...state, message: 'Loading stops...'}
     case 'REQUESTING_ROUTES':
-      return {...state, message: 'Loading routes...'}
     case 'REQUESTING_TRIPS_FOR_CALENDAR':
-      return {...state, message: 'Loading trips...'}
     case 'CREATING_SNAPSHOT':
-      return {...state, message: 'Creating snapshot...'}
     case 'DELETING_SNAPSHOT':
-      return {...state, message: 'Deleting snapshot...'}
     case 'DELETING_AGENCY':
-      return {...state, message: 'Deleting agency...'}
     case 'DELETING_TRIPS_FOR_CALENDAR':
-      return {...state, message: 'Deleting trips...'}
     case 'RESTORING_SNAPSHOT':
-      return {...state, message: 'Restoring snapshot...'}
     case 'RENAMING_FEEDVERSION':
-      return {...state, message: 'Renaming feed version...'}
     case 'LOADING_FEEDVERSION_FOR_EDITING':
-      return {...state, message: 'Loading version into editor...'}
     case 'REQUESTING_ORGANIZATIONS':
-      return {...state, message: 'Loading organizations...'}
     case 'UPDATING_SERVER':
-      return {...state, message: 'Saving server...'}
     case 'FETCHING_ALL_JOBS':
-      return {...state, message: 'Fetching jobs...'}
-
-    // Alerts status message
     case 'REQUEST_RTD_ALERTS':
-      return {...state, message: 'Loading alerts...'}
+      return {...state, message: messages(`${action.type}`)}
 
     // STATUS MODAL UPDATES (TYPICALLY SET ON JOB COMPLETION)
     case 'SET_ERROR_MESSAGE':
@@ -133,8 +90,8 @@ const config = (state: StatusState = defaultState, action: Action): StatusState 
     case 'CREATED_SNAPSHOT':
       return update(state, {
         modal: {$set: {
-          title: 'Snapshot Created',
-          body: `New snapshot "${action.payload}" created. It will be accessible from the "Editor Snapshots" tab in the main Feed Source page.`
+          title: messages('CREATED_SNAPSHOT.title'),
+          body: messages('CREATED_SNAPSHOT.body').replace('%payload%', action.payload)
         }},
         message: {$set: null}
       })

--- a/lib/manager/reducers/status.js
+++ b/lib/manager/reducers/status.js
@@ -71,7 +71,7 @@ const config = (state: StatusState = defaultState, action: Action): StatusState 
     case 'UPDATING_SERVER':
     case 'FETCHING_ALL_JOBS':
     case 'REQUEST_RTD_ALERTS':
-      return {...state, message: messages(`${action.type}`)}
+      return {...state, message: messages(action.type)}
 
     // STATUS MODAL UPDATES (TYPICALLY SET ON JOB COMPLETION)
     case 'SET_ERROR_MESSAGE':

--- a/lib/public/components/PublicLandingPage.js
+++ b/lib/public/components/PublicLandingPage.js
@@ -6,17 +6,19 @@ import {Link} from 'react-router'
 import {LinkContainer} from 'react-router-bootstrap'
 
 import { DEFAULT_DESCRIPTION, DEFAULT_LOGO, DEFAULT_TITLE } from '../../common/constants'
-import { getConfigProperty, isModuleEnabled } from '../../common/util/config'
-import PublicPage from './PublicPage'
-
+import { getComponentMessages, getConfigProperty, isModuleEnabled } from '../../common/util/config'
 import type {Props as ContainerProps} from '../containers/ActivePublicLandingPage'
 import type {ManagerUserState} from '../../types/reducers'
+
+import PublicPage from './PublicPage'
 
 type Props = ContainerProps & {
   user: ManagerUserState
 }
 
 export default class PublicLandingPage extends Component<Props> {
+  messages = getComponentMessages('PublicLandingPage')
+
   render () {
     const appTitle = getConfigProperty('application.title') || DEFAULT_TITLE
     const appDescription = getConfigProperty('application.description') || DEFAULT_DESCRIPTION
@@ -26,7 +28,7 @@ export default class PublicLandingPage extends Component<Props> {
         <Grid>
           <Row>
             <Col style={{textAlign: 'center'}} smOffset={4} xs={12} sm={4}>
-              <img alt='App logo' src={logoLarge} style={{maxWidth: '256px'}} />
+              <img alt={this.messages('appLogo')} src={logoLarge} style={{maxWidth: '256px'}} />
               <h1>{appTitle}</h1>
             </Col>
           </Row>
@@ -36,7 +38,7 @@ export default class PublicLandingPage extends Component<Props> {
                 {this.props.user.profile
                   ? <LinkContainer to='/home'>
                     <Button bsSize='large'>
-                      View dashboard
+                      {this.messages('viewDashboard')}
                     </Button>
                   </LinkContainer>
                   : <span>
@@ -45,12 +47,12 @@ export default class PublicLandingPage extends Component<Props> {
                 }
               </p>
               {!isModuleEnabled('enterprise') && <p>
-                Learn more about Data Tools{' '}
-                <a href='https://www.ibigroup.com/products'>here</a>.
+                {this.messages('learnMore')}{' '}
+                <a href='https://www.ibigroup.com/products'>{this.messages('here')}</a>.
               </p>}
               <p>
                 {!this.props.user.profile
-                  ? <span>Existing users <Link to='/login'>sign in here</Link>.</span>
+                  ? <span>{this.messages('existingUsers')} <Link to='/login'>{this.messages('signInHere')}</Link>.</span>
                   : null
                 }
               </p>
@@ -60,7 +62,7 @@ export default class PublicLandingPage extends Component<Props> {
         <footer className='landing-footer'>
           <div className='container'>
             <p className='text-center text-muted'>
-              <span role='img' title='Copyright' aria-label='copyright'>
+              <span role='img' title={this.messages('copyright')} aria-label='copyright'>
                 &copy;
               </span>{' '}
               <a href='https://www.ibigroup.com'>IBI Group</a>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x/?] All tests and CI builds passing

### Description

This PR adds German translations and adds locale-dependent message retrieval to a number of components. Though not complete, I'd like to request a merge to avoid future merge conflicts, as a number of components where touched.

Other tasks still to done to have datatools fully internationalized:
* Some components (e.g. the alerts module (`lib/alerts/**`) are not yet fully internationalized
* A couple of messages (i.e. job names and status) are generated server-side and are not internationalized yet.
* Time and date formatting performed by the moment javascript lib are not locale aware
* Some messages from the react-bootstrap table component, e.g. `Showing row x-y of z` are not locale aware
* GTFS-related field names and descriptions defined in GTFS.yml (see #864)

Regarding the German translation, I decided to keep some terms in English, as I think they are commonly (or in GTFS context) used and understandable (e.g. deployment, trip, feed,...)

Finally, this PR includes a small dev doc regarding localization, to document some of my learnings.
