### PR TITLE
Add links to patterns for stop deletion

### DIFF
--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -145,7 +145,6 @@ function getErrorMessageFromJson (
           const [patternId, routeId] = pattern.split('-')
           return {patternId, routeId}
         })
-        // $FlowFixMe
         detail = <PatternLinkErrorMessage detail={detail} patterns={patterns} />
       }
     }

--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import fetch from 'isomorphic-fetch'
+import React from 'react'
 
 import {GTFS_GRAPHQL_PREFIX} from '../../common/constants'
 import {getComponentMessages} from '../../common/util/config'
@@ -131,12 +132,54 @@ function getErrorMessageFromJson (
     }
     // re-assign error message after it gets used in the detail.
     errorMessage = json.message || JSON.stringify(json)
+    if (json.detail && json.detail.includes('Referenced pattern IDs:')) {
+      // Custom formatting to link to pattern stops to remove if so desired.
+      // Pull the string of patternIds
+      const patternSplit = json.detail.split(/\[(.*?)\]/) // Match text within square brackets (our comma separated list of patternIds)
+      detail = patternSplit[0]
+      const patternsMatch = patternSplit[1]
+      if (patternsMatch) {
+        const patterns = patternsMatch.split(',')
+        // $FlowFixMe
+        detail = <PatternLinkErrorMessage detail={detail} patterns={patterns} />
+      }
+    }
     if (json.detail && json.detail.includes('conflicts with an existing trip id')) {
       action = 'DEFAULT'
     }
   }
-  console.error(errorMessage)
   return { action, detail, message: errorMessage }
+}
+
+const PatternLinkErrorMessage = (props) => {
+  const url = window.location.href
+  const basePath = url.split('edit/')[0] // Remove the current component from the URL
+  const {detail, patterns} = props
+
+  // Limit the list of patterns to 5 to not overwhelm users
+  const unDisplayedPatterns = patterns.length - 5
+  const limitedPatterns = patterns.slice(0, 5)
+
+  // $FlowFixMe
+  return <div>
+    {detail}
+    {limitedPatterns.map((pattern, index) => {
+      if (index > 5) return
+      // Pattern contains route and pattern data in format {pattern-route}
+      pattern = pattern.slice(1, -1) // Remove curly braces
+      const [patternId, routeId] = pattern.split('-')
+
+      const patternPath = `edit/route/${routeId}/trippattern/${patternId}`
+      return (
+        <li style={{listStyle: 'none'}}>
+          <a href={basePath + patternPath}>
+            {`Pattern ${patternId}`}
+          </a>
+        </li>
+      )
+    })}
+    {unDisplayedPatterns > 0 && `... and ${unDisplayedPatterns} other patterns`}
+  </div>
 }
 
 function graphQLErrorsToString (errors: Array<{locations: any, message: string}>): Array<string> {

--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -132,9 +132,9 @@ function getErrorMessageFromJson (
     }
     // re-assign error message after it gets used in the detail.
     errorMessage = json.message || JSON.stringify(json)
+    // This section (L135 - L146) is a hack to display links to patterns referenced by a stop to delete.
+    // This should be replaced with a better solution such as a new endpoint for this information.
     if (json.detail && json.detail.includes('Referenced pattern IDs:')) {
-      // Custom formatting to link to pattern stops to remove if so desired.
-      // Pull the string of patternIds
       const patternSplit = json.detail.split(/\[(.*?)\]/) // Match text within square brackets (our comma separated list of patternIds)
       detail = patternSplit[0]
       const patternsMatch = patternSplit[1]
@@ -148,37 +148,48 @@ function getErrorMessageFromJson (
       action = 'DEFAULT'
     }
   }
+  console.error(errorMessage)
   return { action, detail, message: errorMessage }
 }
 
