### PR TITLE
Fix stop handle move bug

### DIFF
--- a/lib/editor/util/__tests__/__snapshots__/map.js.snap
+++ b/lib/editor/util/__tests__/__snapshots__/map.js.snap
@@ -887,16 +887,6 @@ Object {
         42.09798,
       ],
     ],
-    Array [
-      Array [
-        -77.92364,
-        42.09798,
-      ],
-      Array [
-        -77.92364,
-        42.09798,
-      ],
-    ],
   ],
   "dragId": undefined,
   "updatedControlPoints": Array [

--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -450,7 +450,10 @@ export async function recalculateShape ({
       // Only update previous segment if index is greater than zero
       updatedPatternCoordinates[index - 1] = beforeSlice.geometry.coordinates
     }
-    updatedPatternCoordinates[index] = afterSlice.geometry.coordinates
+    if (updatedPatternCoordinates[index]) {
+      // Only update post segment if it already exists.
+      updatedPatternCoordinates[index] = afterSlice.geometry.coordinates
+    }
     if (snapControlPointToNewSegment) {
       // Shape sequence offset for following points equals number of points in
       // new segment less the previous segment length.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Previously, when editing stop handles an additional small segment was created, which would interfere with other editing in the editing session because it through off the editSegment used by operations like constructControlPoint. This fix required updating the snapshots since the stop move snapshot included the bug. 
