### PR TITLE
Fix stops layer rendering

### DIFF
--- a/__tests__/e2e/docker-compose.yml
+++ b/__tests__/e2e/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       args: *common-variables
       dockerfile: ./__tests__/e2e/Dockerfile
 
-    command: /bin/sh -c "./wait-for-command.sh -t 15 -c 'nc -z datatools-ui 9966' && sleep 25 && yarn test-end-to-end"
+    command: /bin/sh -c "./wait-for-command.sh -t 15 -c 'nc -z datatools-ui 9966' && sleep 40 && yarn test-end-to-end"
     shm_size: '2gb'
     cap_add:
       - ALL

--- a/lib/editor/components/map/StopsLayer.js
+++ b/lib/editor/components/map/StopsLayer.js
@@ -47,13 +47,13 @@ export default class StopsLayer extends Component<Props> {
             .filter(stop => {
               // Do not render stops if the bounds are invalid
               if (!paddedBounds) return false
-              // Always render is no activeEntity is present (we are in basic mode)
-              if (!activeEntity) return true
               const stopIsActive = activeEntity && activeEntity.id === stop.id
               // Always render active stop.
               if (stopIsActive) return true
               // If zoomed out too much, do not render any other stops.
               if (!drawStops) return false
+              // Always render if no activeEntity is present (we are in location group viewer (basic ✨) mode)
+              if (!activeEntity) return true
               // Filter out stops that do not fall within bounds.
               if (stopIsOutOfBounds(stop, paddedBounds)) return false
               else return true


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

Previously because of how we were rendering Location Groups, we began rendering all stops when the `stops` menu was opened. This created major performance issues with Leaflet. This PR stops this process, but maintains the previous location groups behaviour. 