### PR TITLE
fix: name field + duplicate exception bugs

### DIFF
--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -85,6 +85,11 @@ function getCloneProps (entityId: number, component: string, state: AppState) {
       // See https://github.com/catalogueglobal/datatools-ui/issues/153
       delete route.tripPatterns
       return route
+    case 'scheduleexception':
+      const scheduleExceptionClone = {
+        ...activeTable.find(e => e.id === entityId),
+        name: active.entity.name + ' (duplicate)'}
+      return scheduleExceptionClone
     default:
       return {...activeTable.find(e => e.id === entityId)}
   }

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -86,10 +86,9 @@ function getCloneProps (entityId: number, component: string, state: AppState) {
       delete route.tripPatterns
       return route
     case 'scheduleexception':
-      const scheduleExceptionClone = {
+      return {
         ...activeTable.find(e => e.id === entityId),
-        name: active.entity.name + ' (duplicate)'}
-      return scheduleExceptionClone
+        name: active.entity && active.entity.name && active.entity.name + ' (duplicate)'}
     default:
       return {...activeTable.find(e => e.id === entityId)}
   }

--- a/lib/editor/components/EntityList.js
+++ b/lib/editor/components/EntityList.js
@@ -60,8 +60,8 @@ export default class EntityList extends Component<Props, State> {
 
   _getRowStyle = ({index}: {index: number}) => {
     const {fromIndex, toIndex} = this.state
-    const activeColor = '#F2F2F2'
-    const newEntityUnsavedColor = '#ffdfe5'
+    const ACTIVE_COLOR = '#F2F2F2'
+    const NEW_ENTITY_UNSAVED_COLOR = '#ffdfe5'
     const rowStyle = {
       borderBottom: 'solid 1px #ddd',
       cursor: 'pointer',
@@ -75,10 +75,10 @@ export default class EntityList extends Component<Props, State> {
     const row = this._getRow({index})
     if (row && (row.isActive || isSelected)) {
       // Set active color for selected rows
-      rowStyle.backgroundColor = activeColor
+      rowStyle.backgroundColor = ACTIVE_COLOR
     }
     if (row && !row.isActive && entityIsNew(row)) {
-      rowStyle.backgroundColor = newEntityUnsavedColor
+      rowStyle.backgroundColor = NEW_ENTITY_UNSAVED_COLOR
     }
     return rowStyle
   }

--- a/lib/editor/components/EntityList.js
+++ b/lib/editor/components/EntityList.js
@@ -61,6 +61,7 @@ export default class EntityList extends Component<Props, State> {
   _getRowStyle = ({index}: {index: number}) => {
     const {fromIndex, toIndex} = this.state
     const activeColor = '#F2F2F2'
+    const newEntityUnsavedColor = '#ffdfe5'
     const rowStyle = {
       borderBottom: 'solid 1px #ddd',
       cursor: 'pointer',
@@ -75,6 +76,9 @@ export default class EntityList extends Component<Props, State> {
     if (row && (row.isActive || isSelected)) {
       // Set active color for selected rows
       rowStyle.backgroundColor = activeColor
+    }
+    if (row && !row.isActive && entityIsNew(row)) {
+      rowStyle.backgroundColor = newEntityUnsavedColor
     }
     return rowStyle
   }

--- a/lib/editor/components/EntityListButtons.js
+++ b/lib/editor/components/EntityListButtons.js
@@ -142,7 +142,7 @@ export default class EntityListButtons extends Component<Props, State> {
             <Button
               bsSize='small'
               data-test-id={`clone-${activeComponent}-button`}
-              // prohbit user from creating additional duplicates when there are unsaved entities
+              // prohibit user from creating additional duplicates when there are unsaved entities
               disabled={!activeEntity || entities.findIndex(entityIsNew) !== -1}
               onClick={this._onClickClone}>
               <Icon type='clone' />

--- a/lib/editor/components/EntityListButtons.js
+++ b/lib/editor/components/EntityListButtons.js
@@ -142,7 +142,8 @@ export default class EntityListButtons extends Component<Props, State> {
             <Button
               bsSize='small'
               data-test-id={`clone-${activeComponent}-button`}
-              disabled={!activeEntity}
+              // prohbit user from creating additional duplicates when there are unsaved entities
+              disabled={!activeEntity || entities.findIndex(entityIsNew) !== -1}
               onClick={this._onClickClone}>
               <Icon type='clone' />
             </Button>

--- a/lib/editor/components/EntityListButtons.js
+++ b/lib/editor/components/EntityListButtons.js
@@ -143,7 +143,7 @@ export default class EntityListButtons extends Component<Props, State> {
               bsSize='small'
               data-test-id={`clone-${activeComponent}-button`}
               // prohibit user from creating additional duplicates when there are unsaved entities
-              disabled={!activeEntity || entities.findIndex(entityIsNew) !== -1}
+              disabled={!activeEntity || !!entities.find(entityIsNew)}
               onClick={this._onClickClone}>
               <Icon type='clone' />
             </Button>
@@ -169,7 +169,7 @@ export default class EntityListButtons extends Component<Props, State> {
           : <Button
             bsSize='small'
             data-test-id={`new-${activeComponent}-button`}
-            disabled={entities && entities.findIndex(entityIsNew) !== -1}
+            disabled={entities && !!entities.find(entityIsNew)}
             onClick={this._onClickNew}
             // Setting the max width based on the width of the 'New Calendar' button
             // so the button does not move to a new line in deployed systems.

--- a/lib/editor/components/ScheduleExceptionForm.js
+++ b/lib/editor/components/ScheduleExceptionForm.js
@@ -150,7 +150,7 @@ export default class ScheduleExceptionForm extends Component<Props> {
               <small>Exception name*</small>
             </ControlLabel>
             <FormControl
-              value={name}
+              value={!name ? '' : name}
               placeholder='Thanksgiving Day'
               onChange={this._onNameChange} />
           </FormGroup>

--- a/lib/editor/components/ScheduleExceptionForm.js
+++ b/lib/editor/components/ScheduleExceptionForm.js
@@ -150,7 +150,7 @@ export default class ScheduleExceptionForm extends Component<Props> {
               <small>Exception name*</small>
             </ControlLabel>
             <FormControl
-              value={!name ? '' : name}
+              value={name || ''} // If name not given, provide empty string to override FormControl state.
               placeholder='Thanksgiving Day'
               onChange={this._onNameChange} />
           </FormGroup>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

- Fixes issue where name value was carrying over into input field on new exception
- Disables duplicate button when there is already an unsaved duplicate
- Adds red styling to indicate unsaved duplicate entity
- Automatically appends "duplicate" to the name field of any duplicate exception


<img width="521" alt="Screen Shot 2022-11-07 at 9 54 28 AM" src="https://user-images.githubusercontent.com/115499534/200340828-2c8283fe-3f86-4aff-8b32-5256aff73eda.png">
