### PR TITLE
Bugfix: Delete Polygon from Store (Flex)

### DIFF
--- a/lib/editor/components/EntityDetailsHeader.js
+++ b/lib/editor/components/EntityDetailsHeader.js
@@ -126,6 +126,7 @@ export default class EntityDetailsHeader extends Component<Props> {
       </Tooltip>
     )
     const hasErrors = validationErrors.length > 0
+    const noLocationShapes = activeEntity.location_shapes && !activeEntity.location_shapes.length
     const entityName = activeComponent === 'feedinfo'
       ? this.messages('feedInfo')
       : getEntityName(activeEntity)
@@ -174,7 +175,7 @@ export default class EntityDetailsHeader extends Component<Props> {
               <Button
                 bsSize='small'
                 data-test-id='save-entity-button'
-                disabled={!entityEdited || hasErrors}
+                disabled={!entityEdited || hasErrors || noLocationShapes}
                 onClick={this._onClickSave}>
                 <Icon type='floppy-o' />
               </Button>

--- a/lib/editor/components/map/LocationsLayer.js
+++ b/lib/editor/components/map/LocationsLayer.js
@@ -95,7 +95,7 @@ const LocationsLayer = (props: Props) => {
     const locationShapes = clone(activeEntity.location_shapes)
     const {key} = e
 
-    const newLocationShapes = locationShapes.filter((shapePt) => !(key === shapePt.geometry_id))
+    const newLocationShapes = locationShapes.filter((shapePt) => !(Number(key) === shapePt.geometry_id))
 
     if (!updatingLocationShape) return
     updatingLocationShape({ geometryType, shapes: newLocationShapes })

--- a/lib/editor/components/map/LocationsLayer.js
+++ b/lib/editor/components/map/LocationsLayer.js
@@ -30,7 +30,7 @@ const LocationsLayer = (props: Props) => {
   useEffect(() => {
     // Create our locations shape out of the bulk location shape points
     updateGroupLocationShapePts(groupLocationShapePoints(locationShapes))
-  }, [])
+  }, [locationShapes])
 
   const _onCreated = (e: L.LeafletEvent) => {
     const { layerType: geometryType, layer } = e
@@ -94,16 +94,14 @@ const LocationsLayer = (props: Props) => {
     const {activeEntity} = props
     const locationShapes = clone(activeEntity.location_shapes)
     const {key} = e
-
-    const newLocationShapes = locationShapes.filter((shapePt) => !(Number(key) === shapePt.geometry_id))
+    const newLocationShapes = locationShapes.filter((shapePt) => !(String(key) === String(shapePt.geometry_id)))
 
     if (!updatingLocationShape) return
     updatingLocationShape({ geometryType, shapes: newLocationShapes })
   }
 
-  const noShapes = locationShapes.length === 0
-
   const Group = updatingLocationShape ? EditControlFeatureGroup : FeatureGroup
+
   return (
     <div id='location-features-layer'>
       <Group
@@ -112,8 +110,8 @@ const LocationsLayer = (props: Props) => {
           circle: false,
           circlemarker: false,
           marker: false,
-          polygon: noShapes,
-          polyline: noShapes,
+          polygon: true,
+          polyline: true,
           rectangle: false
         },
         position: 'topleft'}}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fixes a bug where if you create a location by drawing a polygon on the map and then delete said polygon, it will not remove the shape from the store (but it will disappear from the map). This will create a "multiple polylines not supported" error if the user attempts to create another polygon. If the user saves the blank map they will see their deleted shape.

Also disables save button when the location has no shapes. 

EDIT: Fixes 2 additional bugs:
- Stops react-draw polyline/polygon control group on map from disappearing even when no shapes exist in location
- If you delete a polygon and re-draw, that polygon will no longer disappear on the map. (bug shown[ here](https://ibigroup-my.sharepoint.com/personal/philip_cline_ibigroup_com/_layouts/15/stream.aspx?id=%2Fpersonal%2Fphilip%5Fcline%5Fibigroup%5Fcom%2FDocuments%2FMicrosoft%20Teams%20Chat%20Files%2FFlex%20new%20polygon%20disappears%2Emov&referrer=Teams%2ETEAMS%2DELECTRON&referrerScenario=p2p%5Fns%2Dbim&ga=1)
