### PR TITLE
Allow duplicate locations in timetable

### DIFF
--- a/lib/editor/selectors/timetable.js
+++ b/lib/editor/selectors/timetable.js
@@ -154,6 +154,8 @@ const isCellValueInvalid = (
   tripIds: Array<string>
 ): ?EditorValidationIssue => {
   const col = columns[colIndex]
+  const isFlexStopTime = (col: TimetableColumn) => col.key.includes('startPickupDropoffWindow') || col.key.includes('endPickupDropoffWindow')
+
   if (isTimeFormat(col.type)) {
     // FIXME: This does not yet support validating frequency start/end times.
     // Handle time column validation.
@@ -170,7 +172,9 @@ const isCellValueInvalid = (
         previousIndex--
       }
       // Ensure value is increasing over previous value
-      const isInvalid = val < previousValue
+      // Flexible stop times (because intra zonal trips are represented by a duplicate stop time) can
+      // include the same start and end pickup times back to back and so must avoid this check.
+      const isInvalid = isFlexStopTime(col) ? false : val < previousValue
       return isInvalid
         ? {
           field: col.key,

--- a/lib/editor/selectors/timetable.js
+++ b/lib/editor/selectors/timetable.js
@@ -140,6 +140,9 @@ export const getTimetableColumns = createSelector(
 // see https://github.com/conveyal/gtfs-lib/issues/148
 const MAX_HEADWAY_SECONDS = 60 * 60 * 2
 
+/* Utility function which checks if a column is a flex stop time. */
+const isFlexStopTime = (col: TimetableColumn) => col.key.includes('startPickupDropoffWindow') || col.key.includes('endPickupDropoffWindow')
+
 /**
  * Utility function that checks whether any individual cell (value) for an editor
  * trip or frequency is valid. Returns an EditorValidationIssue or null if the
@@ -154,7 +157,6 @@ const isCellValueInvalid = (
   tripIds: Array<string>
 ): ?EditorValidationIssue => {
   const col = columns[colIndex]
-  const isFlexStopTime = (col: TimetableColumn) => col.key.includes('startPickupDropoffWindow') || col.key.includes('endPickupDropoffWindow')
 
   if (isTimeFormat(col.type)) {
     // FIXME: This does not yet support validating frequency start/end times.

--- a/lib/editor/selectors/timetable.js
+++ b/lib/editor/selectors/timetable.js
@@ -174,7 +174,7 @@ const isCellValueInvalid = (
       // Ensure value is increasing over previous value
       // Flexible stop times (because intra zonal trips are represented by a duplicate stop time) can
       // include the same start and end pickup times back to back and so must avoid this check.
-      const isInvalid = isFlexStopTime(col) ? false : val < previousValue
+      const isInvalid = !isFlexStopTime(col) && val < previousValue
       return isInvalid
         ? {
           field: col.key,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Previous checks ensuring that a timetable time was < previousValue were preventing the addition of a duplicate flex stop time for intra zonal trips (since the startPickupDropoffWindow will be less than previous endPickupDropoffWindow). This PR removes that check for flex stop times. 
