### PR TITLE
Improve stop insertion shape generation

### DIFF
--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -318,30 +318,34 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
           previousStopControlPoint.point.geometry.coordinates,
           [stop.stop_lon, stop.stop_lat]
         ]
-        const newFromSegment = await getSegment(newFromSegmentCoords, true)
-        const segmentDistance = lineDistance(newFromSegment, 'meters')
-        const addedControlPoint = newControlPoint(
-          previousStopControlPoint.distance + segmentDistance,
-          insertPoint,
-          {
-            stopId: stop.stop_id,
-            pointType: POINT_TYPE.STOP // 2
-          })
-        // Instead of splicing at the previousStopControlPoint, splice immediately after.
-        clonedControlPoints.splice(spliceIndex, 0, addedControlPoint)
 
-        // Replace n segments with 2 segments to be replaced
-        // with new routed segments.
-        clonedPatternSegments.splice(
-          previousStopControlPoint.cpIndex,
-          1,
-          [previousStopControlPoint.point.geometry.coordinates, insertPoint.geometry.coordinates],
-          [insertPoint.geometry.coordinates, nextControlPoint.point.geometry.coordinates]
-        )
+        // We wrap more of the code in this try block because the pre-calculated "newFromSegment" can fail in the same way
+        // as recalculate shape.
         let result
