### PR TITLE
Stop refresh on Trip ID Error

### DIFF
--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -131,6 +131,9 @@ function getErrorMessageFromJson (
     }
     // re-assign error message after it gets used in the detail.
     errorMessage = json.message || JSON.stringify(json)
+    if (json.detail.includes('Key field must be unique')) {
+      action = 'DEFAULT'
+    }
   }
   console.error(errorMessage)
   return { action, detail, message: errorMessage }

--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -131,7 +131,7 @@ function getErrorMessageFromJson (
     }
     // re-assign error message after it gets used in the detail.
     errorMessage = json.message || JSON.stringify(json)
-    if (json.detail.includes('Key field must be unique')) {
+    if (json.detail.includes('conflicts with an existing trip id')) {
       action = 'DEFAULT'
     }
   }

--- a/lib/editor/actions/trip.js
+++ b/lib/editor/actions/trip.js
@@ -180,7 +180,10 @@ export function saveTripsForCalendar (
         })
     }))
       .then(trips => {
-        dispatch(fetchTripsForCalendar(feedId, pattern, calendarId, true))
+        // if error in saving, state will not refresh so user does not lose work
+        if (!trips.includes(undefined)) {
+          dispatch(fetchTripsForCalendar(feedId, pattern, calendarId, true))
+        }
         return errorIndexes
       })
   }

--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -190,7 +190,7 @@ export default class EditableCell extends Component<Props, State> {
 
   _handleSave = (value: any) => {
     const { rowIndex, column, columnIndex, onChange, onStopEditing } = this.props
-    this.setState({isEditing: false, data: value})
+    this.setState({isEditing: false, data: value, originalData: value})
     onChange(value, rowIndex, column, columnIndex)
     onStopEditing()
   }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR seeks to address an issue where users who were saving a trip id previously held by a different trip were getting an error that asked them to reload the page and lose their changes.
-  Returns an error message that can be closed instead of prompting refresh
-  Stop state refresh on error
-  Fixes a small error where field could not be reset to its original value after error
