### PR TITLE
Disable routes filter when no shapes available

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1132,6 +1132,7 @@ components:
     noEC2Instances: No EC2 instances associated with server.
   ShowAllRoutesOnMapFilter:
     fetching: Fetching
+    noShapes: The feed does not have any route shapes created yet.
     showAllRoutesOnMap: Show all routes
     tooManyShapeRecords: large shapes.txt may impact performance
   Sidebar:

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1160,7 +1160,7 @@ components:
     useELB: Elastic Load Balancer (ELB) verwenden?
   ShowAllRoutesOnMapFilter:
     fetching: Abruf läuft...
-    noShapes: Für den Feed wurden noch keine Routenformen erstellt.
+    noShapes: Für dieses Feed wurden noch keine Routenformen erstellt.
     showAllRoutesOnMap: Zeige alle Routen
     tooManyShapeRecords: große shapes.txt können Performance beeinträchtigen
   Sidebar:

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1160,6 +1160,7 @@ components:
     useELB: Elastic Load Balancer (ELB) verwenden?
   ShowAllRoutesOnMapFilter:
     fetching: Abruf läuft...
+    noShapes: Für den Feed wurden noch keine Routenformen erstellt.
     showAllRoutesOnMap: Zeige alle Routen
     tooManyShapeRecords: große shapes.txt können Performance beeinträchtigen
   Sidebar:

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1137,6 +1137,7 @@ components:
     useELB: Use Elastic Load Balancer (ELB)?
   ShowAllRoutesOnMapFilter:
     fetching: Fetching
+    noShapes: Karma nie ma jeszcze utworzonych żadnych kształtów tras.
     showAllRoutesOnMap: Show all routes
     tooManyShapeRecords: large shapes.txt may impact performance
   Sidebar:

--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -163,11 +163,16 @@ export function fetchGraphQL ({
     return dispatch(secureFetch(GTFS_GRAPHQL_PREFIX, 'post', body))
       .then(res => res.json())
       .then(json => {
+        const noShapesMessage = messages('errorNoShapes')
+        const errorsStringArray = graphQLErrorsToString(json.errors)
+        const detail = errorsStringArray.some(error => error.search(/relation (.*)(=?.shapes" does not exist)/) !== -1)
+          ? noShapesMessage
+          : errorsStringArray
         if (json.errors && json.errors.length) {
           dispatch(setErrorMessage({
             message: errorMessage || messages('errorGraphQL'),
             // action,
-            detail: graphQLErrorsToString(json.errors)
+            detail
           }))
         } else {
           return json.data

--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -163,16 +163,11 @@ export function fetchGraphQL ({
     return dispatch(secureFetch(GTFS_GRAPHQL_PREFIX, 'post', body))
       .then(res => res.json())
       .then(json => {
-        const noShapesMessage = messages('errorNoShapes')
-        const errorsStringArray = graphQLErrorsToString(json.errors)
-        const detail = errorsStringArray.some(error => error.search(/relation (.*)(=?.shapes" does not exist)/) !== -1)
-          ? noShapesMessage
-          : errorsStringArray
         if (json.errors && json.errors.length) {
           dispatch(setErrorMessage({
             message: errorMessage || messages('errorGraphQL'),
             // action,
-            detail
+            detail: graphQLErrorsToString(json.errors)
           }))
         } else {
           return json.data

--- a/lib/gtfs/components/ShowAllRoutesOnMapFilter.js
+++ b/lib/gtfs/components/ShowAllRoutesOnMapFilter.js
@@ -6,7 +6,6 @@ import {Checkbox} from 'react-bootstrap'
 
 import * as shapesActions from '../actions/shapes'
 import {getComponentMessages} from '../../common/util/config'
-
 import type {FetchStatus} from '../../types'
 import type {Props as ContainerProps} from '../containers/ShowAllRoutesOnMapFilter'
 
@@ -34,11 +33,13 @@ export default class ShowAllRoutesOnMapFilter extends Component<Props> {
     // performance might suffer (server should be fine). This is a somewhat
     // arbitrary limit. NL has over 4M shape records.
     const tooManyShapeRecords = version.feedLoadResult.shapes.rowCount > 1000000
+    const noShapes = version.feedLoadResult.shapes.rowCount === 0
     return (
       <Checkbox
         checked={showAllRoutesOnMap}
-        disabled={fetchStatus.fetching}
+        disabled={noShapes || fetchStatus.fetching}
         onChange={this.onChange}
+        title={noShapes && this.messages('noShapes')}
       >
         {fetchStatus.fetching
           ? <span className='text-muted'>

--- a/lib/gtfs/components/ShowAllRoutesOnMapFilter.js
+++ b/lib/gtfs/components/ShowAllRoutesOnMapFilter.js
@@ -39,7 +39,7 @@ export default class ShowAllRoutesOnMapFilter extends Component<Props> {
         checked={showAllRoutesOnMap}
         disabled={noShapes || fetchStatus.fetching}
         onChange={this.onChange}
-        title={noShapes && this.messages('noShapes')}
+        title={noShapes ? this.messages('noShapes') : ''}
       >
         {fetchStatus.fetching
           ? <span className='text-muted'>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

Previously, we would throw an error from the server if a user requested that the map show all routes for a feed without any shapes. This PR disables the `Show all routes` filter instead, and provides i18n'd tooltip text to explain. 