-        // TODO: Because we are pre-generating the from segment above, we could use that in the final recalculated shape.
-        // Right now, bc of the legacy method we are repeating that small amount of work.
         try {
+          const newFromSegment = await getSegment(newFromSegmentCoords, true)
+          const segmentDistance = lineDistance(newFromSegment, 'meters')
+          const addedControlPoint = newControlPoint(
+            previousStopControlPoint.distance + segmentDistance,
+            insertPoint,
+            {
+              stopId: stop.stop_id,
+              pointType: POINT_TYPE.STOP // 2
+            })
+          // Instead of splicing at the previousStopControlPoint, splice immediately after.
+          clonedControlPoints.splice(spliceIndex, 0, addedControlPoint)
+
+          // Replace n segments with 2 segments to be replaced
+          // with new routed segments.
+          clonedPatternSegments.splice(
+            previousStopControlPoint.cpIndex,
+            1,
+            [previousStopControlPoint.point.geometry.coordinates, insertPoint.geometry.coordinates],
+            [insertPoint.geometry.coordinates, nextControlPoint.point.geometry.coordinates]
+          )
+
+          // TODO: Because we are pre-generating the from segment above, we could use that in the final recalculated shape.
+          // Right now, bc of the legacy method we are repeating that small amount of work.
           result = await recalculateShape({
             avoidMotorways,
             controlPoints: clonedControlPoints,

--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -17,21 +17,19 @@ import {newGtfsEntity} from '../editor'
 import {setErrorMessage} from '../../../manager/actions/status'
 import {updatePatternGeometry} from '../map'
 import {getControlPoints} from '../../selectors'
-import {polyline as getPolyline} from '../../../scenario-editor/utils/valhalla'
+import {getSegment, polyline as getPolyline} from '../../../scenario-editor/utils/valhalla'
 import {getTableById} from '../../util/gtfs'
-import {
+import {stopToGeoJSONPoint,
   constructStop,
   controlPointsFromSegments,
   newControlPoint,
   stopToPatternStop,
   recalculateShape,
   getPatternEndPoint,
-  projectStopOntoLine,
   street,
   stopToPoint,
   constructPoint
 } from '../../util/map'
-import {coordinatesFromShapePoints} from '../../util/objects'
 import type {ControlPoint, GtfsStop, LatLng, Pattern} from '../../../types'
 import type {dispatchFn, getStateFn} from '../../../types/reducers'
 
@@ -226,7 +224,6 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
     const {patternStops: currentPatternStops, shapePoints} = pattern
     const patternStops = clone(currentPatternStops)
     const {controlPoints, patternSegments} = getControlPoints(getState())
-    const patternLine = lineString(coordinatesFromShapePoints(shapePoints))
     const hasShapePoints = shapePoints && shapePoints.length > 1
     const newStop = stopToPatternStop(
       stop,
@@ -286,48 +283,64 @@ export function addStopToPattern (pattern: Pattern, stop: GtfsStop, index?: ?num
       if (hasShapePoints) {
         // Update shape if it exists. No need to update anything besides pattern
         // stops (which already occurred above) if there is no shape. NOTE: the
-        // behavior in this code block essentially replaces any surrounding
-        // non-stop control points with the new pattern stop and re-routes the
-        // shape between it and the surrounding stop control points.
-        // Find projected location onto pattern shape.
-        const {distanceInMeters, insertPoint} = projectStopOntoLine(stop, patternLine)
+        // behavior in this code block essentially replaces any
+        // non-stop control points in the "from" segment with the new pattern stop and re-routes the
+        // shape between it and the new stop.
+        // Non-stop control points are preserved in the new "to" segment.
+        //     ↙️ "from" segment      ↙️ "to" segment
+        //  0 ——x——— 0 ——————————x———x——— 0
+        //             ^— 0 —^ <--- new inserted stop
+
         // Add control point in order to copy of current list.
-        const controlPoint = newControlPoint(distanceInMeters, insertPoint, {
-          stopId: stop.stop_id,
-          pointType: POINT_TYPE.STOP // 2
-        })
         const stopControlPoints = controlPoints
           // TODO: refactor into shared function (see pattern-debug-lines.js)
           .map((cp, index) => ({...cp, cpIndex: index}))
           .filter(cp => cp.pointType === POINT_TYPE.STOP)
-        const {cpIndex: nextStopIndex} = stopControlPoints[index]
-        // Iterate over control points to find previous and next stop control
-        // points.
-        let spliceIndex = 1 // Init to 1 to avoid crashing in a case where we can't project the stop onto the existing pattern.
-        while (controlPoints[spliceIndex].distance < distanceInMeters && spliceIndex < nextStopIndex) {
-          spliceIndex++
-        }
         // Perform splice operation on cloned control points to remove any
         // control points between the previous and next stop control points and
         // insert new stop control point in their stead.
         const clonedControlPoints = clone(controlPoints)
         const clonedPatternSegments = clone(patternSegments)
-        // Replace n segments with 2 blank "placeholder" segments to be replaced
+
+        // Insert the new stop after the previous stopControlPoint.
+        // We assume that all control points hold for the "to" semgent (see above).
+        const previousStopControlPoint = stopControlPoints[index - 1]
+        const spliceIndex = previousStopControlPoint.cpIndex + 1
+        const nextControlPoint = clonedControlPoints[spliceIndex]
+
+        // Previously, at this point we had created our control point by projecting the stop onto the existing shape.
+        // However, this created problems for insertions where the stop is geographically before the previous stop
+        // but is being inserted after it in the stop sequence. We were projecting previously bc to create a control point
+        // we need to know the distance along the shape, but to avoid the above issue we need to make a sub-request to graphhopper
+        // to get the segment between the two points and from that, the distance.
+        const insertPoint = stopToGeoJSONPoint(stop)
+        const newFromSegmentCoords = [
+          previousStopControlPoint.point.geometry.coordinates,
+          [stop.stop_lon, stop.stop_lat]
+        ]
+        const newFromSegment = await getSegment(newFromSegmentCoords, true)
+        const segmentDistance = lineDistance(newFromSegment, 'meters')
+        const addedControlPoint = newControlPoint(
+          previousStopControlPoint.distance + segmentDistance,
+          insertPoint,
+          {
+            stopId: stop.stop_id,
+            pointType: POINT_TYPE.STOP // 2
+          })
+        // Instead of splicing at the previousStopControlPoint, splice immediately after.
+        clonedControlPoints.splice(spliceIndex, 0, addedControlPoint)
+
+        // Replace n segments with 2 segments to be replaced
         // with new routed segments.
-        clonedControlPoints.splice(spliceIndex, 0, controlPoint)
-        const prev = clonedControlPoints[spliceIndex - 1]
-        const next = clonedControlPoints[spliceIndex + 1]
-        const segmentSpliceIndex = spliceIndex - 1
         clonedPatternSegments.splice(
-          segmentSpliceIndex,
+          previousStopControlPoint.cpIndex,
           1,
-          [prev.point.geometry.coordinates, insertPoint.geometry.coordinates],
-          [insertPoint.geometry.coordinates, next.point.geometry.coordinates]
+          [previousStopControlPoint.point.geometry.coordinates, insertPoint.geometry.coordinates],
+          [insertPoint.geometry.coordinates, nextControlPoint.point.geometry.coordinates]
         )
-        // console.log(`splicing control points at ${spliceIndex}. Replacing ${controlPointsToRemove}`, controlPoints, clonedControlPoints)
-        // console.log(`splicing segments at ${segmentSpliceIndex}. Replacing ${segmentsToRemove}`, patternSegments, clonedPatternSegments)
-        // Recalculate shape
         let result
+        // TODO: Because we are pre-generating the from segment above, we could use that in the final recalculated shape.
+        // Right now, bc of the legacy method we are repeating that small amount of work.
         try {
           result = await recalculateShape({
             avoidMotorways,

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -852,6 +852,16 @@ export function stopToPoint (stop: GtfsStop) {
   return point([stop.stop_lon, stop.stop_lat])
 }
 
+export function stopToGeoJSONPoint (stop: GtfsStop): GeoJsonPoint {
+  return {
+    geometry: {
+      coordinates: [stop.stop_lon, stop.stop_lat],
+      type: 'Point'
+    },
+    type: 'Feature'
+  }
+}
+
 /**
  * Generate control points from a list of pattern stops and pattern segments.
  *


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [x] Internationalize touched files


### Description

This one was a doozy. The old shapes generation method was incorrectly creating shapes when inserting stops between a segment: https://drive.google.com/file/d/1OTspw4hoiBdRmkoVu4bZPYQ6TF-Nv6H5/view?usp=sharing

The issue was that we were projecting the new stop onto the existing pattern, but this projection could result in an insertion point geographically **before** the previous stop, when the stop is being inserted **after** that stop. 

This PR addresses that issue, and avoid creating issues in this case when stops are inserted to the pattern.

New in this PR as well, we now preserve control points that exist _after_ the previous stop (the one before the insertion order point) so that any navigation that takes place in the new _to_ segment maintains those control points. Here is what the new method looks like: https://drive.google.com/file/d/1H5T-1l0AqGx-k2JBPFo1b2Gmtx1sjAbi/view?usp=share_link

*** complete with ascii art... let me know if that's a little bit much and I'll remove it

 
