### PR TITLE
Don't Create Location Shape Points on Map Drag

### DIFF
--- a/lib/editor/components/map/EditorMap.js
+++ b/lib/editor/components/map/EditorMap.js
@@ -125,12 +125,12 @@ export default class EditorMap extends Component<Props, State> {
 
     // From https://github.com/Leaflet/Leaflet.draw/issues/695#issuecomment-281663243
     // Prevents creating a new leaflet draw point on drag
-    var originalOnTouch = L.Draw.Polyline.prototype._onTouch;
-  	L.Draw.Polyline.prototype._onTouch = function (e) {
-      if (e.originalEvent.pointerType != "mouse") {
-        return originalOnTouch.call(this, e);
+    var originalOnTouch = L.Draw.Polyline.prototype._onTouch
+    L.Draw.Polyline.prototype._onTouch = function (e) {
+      if (e.originalEvent.pointerType !== 'mouse') {
+        return originalOnTouch.call(this, e)
       }
-   };
+    }
   }
 
   componentWillUnmount () {

--- a/lib/editor/components/map/EditorMap.js
+++ b/lib/editor/components/map/EditorMap.js
@@ -3,6 +3,7 @@
 import React, {Component} from 'react'
 import {Map, ZoomControl, FeatureGroup, GeoJSON} from 'react-leaflet'
 import {shallowEqual} from 'react-pure-render'
+import L from 'leaflet'
 
 import * as activeActions from '../../actions/active'
 import * as editorActions from '../../actions/editor'
@@ -121,6 +122,15 @@ export default class EditorMap extends Component<Props, State> {
   componentDidMount () {
     window.addEventListener('resize', this._onResize)
     this.setState({willMount: false})
+
+    // From https://github.com/Leaflet/Leaflet.draw/issues/695#issuecomment-281663243
+    // Prevents creating a new leaflet draw point on drag
+    var originalOnTouch = L.Draw.Polyline.prototype._onTouch;
+  	L.Draw.Polyline.prototype._onTouch = function (e) {
+      if (e.originalEvent.pointerType != "mouse") {
+        return originalOnTouch.call(this, e);
+      }
+   };
   }
 
   componentWillUnmount () {

--- a/lib/editor/components/map/EditorMap.js
+++ b/lib/editor/components/map/EditorMap.js
@@ -99,6 +99,15 @@ type State = {
   zoomToTarget: boolean
 }
 
+// From https://github.com/Leaflet/Leaflet.draw/issues/695#issuecomment-281663243
+// Prevents creating a new leaflet draw point on drag
+const originalOnTouch = L.Draw.Polyline.prototype._onTouch
+L.Draw.Polyline.prototype._onTouch = function (e) {
+  if (e.originalEvent.pointerType !== 'mouse') {
+    return originalOnTouch.call(this, e)
+  }
+}
+
 export default class EditorMap extends Component<Props, State> {
   state = {
     width: 200,
@@ -122,15 +131,6 @@ export default class EditorMap extends Component<Props, State> {
   componentDidMount () {
     window.addEventListener('resize', this._onResize)
     this.setState({willMount: false})
-
-    // From https://github.com/Leaflet/Leaflet.draw/issues/695#issuecomment-281663243
-    // Prevents creating a new leaflet draw point on drag
-    var originalOnTouch = L.Draw.Polyline.prototype._onTouch
-    L.Draw.Polyline.prototype._onTouch = function (e) {
-      if (e.originalEvent.pointerType !== 'mouse') {
-        return originalOnTouch.call(this, e)
-      }
-    }
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Leaflet draw has a bug where when dragging the map, it receives both a touch and a click event, causing the map to both pan while a new point is added to a location shape. This behavior is confusing for users. The solution is to disable the leaflet touch event handler when a touch device is not present.