### PR TITLE
Prior_Notice_Last_Time accept Time instead of Number

### DIFF
--- a/lib/editor/util/validation.js
+++ b/lib/editor/util/validation.js
@@ -252,6 +252,15 @@ export function validate (
       }
       return false
     case 'TIME':
+      const isValid = moment(value, 'HH:mm:ss', true).isValid()
+      if (isRequiredButEmpty) {
+        return emptyFieldValidationIssue()
+      } else if (!valueDoesNotExist && !isValid) {
+        return validationIssue('Field must be valid time')
+      } else {
+        return false
+      }
+
     case 'NUMBER':
       const isNotANumber = isNaN(value)
       if (isRequiredButEmpty) {

--- a/lib/types/reducers.js
+++ b/lib/types/reducers.js
@@ -129,7 +129,7 @@ export type EditorTables = {
     pickup_message: string,
     prior_notice_duration_max: number,
     prior_notice_duration_min: number,
-    prior_notice_last_time: number,
+    prior_notice_last_time: time,
     prior_notice_start_day: number,
     prior_notice_start_time: number
   }>,

--- a/lib/types/reducers.js
+++ b/lib/types/reducers.js
@@ -129,9 +129,9 @@ export type EditorTables = {
     pickup_message: string,
     prior_notice_duration_max: number,
     prior_notice_duration_min: number,
-    prior_notice_last_time: time,
+    prior_notice_last_time: Date,
     prior_notice_start_day: number,
-    prior_notice_start_time: number
+    prior_notice_start_time: Date
   }>,
   calendar: Array<{
     description: string,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

Updates validation to include a case for "Time", which allows `Prior_Notice_Last_Time` and `Prior_Notice_Start_Time` to accept `hh:mm:ss` instead of `number`. 

Depends on https://github.com/ibi-group/datatools-server/pull/530

