### PR TITLE
ci: bump node to version 14

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -20,10 +20,10 @@ jobs:
         run: |
           pip install Jinja2==3.0.3 mkdocs
           mkdocs --version
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: Install npm/yarn packages using cache
         uses: bahmutov/npm-install@v1
       - name: Lint code


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Looks like node 12 was causing some issues. Node 14 resolves these issues. 