### PR TITLE
Don't Refetch feed source list when opening project

### DIFF
--- a/lib/manager/actions/feeds.js
+++ b/lib/manager/actions/feeds.js
@@ -50,12 +50,6 @@ const FS_URL = '/api/manager/secure/feedsource'
  */
 export function fetchProjectFeeds (projectId: string) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    // Don't fetch project or feeds if project and feeds are already present
-    const state = getState()
-    const project = state.projects.all.find(p => p.id === projectId)
-    if (project && project.feedSources && project.feedSources.length > 0) {
-      return
-    }
     dispatch(requestingFeedSources())
     return dispatch(secureFetch(`${FS_URL}?projectId=${projectId}`))
       .then(response => response.json())

--- a/lib/manager/actions/feeds.js
+++ b/lib/manager/actions/feeds.js
@@ -50,6 +50,12 @@ const FS_URL = '/api/manager/secure/feedsource'
  */
 export function fetchProjectFeeds (projectId: string) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
+    // Don't fetch project or feeds if project and feeds are already present
+    const state = getState()
+    const project = state.projects.all.find(p => p.id === projectId)
+    if (project && project.feedSources && project.feedSources.length > 0) {
+      return
+    }
     dispatch(requestingFeedSources())
     return dispatch(secureFetch(`${FS_URL}?projectId=${projectId}`))
       .then(response => response.json())

--- a/lib/manager/actions/projects.js
+++ b/lib/manager/actions/projects.js
@@ -112,7 +112,7 @@ export function fetchProjectWithFeeds (projectId: string, unsecure: ?boolean) {
     // Don't fetch project or feeds if project and feeds are already present
     const state = getState()
     const project = state.projects.all.find(p => p.id === projectId)
-    if (project && project.feedSources && project.feedSources.length > 0) {
+    if (project && project.feedSources && project.feedSourceCount && project.feedSources.length === project.feedSourceCount) {
       return
     }
 

--- a/lib/manager/actions/projects.js
+++ b/lib/manager/actions/projects.js
@@ -109,6 +109,13 @@ export function fetchProject (projectId: string, unsecure: ?boolean) {
 
 export function fetchProjectWithFeeds (projectId: string, unsecure: ?boolean) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
+    // Don't fetch project or feeds if project and feeds are already present
+    const state = getState()
+    const project = state.projects.all.find(p => p.id === projectId)
+    if (project && project.feedSources && project.feedSources.length > 0) {
+      return
+    }
+
     dispatch(requestingProject())
     const apiRoot = unsecure ? 'public' : 'secure'
     const url = `/api/manager/${apiRoot}/project/${projectId}`

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -810,6 +810,7 @@ export type Project = {
   defaultLocationLon?: number,
   defaultTimeZone: ?string,
   deployments: Array<Deployment>,
+  feedSourceCount?: number,
   feedSources: Array<Feed>,
   id: string,
   isCreating?: boolean,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] e2e tests are all passing _(remove this if not merging to master)_

### Description

Currently we re-fetch the entire feed source list when opening a project, even though we already have all that information downloaded. Really the true fix here is to look at our data insertion pipeline. For now, this PR adds a check that prevents the re-fetch from happening if we already have the needed data. 

I would be open to a more holistic solution if anyone has one in mind!