+/*
+ * This component displays an error message with links to individual patterns that are
+ * used by the stop being deleted. Use of this component is a hack itself, so this should
+ * be removed when a better solution is put in place.
+ * For discussion see original PR: https://github.com/ibi-group/datatools-ui/pull/943
+ */
 const PatternLinkErrorMessage = (props) => {
   const url = window.location.href
   const basePath = url.split('edit/')[0] // Remove the current component from the URL
   const {detail, patterns} = props
-
-  // Limit the list of patterns to 5 to not overwhelm users
-  const unDisplayedPatterns = patterns.length - 5
-  const limitedPatterns = patterns.slice(0, 5)
-
   // $FlowFixMe
   return <div>
     {detail}
-    {limitedPatterns.map((pattern, index) => {
-      if (index > 5) return
-      // Pattern contains route and pattern data in format {pattern-route}
-      pattern = pattern.slice(1, -1) // Remove curly braces
-      const [patternId, routeId] = pattern.split('-')
-
-      const patternPath = `edit/route/${routeId}/trippattern/${patternId}`
-      return (
-        <li style={{listStyle: 'none'}}>
-          <a href={basePath + patternPath}>
-            {`Pattern ${patternId}`}
-          </a>
-        </li>
-      )
-    })}
-    {unDisplayedPatterns > 0 && `... and ${unDisplayedPatterns} other patterns`}
+    <ul style={{
+      background: 'aliceblue',
+      border: 'solid',
+      borderColor: 'lightgray',
+      borderRadius: '5px',
+      borderWidth: '2px',
+      maxHeight: '150px',
+      margin: '10px 0px',
+      overflow: 'auto',
+      padding: '5px 10px'
+    }}>
+      {patterns.map((pattern, index) => {
+        // Pattern contains route and pattern data in format {pattern-route}
+        pattern = pattern.slice(1, -1) // Remove curly braces
+        const [patternId, routeId] = pattern.split('-')
+        const patternPath = `edit/route/${routeId}/trippattern/${patternId}`
+        return (
+          <li style={{listStyle: 'none', margin: '3px 0px'}}>
+            <a href={basePath + patternPath}>
+              {`Route ${routeId}, Pattern ${patternId}`}
+            </a>
+          </li>
+        )
+      })}
+    </ul>
   </div>
 }
 

--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -135,7 +135,7 @@ function getErrorMessageFromJson (
     // TODO: REMOVE HACK
     // This section (L135 - L146) is a hack to display links to patterns referenced by a stop to delete.
     // This should be replaced with a better solution such as a new endpoint for this information.
-    if (json.detail && json.detail.includes('Referenced pattern IDs:')) {
+    if (json.detail && json.detail.includes('Referenced patterns:')) {
       const patternSplit = json.detail.split(/\[(.*?)\]/) // Match text within square brackets (our comma separated list of patternIds)
       detail = patternSplit[0]
       const patternsMatch = patternSplit[1]
@@ -163,8 +163,6 @@ function getErrorMessageFromJson (
  * For discussion see original PR: https://github.com/ibi-group/datatools-ui/pull/943
  */
 const PatternLinkErrorMessage = (props) => {
-  const url = window.location.href
-  const basePath = url.split('edit/')[0] // Remove the current component from the URL
   const {detail, patterns} = props
   // $FlowFixMe
   return <div>
@@ -181,10 +179,10 @@ const PatternLinkErrorMessage = (props) => {
       padding: '5px 10px'
     }}>
       {patterns.map((pattern, index) => {
-        const patternPath = `edit/route/${pattern.routeId}/trippattern/${pattern.patternId}`
+        const patternPath = `../edit/route/${pattern.routeId}/trippattern/${pattern.patternId}`
         return (
           <li style={{listStyle: 'none', margin: '3px 0px'}}>
-            <a href={basePath + patternPath}>
+            <a href={patternPath}>
               {`Route ${pattern.routeId}, Pattern ${pattern.patternId}`}
             </a>
           </li>

--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -132,6 +132,7 @@ function getErrorMessageFromJson (
     }
     // re-assign error message after it gets used in the detail.
     errorMessage = json.message || JSON.stringify(json)
+    // TODO: REMOVE HACK
     // This section (L135 - L146) is a hack to display links to patterns referenced by a stop to delete.
     // This should be replaced with a better solution such as a new endpoint for this information.
     if (json.detail && json.detail.includes('Referenced pattern IDs:')) {
@@ -139,7 +140,11 @@ function getErrorMessageFromJson (
       detail = patternSplit[0]
       const patternsMatch = patternSplit[1]
       if (patternsMatch) {
-        const patterns = patternsMatch.split(',')
+        const patterns = patternsMatch.split(',').map(pattern => {
+          pattern = pattern.slice(1, -1) // Remove curly braces
+          const [patternId, routeId] = pattern.split('-')
+          return {patternId, routeId}
+        })
         // $FlowFixMe
         detail = <PatternLinkErrorMessage detail={detail} patterns={patterns} />
       }
@@ -177,14 +182,11 @@ const PatternLinkErrorMessage = (props) => {
       padding: '5px 10px'
     }}>
       {patterns.map((pattern, index) => {
-        // Pattern contains route and pattern data in format {pattern-route}
-        pattern = pattern.slice(1, -1) // Remove curly braces
-        const [patternId, routeId] = pattern.split('-')
-        const patternPath = `edit/route/${routeId}/trippattern/${patternId}`
+        const patternPath = `edit/route/${pattern.routeId}/trippattern/${pattern.patternId}`
         return (
           <li style={{listStyle: 'none', margin: '3px 0px'}}>
             <a href={basePath + patternPath}>
-              {`Route ${routeId}, Pattern ${patternId}`}
+              {`Route ${pattern.routeId}, Pattern ${pattern.patternId}`}
             </a>
           </li>
         )


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Link a user to the pattern that uses a specific stop when trying to delete it for faster (and much more usable) deletion work flow
