### PR TITLE
fix(CurrentDeploymentPanel): support otp2 graph downloads

### DIFF
--- a/lib/manager/components/deployment/CurrentDeploymentPanel.js
+++ b/lib/manager/components/deployment/CurrentDeploymentPanel.js
@@ -229,7 +229,8 @@ class DeployJobSummary extends Component<{
   }
 
   _onClickDownloadGraph = () => {
-    this.props.downloadBuildArtifact(this.props.deployment, 'Graph.obj', this._getJobId())
+    const g = this.props.deployment.tripPlannerVersion === 'OTP_2' ? 'g' : 'G'
+    this.props.downloadBuildArtifact(this.props.deployment, `${g}raph.obj`, this._getJobId())
   }
 
   _onClickDownloadReport = () => {
@@ -277,7 +278,7 @@ class DeployJobSummary extends Component<{
             onClick={this._onClickDownloadLogs}>
             <Icon type='file-text-o' /> Build log
           </Button>
-          <Button
+          {/* TODO: otp-runner uploads these? <Button
             bsSize='xsmall'
             onClick={this._onClickDownloadReport}>
             <Icon type='file-zip-o' /> Graph build report
@@ -286,7 +287,7 @@ class DeployJobSummary extends Component<{
             bsSize='xsmall'
             onClick={this._onClickDownloadBundle}>
             <Icon type='file-zip-o' /> Bundle
-          </Button>
+        </Button> */}
         </ButtonToolbar>
         <div style={{ margin: '20px 0' }}>
           <DeploymentPreviewButton


### PR DESCRIPTION
Co-authored-by: philip-cline <philip-cline@users.noreply.github.com>

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

OTP2 uses `g`raph rather than `G`raph