### PR TITLE
Fix editor lock regression

### DIFF
--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -131,7 +131,7 @@ function getErrorMessageFromJson (
     }
     // re-assign error message after it gets used in the detail.
     errorMessage = json.message || JSON.stringify(json)
-    if (json.detail.includes('conflicts with an existing trip id')) {
+    if (json.detail && json.detail.includes('conflicts with an existing trip id')) {
       action = 'DEFAULT'
     }
   }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

There was a small regression in the `getErrorMessageFromJson` that caused the editor lock message to not show up. This is resolved by avoiding the front end crash. 
