### PR TITLE
Extract auth0 user ID when failing

### DIFF
--- a/lib/manager/actions/user.js
+++ b/lib/manager/actions/user.js
@@ -217,6 +217,8 @@ export function updateUserData (user: any, userData: any) {
     // FIXME: Currently there are some implementations of this method that pass
     // profile as an argument and others that pass user.
     const profile = user.profile || user
+    // The auth0 user_id may change locations, but it is still present in the "sub" field
+    const userId = profile.user_id || user.sub
     const metadata = profile.app_metadata
     const clientIndex = metadata.datatools.findIndex(isSettingForThisClient)
     if (clientIndex === -1) {
@@ -228,9 +230,9 @@ export function updateUserData (user: any, userData: any) {
     for (const key in userData) {
       objectPath.set(metadata, `datatools.${clientIndex}.${key}`, userData[key])
     }
-    const url = `/api/manager/secure/user/${user.user_id}`
+    const url = `/api/manager/secure/user/${userId}`
     const payload = {
-      user_id: profile.user_id,
+      user_id: userId,
       data: metadata.datatools
     }
     let status
@@ -248,7 +250,7 @@ export function updateUserData (user: any, userData: any) {
         }
         const {profile} = getState().user
         if (!profile) throw new Error('Could not find user profile in state.')
-        if (responseJson.user_id === profile.user_id) {
+        if (responseJson.user_id === userId) {
           // If user being updated matches the logged in user, update their
           // profile in the application state as the change in user_metdata can
           // change various items in the application such as user subscriptions


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

The new auth0 library is resulting in a different format for the nesting of the user_id in the user object. We were missing extracting, this PR adjusts this although this is more of a quick fix to get it working and I need to look into a more robust fix and where else this might be failing. 