### PR TITLE
Avoid crash on failed projection

### DIFF
--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -303,7 +303,7 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
         const {cpIndex: nextStopIndex} = stopControlPoints[index]
         // Iterate over control points to find previous and next stop control
         // points.
-        let spliceIndex = 0
+        let spliceIndex = 1 // Init to 1 to avoid crashing in a case where we can't project the stop onto the existing pattern.
         while (controlPoints[spliceIndex].distance < distanceInMeters && spliceIndex < nextStopIndex) {
           spliceIndex++
         }
@@ -315,8 +315,6 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
         // Replace n segments with 2 blank "placeholder" segments to be replaced
         // with new routed segments.
         clonedControlPoints.splice(spliceIndex, 0, controlPoint)
-        // Avoid crashing in a case where we can't project the stop onto the existing pattern.
-        if (spliceIndex === 0) spliceIndex = 1
         const prev = clonedControlPoints[spliceIndex - 1]
         const next = clonedControlPoints[spliceIndex + 1]
         const segmentSpliceIndex = spliceIndex - 1

--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -234,7 +234,6 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
         ? patternStops.length
         : index
     )
-
     if (typeof index === 'undefined' || index === null || index === patternStops.length) {
       // Push pattern stop to cloned list.
       patternStops.push(newStop)
@@ -316,6 +315,8 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
         // Replace n segments with 2 blank "placeholder" segments to be replaced
         // with new routed segments.
         clonedControlPoints.splice(spliceIndex, 0, controlPoint)
+        // Avoid crashing in a case where we can't project the stop onto the existing pattern.
+        if (spliceIndex === 0) spliceIndex = 1
         const prev = clonedControlPoints[spliceIndex - 1]
         const next = clonedControlPoints[spliceIndex + 1]
         const segmentSpliceIndex = spliceIndex - 1


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing


### Description

Simple fix to avoid a bug associated with inserting stops into a pattern where the projection fails and places the stop at `spliceIndex` 0. A more robust fix will be coming in a forthcoming PR, which will resolve some other issues associated with this ✨ quirk ✨. 