### PR TITLE
Generate Rows with Offset Button

### DIFF
--- a/lib/editor/actions/trip.js
+++ b/lib/editor/actions/trip.js
@@ -44,6 +44,10 @@ export const setOffset = createAction(
   'SET_TIMETABLE_OFFSET',
   (payload: number) => payload
 )
+export const setGenerateTripsCount = createAction(
+  'SET_GENERATE_TRIPS_COUNT',
+  (payload: number) => payload
+)
 export const setScrollIndexes = createAction(
   'SET_TIMETABLE_SCROLL_INDEXES',
   (payload: { scrollToColumn: number, scrollToRow: number }) => payload

--- a/lib/editor/components/timetable/Timetable.js
+++ b/lib/editor/components/timetable/Timetable.js
@@ -7,12 +7,12 @@ import {ScrollSync} from 'react-virtualized/dist/commonjs/ScrollSync'
 
 import * as tripActions from '../../actions/trip'
 import Loading from '../../../common/components/Loading'
-import TimetableGrid from './TimetableGrid'
 import {getHeaderColumns, isTimeFormat} from '../../util/timetable'
-
 import type {Pattern, TimetableColumn, Trip} from '../../../types'
 import type {TimetableState} from '../../../types/reducers'
 import type {TripValidationIssues} from '../../selectors/timetable'
+
+import TimetableGrid from './TimetableGrid'
 import type {CellData} from './EditableCell'
 
 type Props = {
@@ -29,6 +29,7 @@ type Props = {
   scrollToColumn: number,
   scrollToRow: number,
   setActiveCell: typeof tripActions.setActiveCell,
+  setGenerateTripsCount: typeof tripActions.setGenerateTripsCount,
   setOffset: typeof tripActions.setOffset,
   setScrollIndexes: typeof tripActions.setScrollIndexes,
   showHelpModal: () => void,

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -178,7 +178,9 @@ export default class TimetableEditor extends Component<Props, State> {
 
       // TODO: auto-add offset to any new trip?  No, for now. Perhaps we could
       // add toggle/checkbox that allows for this.
-      cumulativeTravelTime += this.props.timetable.offset
+      if (withOffset) {
+        cumulativeTravelTime += this.props.timetable.offset
+      }
 
       for (let i = 0; i < activePattern.patternStops.length; i++) {
         const stop = activePattern.patternStops[i]

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -144,7 +144,12 @@ export default class TimetableEditor extends Component<Props, State> {
 
   cloneSelectedTrips = () => this.duplicateRows(this._getSelectedRowIndexes())
 
-  constructNewRow = (toClone: ?Trip = null) => {
+  generateOffsetTrips = () => this.generateRowsWithOffset(
+    this._getSelectedRowIndexes()[0],
+    this.state.generateRowsCount
+  );
+
+  constructNewRow = (toClone: ?Trip = null, withOffset: ?boolean) => {
     const {activePatternId, route} = this.props
     const activePattern = route && route.tripPatterns
       ? route.tripPatterns.find(p => p.id === activePatternId)
@@ -158,20 +163,21 @@ export default class TimetableEditor extends Component<Props, State> {
     const newRow: Trip = toClone
       ? clone(toClone) || blankTrip
       : blankTrip
-    if (toClone) {
+    // If there's an offset, then we need to recalculate all the stop times
+    if (toClone && !withOffset) {
       // Update trip's internal ID and trip ID if cloning.
       objectPath.set(newRow, 'id', ENTITY.NEW_ID)
       objectPath.set(newRow, 'tripId', null)
       return newRow
     } else {
       // set starting time for first arrival
-      let cumulativeTravelTime = !toClone
-        ? 0
-        : objectPath.get(newRow, `stopTimes.0.arrivalTime`)
+      let cumulativeTravelTime = toClone && withOffset
+        ? objectPath.get(newRow, `stopTimes.0.arrivalTime`)
+        : 0
 
       // TODO: auto-add offset to any new trip?  No, for now. Perhaps we could
       // add toggle/checkbox that allows for this.
-      // cumulativeTravelTime += this.props.timetable.offset
+      cumulativeTravelTime += this.props.timetable.offset
 
       for (let i = 0; i < activePattern.patternStops.length; i++) {
         const stop = activePattern.patternStops[i]
@@ -259,6 +265,19 @@ export default class TimetableEditor extends Component<Props, State> {
         scrollToColumn: 0
       })
     }
+  }
+
+  generateRowsWithOffset = (startingIndex: number, count: number) => {
+    const startingPoint = this.props.timetable.trips[startingIndex]
+    let lastRow = startingPoint
+    for (let i = 0; i < count; i++) {
+      lastRow = this.constructNewRow(startingPoint, true)
+      this.props.addNewTrip(lastRow)
+    }
+    // this.props.setScrollIndexes({
+    //   scrollToRow: lastIndex + arrayAscending.length,
+    //   scrollToColumn: 0
+    // })
   }
 
   addNewRow = (blank: ?boolean = false, scroll: ?boolean = false) => {
@@ -393,6 +412,7 @@ export default class TimetableEditor extends Component<Props, State> {
           offsetWithDefaults={this._offsetWithDefaults}
           cloneSelectedTrips={this.cloneSelectedTrips}
           saveEditedTrips={this.saveEditedTrips}
+          generateOffsetTrips={this.generateOffsetTrips}
           {...this.props} />
         {activeSchedule
           ? <Timetable

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -40,6 +40,7 @@ type Props = ContainerProps & {
   saveTripsForCalendar: typeof tripActions.saveTripsForCalendar,
   setActiveCell: typeof tripActions.setActiveCell,
   setActiveEntity: typeof activeActions.setActiveEntity,
+  setGenerateTripsCount: typeof tripActions.setGenerateTripsCount,
   setOffset: typeof tripActions.setOffset,
   setScrollIndexes: typeof tripActions.setScrollIndexes,
   tableData: EditorTables,
@@ -146,7 +147,7 @@ export default class TimetableEditor extends Component<Props, State> {
 
   generateOffsetTrips = () => this.generateRowsWithOffset(
     this._getSelectedRowIndexes()[0],
-    this.state.generateRowsCount
+    this.props.timetable.generateTripsCount
   );
 
   constructNewRow = (toClone: ?Trip = null, withOffset: ?boolean) => {
@@ -271,7 +272,7 @@ export default class TimetableEditor extends Component<Props, State> {
     const startingPoint = this.props.timetable.trips[startingIndex]
     let lastRow = startingPoint
     for (let i = 0; i < count; i++) {
-      lastRow = this.constructNewRow(startingPoint, true)
+      lastRow = this.constructNewRow(lastRow, true)
       this.props.addNewTrip(lastRow)
     }
     // this.props.setScrollIndexes({

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -270,6 +270,9 @@ export default class TimetableEditor extends Component<Props, State> {
     }
   }
 
+  /**
+   * Generates the specified number of rows based with the offset from the offset field applied
+   */
   generateRowsWithOffset = (startingIndex: number, count: number) => {
     const startingPoint = this.props.timetable.trips[startingIndex]
     let lastRow = startingPoint
@@ -277,10 +280,6 @@ export default class TimetableEditor extends Component<Props, State> {
       lastRow = this.constructNewRow(lastRow, true)
       this.props.addNewTrip(lastRow)
     }
-    // this.props.setScrollIndexes({
-    //   scrollToRow: lastIndex + arrayAscending.length,
-    //   scrollToColumn: 0
-    // })
   }
 
   addNewRow = (blank: ?boolean = false, scroll: ?boolean = false) => {

--- a/lib/editor/components/timetable/TimetableHeader.js
+++ b/lib/editor/components/timetable/TimetableHeader.js
@@ -44,6 +44,7 @@ type Props = {
   route: GtfsRoute,
   saveEditedTrips: (Pattern, string) => void,
   setActiveEntity: typeof activeActions.setActiveEntity,
+  setGenerateTripsCount: typeof tripActions.setGenerateTripsCount,
   setOffset: typeof tripActions.setOffset,
   setScrollIndexes: typeof tripActions.setScrollIndexes,
   showHelpModal: () => void,
@@ -98,6 +99,7 @@ export default class TimetableHeader extends Component<Props> {
       fetchCalendarTripCountsForPattern,
       timetable,
       setOffset,
+      setGenerateTripsCount,
       toggleDepartureTimes,
       removeSelectedRows,
       route,
@@ -210,47 +212,25 @@ export default class TimetableHeader extends Component<Props> {
             <FormGroup
               className='pull-right'
               style={{
-                maxWidth: '120px',
+                maxWidth: '160px',
                 marginBottom: '0px',
                 marginRight: '18px',
-                minWidth: '60px'
-              }}>
-              <InputGroup>
-                <HourMinuteInput
-                  bsSize='small'
-                  seconds={timetable.offset}
-                  onChange={setOffset} />
-                <InputGroup.Button>
-                  <Button
-                    bsSize='small'
-                    onClick={this._onClickOffset}>
-                    Offset
-                  </Button>
-                </InputGroup.Button>
-              </InputGroup>
-              <HelpBlock
-                className='pull-right'
-                style={{fontSize: '10px', margin: '0px'}}>
-                Shift-click to subtract
-              </HelpBlock>
-            </FormGroup>
-            <FormGroup
-              className='pull-right'
-              style={{
-                maxWidth: '120px',
-                marginBottom: '0px',
-                marginRight: '18px',
-                minWidth: '60px'
+                minWidth: '80px'
               }}>
               <InputGroup>
                 <FormControl
                   // TODO: finish
+                  bsSize='small'
+                  type='number'
+                  onChange={e => setGenerateTripsCount(Number(e.target.value))}
                 />
                 <InputGroup.Button>
                   <Button
                     bsSize='small'
-                    onClick={this._onClickOffset}>
-                    Offset
+                    onClick={this.props.generateOffsetTrips}
+                    disabled={this.props.timetable.selected.length !== 1}
+                  >
+                    Generate
                   </Button>
                 </InputGroup.Button>
               </InputGroup>

--- a/lib/editor/components/timetable/TimetableHeader.js
+++ b/lib/editor/components/timetable/TimetableHeader.js
@@ -14,7 +14,7 @@ import {
   Popover,
   Row,
   Tooltip
-} from 'react-bootstrap'
+  , FormControl} from 'react-bootstrap'
 import truncate from 'truncate'
 
 import * as activeActions from '../../actions/active'
@@ -38,6 +38,7 @@ type Props = {
   feedSource: Feed,
   fetchCalendarTripCountsForPattern: typeof tripActions.fetchCalendarTripCountsForPattern,
   fetchTripsForCalendar: typeof tripActions.fetchTripsForCalendar,
+  generateOffsetTrips: () => void,
   offsetWithDefaults: (boolean) => void,
   removeSelectedRows: () => void,
   route: GtfsRoute,
@@ -206,6 +207,54 @@ export default class TimetableHeader extends Component<Props> {
           </Col>
           <Col sm={3}>
             {/* Offset number/button */}
+            <FormGroup
+              className='pull-right'
+              style={{
+                maxWidth: '120px',
+                marginBottom: '0px',
+                marginRight: '18px',
+                minWidth: '60px'
+              }}>
+              <InputGroup>
+                <HourMinuteInput
+                  bsSize='small'
+                  seconds={timetable.offset}
+                  onChange={setOffset} />
+                <InputGroup.Button>
+                  <Button
+                    bsSize='small'
+                    onClick={this._onClickOffset}>
+                    Offset
+                  </Button>
+                </InputGroup.Button>
+              </InputGroup>
+              <HelpBlock
+                className='pull-right'
+                style={{fontSize: '10px', margin: '0px'}}>
+                Shift-click to subtract
+              </HelpBlock>
+            </FormGroup>
+            <FormGroup
+              className='pull-right'
+              style={{
+                maxWidth: '120px',
+                marginBottom: '0px',
+                marginRight: '18px',
+                minWidth: '60px'
+              }}>
+              <InputGroup>
+                <FormControl
+                  // TODO: finish
+                />
+                <InputGroup.Button>
+                  <Button
+                    bsSize='small'
+                    onClick={this._onClickOffset}>
+                    Offset
+                  </Button>
+                </InputGroup.Button>
+              </InputGroup>
+            </FormGroup>
             <FormGroup
               className='pull-right'
               style={{

--- a/lib/editor/containers/ActiveTimetableEditor.js
+++ b/lib/editor/containers/ActiveTimetableEditor.js
@@ -13,6 +13,7 @@ import {
   saveTripsForCalendar,
   setActiveCell,
   setOffset,
+  setGenerateTripsCount,
   setScrollIndexes,
   toggleAllRows,
   toggleDepartureTimes,
@@ -24,7 +25,6 @@ import {getTableById} from '../util/gtfs'
 import {findProjectByFeedSource} from '../../manager/util'
 import {getTripCounts} from '../selectors'
 import {getTimetableColumns, getTripValidationErrors} from '../selectors/timetable'
-
 import type {AppState, RouteParams} from '../../types/reducers'
 
 export type Props = {
@@ -76,6 +76,7 @@ const mapDispatchToProps = {
   setActiveCell,
   setActiveEntity,
   setOffset,
+  setGenerateTripsCount,
   setScrollIndexes,
   toggleAllRows,
   toggleDepartureTimes,

--- a/lib/editor/reducers/timetable.js
+++ b/lib/editor/reducers/timetable.js
@@ -22,6 +22,7 @@ export const defaultState = {
   selected: [],
   hideDepartureTimes: false,
   offset: 0,
+  generateTripsCount: 0,
   scrollIndexes: {
     scrollToColumn: 0,
     scrollToRow: 0
@@ -112,6 +113,10 @@ const timetable = (state: TimetableState = defaultState, action: Action): Timeta
     case 'SET_TIMETABLE_OFFSET':
       return update(state, {
         offset: {$set: action.payload}
+      })
+    case 'SET_GENERATE_TRIPS_COUNT':
+      return update(state, {
+        generateTripsCount: {$set: action.payload}
       })
     case 'UPDATE_TIMETABLE_CELL_VALUE': {
       const trips = clone(state.trips)

--- a/lib/types/reducers.js
+++ b/lib/types/reducers.js
@@ -236,6 +236,7 @@ export type MapState = {
 export type TimetableState = {
   +activeCell: ?string,
   +edited: Array<number>,
+  +generateTripsCount: number,
   +hideDepartureTimes: boolean,
   +offset: number,
   +scrollIndexes: {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Adds a button to the timetable editor that generates a user set number of new rows from the selected row, with each row being offset by the value set in the offset field. 
