### PR TITLE
Populate pattern pickupType/dropOffType into new stop time

### DIFF
--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -194,6 +194,8 @@ export default class TimetableEditor extends Component<Props, State> {
         cumulativeTravelTime += +stop.defaultDwellTime
         // if (stop.timepoint === null || stop.timepoint) {
         objectPath.set(newRow, `stopTimes.${i}.departureTime`, cumulativeTravelTime)
+        objectPath.set(newRow, `stopTimes.${i}.pickupType`, stop.pickupType)
+        objectPath.set(newRow, `stopTimes.${i}.dropOffType`, stop.dropOffType)
         objectPath.set(newRow, `stopTimes.${i}.continuousPickup`, stop.continuousPickup)
         objectPath.set(newRow, `stopTimes.${i}.continuousDropOff`, stop.continuousDropOff)
         objectPath.set(newRow, `stopTimes.${i}.timepoint`, stop.timepoint || 0)


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

In the timetable editor, when adding a new stop time to a pattern (*not* duplicating an existing one),
the value in fields `pickupType` and `dropOffType` are incorrectly left as null.
This PR populates these fields from the pattern stop as desired.