### PR TITLE
fix(AddPatternStopDropdown): Allow duplicate locations in patterns

### DIFF
--- a/lib/editor/components/pattern/AddPatternStopDropdown.js
+++ b/lib/editor/components/pattern/AddPatternStopDropdown.js
@@ -35,17 +35,12 @@ export default class AddPatternStopDropdown extends Component<Props> {
     const {activePattern, stop} = this.props
     const patternHalts = mergePatternHaltsOfPattern(activePattern)
     const patternStopAtIndex = patternHalts[index]
-    if (!stop) {
+    if (!stop || !stop.stop_id) {
       return false
     }
 
-    if (!stop.stop_id) {
-      // $FlowFixMe Flow can't handle the strange type checking we're doing here
-      return patternStopAtIndex && patternStopAtIndex.locationId === stop.location_id
-    } else {
-      // $FlowFixMe Flow can't handle the strange type checking we're doing here
-      return patternStopAtIndex && patternStopAtIndex.stopId === stop.stop_id
-    }
+    // $FlowFixMe Flow can't handle the strange type checking we're doing here
+    return patternStopAtIndex && patternStopAtIndex.stopId === stop.stop_id
   }
 
   _onAddToEnd = () => this._addStop()
@@ -53,7 +48,7 @@ export default class AddPatternStopDropdown extends Component<Props> {
   _onSelectStop = (key: number) => this._addStop(key)
 
   render () {
-    const {activePattern, index, label, size, style} = this.props
+    const {activePattern, index, label, size, stop, style} = this.props
     const patternHalts = mergePatternHaltsOfPattern(activePattern)
     const lastIndex = patternHalts.length - 1
     // Check that first/last stop is not already set to this stop.
@@ -61,7 +56,7 @@ export default class AddPatternStopDropdown extends Component<Props> {
     let addToBeginningDisabled = this._matchesStopAtIndex(0)
     // Also, disable end/beginning if the current pattern stop being viewed
     // occupies one of these positions.
-    if (typeof index === 'number') {
+    if (typeof index === 'number' && !!stop.stop_id) {
       addToEndDisabled = addToEndDisabled || index >= lastIndex
       addToBeginningDisabled = addToBeginningDisabled || index === 0
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

The current flex specification has intra-zonal trips defined as two stop times with the same location. Currently we were not allowing duplicate locations in a pattern. 
