### PR TITLE
Fix stop headsigns regressions

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -827,6 +827,9 @@ components:
       defaultDwellTime: Default dwell time
       defaultTravelTime: Default travel time
       firstStopTravelTime: Travel time for first stop must be zero
+      stopHeadsignPlaceholder: Outbound
+      stopHeadsignText: Stop headsign
+      stopHeadsignTitle: Headsign that overrides trip headsign between stops.
       timepoint: Timepoint?
       travelTimeHelp: Define the default time it takes to travel to this stop from the previous stop.
     PickupDropOffSelect:

--- a/lib/editor/components/pattern/PatternStopCard.js
+++ b/lib/editor/components/pattern/PatternStopCard.js
@@ -468,13 +468,12 @@ class PatternStopContents extends Component<Props, State> {
               bsSize='small'>
               <ControlLabel
                 className='small'
-                // TODO: internationalize this
-                title={'Headsign that overrides trip headsign between stops.'}>
-                Stop headsign
+                title={patternStopCardMessages('PatternStopContents.stopHeadsignTitle')}>
+                {patternStopCardMessages('PatternStopContents.stopHeadsignText')}
               </ControlLabel>
               <FormControl
-                // TODO: internationalize this
-                placeholder={'Outbound'}
+                onChange={this._onHeadsignChange}
+                placeholder={patternStopCardMessages('PatternStopContents.stopHeadsignPlaceholder')}
                 type='text'
                 value={patternStop.stopHeadsign || ''}
               />


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

Somewhere along recent updates, stop headsigns `onChange` method disappeared, meaning that headsign text could not be saved. This PR resolves that and also internationalizes the stop headsign dropdown for good measure ✨.
