### PR TITLE
test(e2e/server/Dockerfile): Revert to checking out the default branch.

### DIFF
--- a/__tests__/e2e/server/Dockerfile
+++ b/__tests__/e2e/server/Dockerfile
@@ -33,9 +33,6 @@ ARG AWS_SECRET_ACCESS_KEY
 # Grab latest dev build of Datatools Server
 RUN git clone https://github.com/ibi-group/datatools-server.git
 WORKDIR /datatools/datatools-server
-# TEMPORARY!
-RUN git checkout gtfs-lib-update-sep-22
-
 RUN mvn package -DskipTests
 RUN cp target/dt*.jar ./datatools-server-3.8.1-SNAPSHOT.jar
 

--- a/__tests__/e2e/server/Dockerfile
+++ b/__tests__/e2e/server/Dockerfile
@@ -33,6 +33,7 @@ ARG AWS_SECRET_ACCESS_KEY
 # Grab latest dev build of Datatools Server
 RUN git clone https://github.com/ibi-group/datatools-server.git
 WORKDIR /datatools/datatools-server
+
 RUN mvn package -DskipTests
 RUN cp target/dt*.jar ./datatools-server-3.8.1-SNAPSHOT.jar
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This reverts https://github.com/ibi-group/datatools-ui/commit/7ef1cd4b927c450f3eceaf11f854a38ac7a223ce so that e2e tests don't depend on a (to-be-deleted) merged branch.

