### PR TITLE
Don't increment cumulativeTravelTime for an intra zonal segment

### DIFF
--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -219,7 +219,7 @@ export default class TimetableEditor extends Component<Props, State> {
           // $FlowFixMe Flow doesn't recognize our check for stopId property?
           cumulativeTravelTime += +halt.flexDefaultTravelTime
 
-          const haltId = getPatternHaltId(halt)
+          const haltId = getPatternHaltId(halt) // Handles check for Location vs. LocationGroup
           const nextHalt = i + 1 !== patternHalts.length ? patternHalts[i + 1] : null
 
           objectPath.set(newRow, `stopTimes.${i}.stopId`, haltId)

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -224,14 +224,17 @@ export default class TimetableEditor extends Component<Props, State> {
           const nextHalt = i + 1 !== patternHalts.length ? patternHalts[i + 1] : null
           let nextHaltId
           if (nextHalt) {
+            // $FlowFixMe Flow doesn't recognize our check for stopId property?
             nextHaltId = patternHaltIsLocation(nextHalt) ? nextHalt.locationId : nextHalt.locationGroupId
           }
 
           objectPath.set(newRow, `stopTimes.${i}.stopId`, haltId)
           objectPath.set(newRow, `stopTimes.${i}.startPickupDropoffWindow`, cumulativeTravelTime)
+          // $FlowFixMe Flow doesn't recognize our check for stopId property?
           objectPath.set(newRow, `stopTimes.${i}.endPickupDropoffWindow`, cumulativeTravelTime + halt.flexDefaultZoneTime)
 
           // We don't want to increment for intra-zonal travel times.
+          // $FlowFixMe Flow doesn't recognize our check for stopId property?
           if (!nextHaltId && haltId !== nextHaltId) cumulativeTravelTime += +halt.flexDefaultZoneTime
         }
         // }

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -19,7 +19,7 @@ import type {Feed, FetchStatus, Pattern, StopTime, TimetableColumn, Trip, TripCo
 import type {TripValidationIssues} from '../../selectors/timetable'
 import type {EditorTables, TimetableState} from '../../../types/reducers'
 import { mergePatternHaltsOfPattern } from '../../../gtfs/util'
-import { patternHaltIsLocation, patternHaltIsStop } from '../../util/location'
+import { getPatternHaltId, patternHaltIsLocation, patternHaltIsStop } from '../../util/location'
 
 import TimetableHelpModal from './TimetableHelpModal'
 import TimetableHeader from './TimetableHeader'
@@ -219,14 +219,8 @@ export default class TimetableEditor extends Component<Props, State> {
           // $FlowFixMe Flow doesn't recognize our check for stopId property?
           cumulativeTravelTime += +halt.flexDefaultTravelTime
 
-          // $FlowFixMe Flow doesn't recognize our check for stopId property?
-          const haltId = patternHaltIsLocation(halt) ? halt.locationId : halt.locationGroupId
+          const haltId = getPatternHaltId(halt)
           const nextHalt = i + 1 !== patternHalts.length ? patternHalts[i + 1] : null
-          let nextHaltId
-          if (nextHalt) {
-            // $FlowFixMe Flow doesn't recognize our check for stopId property?
-            nextHaltId = patternHaltIsLocation(nextHalt) ? nextHalt.locationId : nextHalt.locationGroupId
-          }
 
           objectPath.set(newRow, `stopTimes.${i}.stopId`, haltId)
           objectPath.set(newRow, `stopTimes.${i}.startPickupDropoffWindow`, cumulativeTravelTime)
@@ -235,7 +229,7 @@ export default class TimetableEditor extends Component<Props, State> {
 
           // We don't want to increment for intra-zonal travel times.
           // $FlowFixMe Flow doesn't recognize our check for stopId property?
-          if (!nextHaltId && haltId !== nextHaltId) cumulativeTravelTime += +halt.flexDefaultZoneTime
+          if (haltId !== getPatternHaltId(nextHalt)) cumulativeTravelTime += +halt.flexDefaultZoneTime
         }
         // }
         // if (stop.timepoint === null || stop.timepoint) {

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -220,11 +220,19 @@ export default class TimetableEditor extends Component<Props, State> {
           cumulativeTravelTime += +halt.flexDefaultTravelTime
 
           // $FlowFixMe Flow doesn't recognize our check for stopId property?
-          objectPath.set(newRow, `stopTimes.${i}.stopId`, patternHaltIsLocation(halt) ? halt.locationId : halt.locationGroupId)
+          const haltId = patternHaltIsLocation(halt) ? halt.locationId : halt.locationGroupId
+          const nextHalt = i + 1 !== patternHalts.length ? patternHalts[i + 1] : null
+          let nextHaltId
+          if (nextHalt) {
+            nextHaltId = patternHaltIsLocation(nextHalt) ? nextHalt.locationId : nextHalt.locationGroupId
+          }
+
+          objectPath.set(newRow, `stopTimes.${i}.stopId`, haltId)
           objectPath.set(newRow, `stopTimes.${i}.startPickupDropoffWindow`, cumulativeTravelTime)
-          // $FlowFixMe Flow doesn't recognize our check for stopId property?
-          cumulativeTravelTime += +halt.flexDefaultZoneTime
-          objectPath.set(newRow, `stopTimes.${i}.endPickupDropoffWindow`, cumulativeTravelTime)
+          objectPath.set(newRow, `stopTimes.${i}.endPickupDropoffWindow`, cumulativeTravelTime + halt.flexDefaultZoneTime)
+
+          // We don't want to increment for intra-zonal travel times.
+          if (!nextHaltId && haltId !== nextHaltId) cumulativeTravelTime += +halt.flexDefaultZoneTime
         }
         // }
         // if (stop.timepoint === null || stop.timepoint) {

--- a/lib/editor/util/location.js
+++ b/lib/editor/util/location.js
@@ -24,7 +24,7 @@ export const patternHaltIsLocation = (
   patternStopOrLocation.hasOwnProperty('locationId') && !patternStopOrLocation.hasOwnProperty('locationGroupId') ? patternStopOrLocation : undefined
 
 export const getPatternHaltId = (
-  patternHalt: PatternHalt
+  patternHalt: PatternHalt | null
 ): string | null => {
   if (!patternHalt) return null
   // $FlowFixMe Flow doesn't understand type check

--- a/lib/editor/util/location.js
+++ b/lib/editor/util/location.js
@@ -23,6 +23,16 @@ export const patternHaltIsLocation = (
   // $FlowFixMe Flow doesn't understand type check
   patternStopOrLocation.hasOwnProperty('locationId') && !patternStopOrLocation.hasOwnProperty('locationGroupId') ? patternStopOrLocation : undefined
 
+export const getPatternHaltId = (
+  patternHalt: PatternHalt
+): string | null => {
+  if (!patternHalt) return null
+  // $FlowFixMe Flow doesn't understand type check
+  if (patternHaltIsStop(patternHalt)) return patternHalt.stopId
+  // $FlowFixMe Flow doesn't understand type check
+  return patternHaltIsLocation(patternHalt) ? patternHalt.locationId : patternHalt.locationGroupId
+}
+
 export const patternHaltIsLocationGroup = (
   patternStopOrLocation: PatternHalt
 ): PatternLocationGroup =>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Intrazonal stop times segments should now be effectively duplicates. We avoid incrementing the cumulative travel time in this PR to make this the case. ✨
