### PR TITLE
Remove Broken Log Button

### DIFF
--- a/lib/manager/components/deployment/CurrentDeploymentPanel.js
+++ b/lib/manager/components/deployment/CurrentDeploymentPanel.js
@@ -273,11 +273,11 @@ class DeployJobSummary extends Component<{
             onClick={this._onClickDownloadGraph}>
             <Icon type='ellipsis-h' /> Graph.obj
           </Button>
-          <Button
+          {/* TODO: This isn't uploaded anymore? <Button
             bsSize='xsmall'
             onClick={this._onClickDownloadLogs}>
             <Icon type='file-text-o' /> Build log
-          </Button>
+          </Button> */}
           {/* TODO: otp-runner uploads these? <Button
             bsSize='xsmall'
             onClick={this._onClickDownloadReport}>


### PR DESCRIPTION
### Checklist

- [X] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [X] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [X] The description lists all applicable issues this PR seeks to resolve
- [X] The description lists any configuration setting(s) that differ from the default settings
- [X] All tests and CI builds passing

### Description

The log button relied on a bash script that hasn't present on deployed instances for a while. This PR removes the button. Logs can be found by clicking on the AWS button and going to cloud watch (if that's configured on the OTP instance ami)
