### PR TITLE
disable normalize stops when locations are present

### DIFF
--- a/lib/editor/components/pattern/CalculateDefaultTimesForm.js
+++ b/lib/editor/components/pattern/CalculateDefaultTimesForm.js
@@ -17,6 +17,7 @@ import * as tripPatternActions from '../../actions/tripPattern'
 import MinuteSecondInput from '../MinuteSecondInput'
 import {getDistanceScaleFactor, straightLineDistancesBetweenStopAnchors} from '../../util/map'
 import type {ControlPoint, Pattern} from '../../../types'
+import { activePatternHasLocations } from '../../util/location'
 
 import NormalizeStopTimesTip from './NormalizeStopTimesTip'
 
@@ -96,7 +97,6 @@ export default class CalculateDefaultTimesForm extends Component<Props, State> {
 
   render () {
     const { activePattern } = this.props
-    const activePatternHasLocations = activePattern.patternLocations.length > 0 || activePattern.patternLocationGroups.length > 0
 
     return (
       <Form>
@@ -129,7 +129,7 @@ export default class CalculateDefaultTimesForm extends Component<Props, State> {
           </InputGroup.Button>
         </InputGroup>
         <br />
-        {!activePatternHasLocations &&
+        {!activePatternHasLocations(activePattern) &&
           <Well style={{padding: '8px'}}>
             <NormalizeStopTimesTip />
           </Well>

--- a/lib/editor/components/pattern/CalculateDefaultTimesForm.js
+++ b/lib/editor/components/pattern/CalculateDefaultTimesForm.js
@@ -95,6 +95,9 @@ export default class CalculateDefaultTimesForm extends Component<Props, State> {
     this.setState({speed: +evt.target.value})
 
   render () {
+    const { activePattern } = this.props
+    const activePatternHasLocations = activePattern.patternLocations.length > 0
+
     return (
       <Form>
         <FormGroup className={`col-xs-4`} bsSize='small'>
@@ -126,9 +129,11 @@ export default class CalculateDefaultTimesForm extends Component<Props, State> {
           </InputGroup.Button>
         </InputGroup>
         <br />
-        <Well style={{padding: '8px'}}>
-          <NormalizeStopTimesTip />
-        </Well>
+        {!activePatternHasLocations &&
+          <Well style={{padding: '8px'}}>
+            <NormalizeStopTimesTip />
+          </Well>
+        }
       </Form>
     )
   }

--- a/lib/editor/components/pattern/CalculateDefaultTimesForm.js
+++ b/lib/editor/components/pattern/CalculateDefaultTimesForm.js
@@ -96,7 +96,7 @@ export default class CalculateDefaultTimesForm extends Component<Props, State> {
 
   render () {
     const { activePattern } = this.props
-    const activePatternHasLocations = activePattern.patternLocations.length > 0
+    const activePatternHasLocations = activePattern.patternLocations.length > 0 || activePattern.patternLocationGroups.length > 0
 
     return (
       <Form>

--- a/lib/editor/components/pattern/PatternStopCard.js
+++ b/lib/editor/components/pattern/PatternStopCard.js
@@ -25,7 +25,7 @@ import { getGtfsSpecField } from '../../../common/util/config'
 import type { Feed, Pattern, PatternHalt } from '../../../types'
 import type {AppState, RouterProps, EditorTables} from '../../../types/reducers'
 import { mergePatternHaltsOfPattern } from '../../../gtfs/util'
-import { patternHaltIsLocation, patternHaltIsStop } from '../../util/location'
+import { activePatternHasLocations, patternHaltIsLocation, patternHaltIsStop } from '../../util/location'
 
 import NormalizeStopTimesTip from './NormalizeStopTimesTip'
 import PatternStopButtons from './PatternStopButtons'
@@ -473,7 +473,6 @@ class PatternStopContents extends Component<Props, State> {
     const pickupBookingRuleId = getGtfsSpecField('stop_time', 'pickup_booking_rule_id')
     const dropOffBookingRuleId = getGtfsSpecField('stop_time', 'drop_off_booking_rule_id')
     const isStop = patternHaltIsStop(patternStop)
-    const activePatternHasLocations = activePattern.patternLocations.length > 0 || activePattern.patternLocationGroups.length > 0
 
     const bookingRuleRow = feedSource.flexUIFeaturesEnabled && (
       <Row>
@@ -672,7 +671,7 @@ class PatternStopContents extends Component<Props, State> {
             </Col>
           </Row>
           {isStop ? stopRows : locationRows}
-          {!activePatternHasLocations && <NormalizeStopTimesTip />}
+          {!activePatternHasLocations(activePattern) && <NormalizeStopTimesTip />}
         </div>
       )
     }

--- a/lib/editor/components/pattern/PatternStopCard.js
+++ b/lib/editor/components/pattern/PatternStopCard.js
@@ -423,6 +423,7 @@ class PatternStopContents extends Component<Props, State> {
 
   _renderPickupDropOffTypes = (isFlex: boolean) => {
     const { activePattern, patternStop } = this.props
+
     // Regular stops have a default pickup/dropoff type of 0 (regularly scheduled stop).
     // Flex stops have a default pickup/dropoff type of 2 (must phone agency).
     const defaultPickupDropOff = isFlex ? 2 : 0
@@ -472,6 +473,7 @@ class PatternStopContents extends Component<Props, State> {
     const pickupBookingRuleId = getGtfsSpecField('stop_time', 'pickup_booking_rule_id')
     const dropOffBookingRuleId = getGtfsSpecField('stop_time', 'drop_off_booking_rule_id')
     const isStop = patternHaltIsStop(patternStop)
+    const activePatternHasLocations = activePattern.patternLocations.length > 0
 
     const bookingRuleRow = feedSource.flexUIFeaturesEnabled && (
       <Row>
@@ -670,7 +672,7 @@ class PatternStopContents extends Component<Props, State> {
             </Col>
           </Row>
           {isStop ? stopRows : locationRows}
-          <NormalizeStopTimesTip />
+          {!activePatternHasLocations && <NormalizeStopTimesTip />}
         </div>
       )
     }

--- a/lib/editor/components/pattern/PatternStopCard.js
+++ b/lib/editor/components/pattern/PatternStopCard.js
@@ -473,7 +473,7 @@ class PatternStopContents extends Component<Props, State> {
     const pickupBookingRuleId = getGtfsSpecField('stop_time', 'pickup_booking_rule_id')
     const dropOffBookingRuleId = getGtfsSpecField('stop_time', 'drop_off_booking_rule_id')
     const isStop = patternHaltIsStop(patternStop)
-    const activePatternHasLocations = activePattern.patternLocations.length > 0
+    const activePatternHasLocations = activePattern.patternLocations.length > 0 || activePattern.patternLocationGroups.length > 0
 
     const bookingRuleRow = feedSource.flexUIFeaturesEnabled && (
       <Row>

--- a/lib/editor/components/pattern/PatternStopsPanel.js
+++ b/lib/editor/components/pattern/PatternStopsPanel.js
@@ -114,7 +114,7 @@ export default class PatternStopsPanel extends Component<Props, State> {
           activePattern.patternLocationGroups.length > 0)
 
     const patternHaltCount = (activePattern.patternStops.length || 0) + (activePattern.patternLocations.length || 0) + (activePattern.patternLocationGroups.length || 0)
-    const patternHasLocations = activePattern.patternLocations.length > 0
+    const activePatternHasLocations = activePattern.patternLocations.length > 0 || activePattern.patternLocationGroups.length > 0
 
     return (
       <div>
@@ -129,7 +129,7 @@ export default class PatternStopsPanel extends Component<Props, State> {
           {`Stops & Locations (${patternHaltCount})`}
         </h4>
         <div style={{width: '100%'}}>
-          {!patternHasLocations &&
+          {!activePatternHasLocations &&
             <Button
               onClick={this._clickNormalizeStopTimes}
               style={{marginBottom: '5px'}}

--- a/lib/editor/components/pattern/PatternStopsPanel.js
+++ b/lib/editor/components/pattern/PatternStopsPanel.js
@@ -114,6 +114,7 @@ export default class PatternStopsPanel extends Component<Props, State> {
           activePattern.patternLocationGroups.length > 0)
 
     const patternHaltCount = (activePattern.patternStops.length || 0) + (activePattern.patternLocations.length || 0) + (activePattern.patternLocationGroups.length || 0)
+    const patternHasLocations = activePattern.patternLocations.length > 0
 
     return (
       <div>
@@ -128,15 +129,17 @@ export default class PatternStopsPanel extends Component<Props, State> {
           {`Stops & Locations (${patternHaltCount})`}
         </h4>
         <div style={{width: '100%'}}>
-          <Button
-            onClick={this._clickNormalizeStopTimes}
-            style={{marginBottom: '5px'}}
-            className='pull-right'
-            block
-            bsSize='small'>
-            <Icon type='clock-o' />{' '}
-            Normalize stop times
-          </Button>
+          {!patternHasLocations &&
+            <Button
+              onClick={this._clickNormalizeStopTimes}
+              style={{marginBottom: '5px'}}
+              className='pull-right'
+              block
+              bsSize='small'>
+              <Icon type='clock-o' />{' '}
+                Normalize stop times
+            </Button>
+          }
           <Button
             onClick={this._toggleAddStopsMode}
             className='pull-right'

--- a/lib/editor/components/pattern/PatternStopsPanel.js
+++ b/lib/editor/components/pattern/PatternStopsPanel.js
@@ -13,6 +13,7 @@ import VirtualizedEntitySelect from '../VirtualizedEntitySelect'
 import {getEntityBounds, getEntityName} from '../../util/gtfs'
 import type {Pattern, GtfsLocation, GtfsStop, Feed, ControlPoint, Coordinates} from '../../../types'
 import type {EditorStatus, EditSettingsUndoState, MapState} from '../../../types/reducers'
+import { activePatternHasLocations } from '../../util/location'
 
 import PatternStopContainer from './PatternStopContainer'
 import NormalizeStopTimesModal from './NormalizeStopTimesModal'
@@ -114,8 +115,6 @@ export default class PatternStopsPanel extends Component<Props, State> {
           activePattern.patternLocationGroups.length > 0)
 
     const patternHaltCount = (activePattern.patternStops.length || 0) + (activePattern.patternLocations.length || 0) + (activePattern.patternLocationGroups.length || 0)
-    const activePatternHasLocations = activePattern.patternLocations.length > 0 || activePattern.patternLocationGroups.length > 0
-
     return (
       <div>
         <NormalizeStopTimesModal
@@ -129,7 +128,7 @@ export default class PatternStopsPanel extends Component<Props, State> {
           {`Stops & Locations (${patternHaltCount})`}
         </h4>
         <div style={{width: '100%'}}>
-          {!activePatternHasLocations &&
+          {!activePatternHasLocations(activePattern) &&
             <Button
               onClick={this._clickNormalizeStopTimes}
               style={{marginBottom: '5px'}}

--- a/lib/editor/util/location.js
+++ b/lib/editor/util/location.js
@@ -1,7 +1,7 @@
 // @flow
 import type { LatLng } from 'leaflet'
 
-import type { LocationShape, PatternHalt, PatternLocation, PatternLocationGroup, PatternStop } from '../../types'
+import type { LocationShape, Pattern, PatternHalt, PatternLocation, PatternLocationGroup, PatternStop } from '../../types'
 
 export const groupLocationShapePoints = (locationShapes: LocationShape) => locationShapes
   .reduce(
@@ -34,6 +34,8 @@ export const patternHaltIsStop = (
 ): PatternStop =>
   // $FlowFixMe Flow doesn't understand type check
   patternStopOrLocation.hasOwnProperty('stopId') ? patternStopOrLocation : undefined
+
+export const activePatternHasLocations = (pattern: Pattern) => pattern.patternLocations.length > 0 || pattern.patternLocationGroups.length > 0
 
 export const getLayerCoords = (isPolygon: boolean, coordSet: any) => isPolygon ? coordSet[0].map(convertLatLngToArray) : coordSet.map(convertLatLngToArray)
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] All tests and CI builds passing

### Description

Removes the Normalize Stop Times button on flex routes. Also removes the associated tips that reference a button that does not exist.
