### PR TITLE
Fix GtfsMap

### DIFF
--- a/lib/gtfs/components/GtfsMap.js
+++ b/lib/gtfs/components/GtfsMap.js
@@ -216,10 +216,12 @@ export default class GtfsMap extends PureComponent<Props> {
       <Map
         ref='map'
         style={mapStyle}
-        // When providing a bounds props, do not also provide a zoom prop
-        // because using zoom requires passing a valid the center prop (otherwise the map crashes).
+        // Fit bounds to the viewed route/pattern,
+        // or the entire feed bound box if on the Summary tab.
+        // Note: When providing a bounds props, do not also use the zoom prop
+        // to avoid crashes (using zoom requires passing a valid center prop).
         // See 1.7.1 source at https://github.com/Leaflet/Leaflet/blob/bd88f73e8ddb90eb945a28bc1de9eb07f7386118/dist/leaflet-src.js#L3181
-        bounds={feedsArrayBounds || mapState.bounds}
+        bounds={(showBounds && versionBoundingBox) || feedsArrayBounds || mapState.bounds}
         scrollWheelZoom={!disableScroll}
         onMoveEnd={this.mapMoved}
         onLayerAdd={this.layerAddHandler}

--- a/lib/gtfs/components/GtfsMap.js
+++ b/lib/gtfs/components/GtfsMap.js
@@ -9,12 +9,12 @@ import * as filterActions from '../actions/filter'
 import * as generalActions from '../actions/general'
 import {getFeedsBounds, convertToArrayBounds} from '../../common/util/geo'
 import {defaultTileLayerProps} from '../../common/util/maps'
-import PatternGeoJson from './PatternGeoJson'
-import StopMarker from './StopMarker'
-
 import type {Props as ContainerProps} from '../containers/ActiveGtfsMap'
 import type {Bounds, Feed, StopWithFeed} from '../../types'
 import type {DateTimeFilter, MapFilter} from '../../types/reducers'
+
+import StopMarker from './StopMarker'
+import PatternGeoJson from './PatternGeoJson'
 
 type Props = ContainerProps & {
   dateTime: DateTimeFilter,
@@ -64,8 +64,7 @@ export default class GtfsMap extends PureComponent<Props> {
     const {map} = this.refs
     const {disableRefresh, updateMapState} = this.props
     const bounds = map && map.leafletElement.getBounds()
-    const zoom = map && map.leafletElement.getBoundsZoom(bounds)
-    updateMapState && updateMapState({bounds, zoom})
+    updateMapState && updateMapState({bounds})
     !disableRefresh && this._refreshGtfsElements()
   }
 
@@ -217,8 +216,10 @@ export default class GtfsMap extends PureComponent<Props> {
       <Map
         ref='map'
         style={mapStyle}
+        // When providing a bounds props, do not also provide a zoom prop
+        // because using zoom requires passing a valid the center prop (otherwise the map crashes).
+        // See 1.7.1 source at https://github.com/Leaflet/Leaflet/blob/bd88f73e8ddb90eb945a28bc1de9eb07f7386118/dist/leaflet-src.js#L3181
         bounds={feedsArrayBounds || mapState.bounds}
-        zoom={mapState.zoom}
         scrollWheelZoom={!disableScroll}
         onMoveEnd={this.mapMoved}
         onLayerAdd={this.layerAddHandler}

--- a/lib/types/reducers.js
+++ b/lib/types/reducers.js
@@ -276,8 +276,7 @@ export type EditorState = {
  type Point = [number, number]
 
 export type MapFilter = {
-  bounds: [Point, Point],
-  zoom: number
+  bounds: [Point, Point]
 }
 
 export type DateTimeFilter = {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

Fix #795.

After inspection of leaflet source and as commented in the code, this PR proposes to not pass a `zoom` prop to the `<Map>` component in `GtfsMap` because using the `zoom` prop assumes that a valid `center` prop is passed too (which we don't use).
