### PR TITLE
fix(TripPatternList): Include flex locations/location groups in summa…

### DIFF
--- a/lib/editor/components/pattern/TripPatternList.js
+++ b/lib/editor/components/pattern/TripPatternList.js
@@ -147,6 +147,7 @@ class PatternRow extends Component<RowProps> {
 
   render () {
     const {active, pattern} = this.props
+    const {name, patternLocations, patternLocationGroups, patternStops} = pattern
     const rowStyle = {
       paddingTop: 5,
       paddingBottom: 5
@@ -158,25 +159,28 @@ class PatternRow extends Component<RowProps> {
       paddingBottom: 5
     }
     let patternName = '[Unnamed]'
-    if (pattern.name) {
-      // FLEX TODO: Include locations here?
-      patternName = `${`${pattern.name.length > 29
-        ? pattern.name.substr(0, 29) + '...'
-        : pattern.name}`} ${pattern.patternStops
-        ? `(${pattern.patternStops.length} stops)`
-        : ''}`
+    if (name) {
+      const showStopCount = patternStops || patternLocations || patternLocationGroups
+      const stopCount = showStopCount ? (
+        (patternStops ? patternStops.length : 0) +
+        (patternLocations ? patternLocations.length : 0) +
+        (patternLocationGroups ? patternLocationGroups.length : 0)
+      ) : 0
+      patternName = `${`${name.length > 29
+        ? name.substr(0, 29) + '…'
+        : name}`} ${showStopCount ? `(${stopCount} stops)` : ''}`
     }
     return (
       <tr style={rowStyle}>
         <td style={active ? activeRowStyle : rowStyle}>
           <div
             className='small'
-            data-test-id={`pattern-title-${pattern.name}`}
+            data-test-id={`pattern-title-${name}`}
             onClick={this._selectRow}
             onKeyDown={this._onKeyDown}
             role='button'
             tabIndex={0}
-            title={pattern.name}
+            title={name}
           >
             <Icon type={active ? 'caret-down' : 'caret-right'} />
             {' '}{patternName}


### PR DESCRIPTION
…rized stop count.

### Checklist

- [x] Appropriate branch selected => This is a PR against `dev-flex` for a flex-specific bug.
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented => not needed
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

With this PR, flex locations and location groups are included in the summary stop count shown for each pattern in the route editor.
