### PR TITLE
Flex Transformations Support

### DIFF
--- a/gtfs.yml
+++ b/gtfs.yml
@@ -1035,7 +1035,6 @@
 # FIXME: helpContent is lifted from https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md
 - id: bookingrule
   name: booking_rules.txt
-  datatools: true
   helpContent: Booking information for rider-requested services using GTFS-FlexibleTrips, such as how far in advance booking should occur or a phone number that should be called.
   fields:
     - name: booking_rule_id
@@ -1128,6 +1127,7 @@
   # FIXME: helpContent is lifted from https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md
 - id: location
   name: locations.geojson
+  flex: true
   helpContent: Adds features that indicate areas where riders can request either pickup or drop off.
   fields:
   # TODO: enable validation to match spec (only appear when appropriate)
@@ -1162,6 +1162,7 @@
     
   # FIXME: helpContent is lifted from https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md
 - id: locationgroup
+  flex: true
   name: location_groups.txt
   helpContent: Adds location groups. Location groups are groups of stops and GeoJSON locations, which allow predetermined groups of these features to be specified on individual rows of stop_times.txt.
   fields:

--- a/lib/manager/components/transform/FeedTransformation.js
+++ b/lib/manager/components/transform/FeedTransformation.js
@@ -100,7 +100,7 @@ export default class FeedTransformation extends Component<Props, {errors: Array<
     // Do not offer to transform datatools-internal tables
       .filter(t => !t.datatools)
       // Non-csv flex tables can only be replaced from another version. Otherwise, filter them out
-      .filter(t => transformationType === FEED_TRANSFORMATION_TYPES.REPLACE_FILE_FROM_VERSION ? true : !t.flex)
+      .filter(t => transformationType === FEED_TRANSFORMATION_TYPES.REPLACE_FILE_FROM_VERSION || !t.flex)
       .sort((a, b) => a.id.localeCompare(b.id))
     if (isModuleEnabled('gtfsplus')) tables.push(...getGtfsPlusSpec())
     const {errors: validationIssues} = this.state

--- a/lib/manager/components/transform/FeedTransformation.js
+++ b/lib/manager/components/transform/FeedTransformation.js
@@ -12,6 +12,7 @@ import type {
   FeedTransformation as FeedTransformationType,
   ReactSelectOption
 } from '../../../types'
+import { FEED_TRANSFORMATION_TYPES } from '../../../common/constants'
 
 import NormalizeField from './NormalizeField'
 import ReplaceFileFromString from './ReplaceFileFromString'
@@ -94,9 +95,14 @@ export default class FeedTransformation extends Component<Props, {errors: Array<
 
   render () {
     const {feedSource, index, transformation} = this.props
-    const tables = [...getGtfsSpec()].filter(t => !t.datatools)
-    if (isModuleEnabled('gtfsplus')) tables.push(...getGtfsPlusSpec())
     const transformationType = transformation['@type']
+    const tables = [...getGtfsSpec()]
+    // Do not offer to transform datatools-internal tables
+      .filter(t => !t.datatools)
+      // Non-csv flex tables can only be replaced from another version. Otherwise, filter them out
+      .filter(t => transformationType === FEED_TRANSFORMATION_TYPES.REPLACE_FILE_FROM_VERSION ? true : !t.flex)
+      .sort((a, b) => a.id.localeCompare(b.id))
+    if (isModuleEnabled('gtfsplus')) tables.push(...getGtfsPlusSpec())
     const {errors: validationIssues} = this.state
     const backgroundColor = validationIssues.length === 0
       ? '#f7f7f7'

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -737,6 +737,7 @@ export type GtfsSpecField = {
 export type GtfsSpecTable = {
   datatools?: boolean,
   fields: Array<GtfsSpecField>,
+  flex?: boolean, // Denotes table as being non-csv flex table
   helpContent: string,
   id: string,
   name: string


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [x] e2e tests are all passing _(remove this if not merging to master)_

### Description

This PR adds support for and removes the appearance of support for transformations on flex files where appropriate. Specifically, booking_rules.txt has been fully enabled for transformations. location_groups.txt and locations.geojson has had transformation support removed as it doesn't make sense for it.
