### PR TITLE
update router config gui to support OTP2 router-config.json

### DIFF
--- a/__tests__/test-utils/mock-data/manager.js
+++ b/__tests__/test-utils/mock-data/manager.js
@@ -109,8 +109,8 @@ export const mockProject = {
   pinnedDeploymentId: null,
   peliasWebhookUrl: null,
   routerConfig: {
-    carDropoffTime: null,
-    numItineraries: null,
+    driveDistanceReluctance: null,
+    itineraryFilters: {nonTransitGeneralizedCostLimit: null},
     requestLogFile: null,
     stairsReluctance: null,
     updaters: null,

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -150,7 +150,7 @@ components:
       title: Router Config
       updaters:
         $index:
-          defaultAgencyId: Default agency ID
+          feedId: Feed ID
           frequencySec: Frequency (in seconds)
           sourceType: Source type
           type: Type
@@ -539,7 +539,7 @@ components:
       title: Router Config
       updaters:
         $index:
-          defaultAgencyId: Default agency ID
+          feedId: Feed ID
           frequencySec: Frequency (in seconds)
           sourceType: Source type
           type: Type
@@ -625,7 +625,7 @@ components:
         title: Router Config
         updaters:
           $index:
-            defaultAgencyId: Default agency ID
+            feedId: Feed ID
             frequencySec: Frequency (in seconds)
             sourceType: Source type
             type: Type
@@ -897,7 +897,7 @@ components:
         title: Router Config
         updaters:
           $index:
-            defaultAgencyId: Default agency ID
+            feedId: Feed ID
             frequencySec: Frequency (in seconds)
             sourceType: Source type
             type: Type

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -144,10 +144,13 @@ components:
     routerConfig:
       brandingUrlRoot: Branding URL Root
       carDropoffTime: Car Dropoff Time
+      driveDistanceReluctance: Drive Distance Reluctance
       numItineraries: '# of itineraries'
       requestLogFile: Request log file
       stairsReluctance: Stairs Reluctance
       title: Router Config
+      itineraryFilters:
+        nonTransitGeneralizedCostLimit: Non-Transit Generalized Cost Limit
       updaters:
         $index:
           feedId: Feed ID
@@ -533,10 +536,13 @@ components:
     routerConfig:
       brandingUrlRoot: Branding URL Root
       carDropoffTime: Car Dropoff Time
+      driveDistanceReluctance: Drive Distance Reluctance
       numItineraries: '# of itineraries'
       requestLogFile: Request log file
       stairsReluctance: Stairs Reluctance
       title: Router Config
+      itineraryFilters:
+        nonTransitGeneralizedCostLimit: Non-Transit Generalized Cost Limit
       updaters:
         $index:
           feedId: Feed ID
@@ -619,10 +625,13 @@ components:
       routerConfig:
         brandingUrlRoot: Branding URL Root
         carDropoffTime: Car Dropoff Time
+        driveDistanceReluctance: Drive Distance Reluctance
         numItineraries: '# of itineraries'
         requestLogFile: Request log file
         stairsReluctance: Stairs Reluctance
         title: Router Config
+        itineraryFilters:
+          nonTransitGeneralizedCostLimit: Non-Transit Generalized Cost Limit
         updaters:
           $index:
             feedId: Feed ID
@@ -891,10 +900,13 @@ components:
       routerConfig:
         brandingUrlRoot: Branding URL Root
         carDropoffTime: Car Dropoff Time
+        driveDistanceReluctance: Drive Distance Reluctance
         numItineraries: '# of itineraries'
         requestLogFile: Request log file
         stairsReluctance: Stairs Reluctance
         title: Router Config
+        itineraryFilters:
+          nonTransitGeneralizedCostLimit: Non-Transit Generalized Cost Limit
         updaters:
           $index:
             feedId: Feed ID

--- a/lib/manager/actions/__tests__/__snapshots__/projects.js.snap
+++ b/lib/manager/actions/__tests__/__snapshots__/projects.js.snap
@@ -89,8 +89,10 @@ Object {
       "peliasWebhookUrl": null,
       "pinnedDeploymentId": null,
       "routerConfig": Object {
-        "carDropoffTime": null,
-        "numItineraries": null,
+        "driveDistanceReluctance": null,
+        "itineraryFilters": Object {
+          "nonTransitGeneralizedCostLimit": null,
+        },
         "requestLogFile": null,
         "stairsReluctance": null,
         "updaters": null,

--- a/lib/manager/components/deployment/DeploymentSettings.js
+++ b/lib/manager/components/deployment/DeploymentSettings.js
@@ -110,7 +110,7 @@ class DeploymentSettings extends Component<Props, State> {
     const stateUpdate = {}
     set(stateUpdate,
       `routerConfig.updaters.$${this.state.routerConfig.updaters ? 'push' : 'set'}`,
-      [{type: '', url: '', frequencySec: 30, sourceType: '', defaultAgencyId: ''}]
+      [{type: '', url: '', frequencySec: 30, sourceType: '', feedId: ''}]
     )
     this.setState(update(this.state, stateUpdate))
   }

--- a/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
@@ -75,8 +75,10 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
           "peliasWebhookUrl": null,
           "pinnedDeploymentId": null,
           "routerConfig": Object {
-            "carDropoffTime": null,
-            "numItineraries": null,
+            "driveDistanceReluctance": null,
+            "itineraryFilters": Object {
+              "nonTransitGeneralizedCostLimit": null,
+            },
             "requestLogFile": null,
             "stairsReluctance": null,
             "updaters": null,
@@ -2024,8 +2026,10 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                           "peliasWebhookUrl": null,
                                                           "pinnedDeploymentId": null,
                                                           "routerConfig": Object {
-                                                            "carDropoffTime": null,
-                                                            "numItineraries": null,
+                                                            "driveDistanceReluctance": null,
+                                                            "itineraryFilters": Object {
+                                                              "nonTransitGeneralizedCostLimit": null,
+                                                            },
                                                             "requestLogFile": null,
                                                             "stairsReluctance": null,
                                                             "updaters": null,
@@ -2071,8 +2075,10 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                             "peliasWebhookUrl": null,
                                                             "pinnedDeploymentId": null,
                                                             "routerConfig": Object {
-                                                              "carDropoffTime": null,
-                                                              "numItineraries": null,
+                                                              "driveDistanceReluctance": null,
+                                                              "itineraryFilters": Object {
+                                                                "nonTransitGeneralizedCostLimit": null,
+                                                              },
                                                               "requestLogFile": null,
                                                               "stairsReluctance": null,
                                                               "updaters": null,
@@ -2208,8 +2214,10 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                                             "peliasWebhookUrl": null,
                                                                             "pinnedDeploymentId": null,
                                                                             "routerConfig": Object {
-                                                                              "carDropoffTime": null,
-                                                                              "numItineraries": null,
+                                                                              "driveDistanceReluctance": null,
+                                                                              "itineraryFilters": Object {
+                                                                                "nonTransitGeneralizedCostLimit": null,
+                                                                              },
                                                                               "requestLogFile": null,
                                                                               "stairsReluctance": null,
                                                                               "updaters": null,
@@ -2277,8 +2285,10 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                                               "peliasWebhookUrl": null,
                                                                               "pinnedDeploymentId": null,
                                                                               "routerConfig": Object {
-                                                                                "carDropoffTime": null,
-                                                                                "numItineraries": null,
+                                                                                "driveDistanceReluctance": null,
+                                                                                "itineraryFilters": Object {
+                                                                                  "nonTransitGeneralizedCostLimit": null,
+                                                                                },
                                                                                 "requestLogFile": null,
                                                                                 "stairsReluctance": null,
                                                                                 "updaters": null,
@@ -4205,8 +4215,10 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                           "peliasWebhookUrl": null,
                                                           "pinnedDeploymentId": null,
                                                           "routerConfig": Object {
-                                                            "carDropoffTime": null,
-                                                            "numItineraries": null,
+                                                            "driveDistanceReluctance": null,
+                                                            "itineraryFilters": Object {
+                                                              "nonTransitGeneralizedCostLimit": null,
+                                                            },
                                                             "requestLogFile": null,
                                                             "stairsReluctance": null,
                                                             "updaters": null,
@@ -4329,8 +4341,10 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                           "peliasWebhookUrl": null,
                                                           "pinnedDeploymentId": null,
                                                           "routerConfig": Object {
-                                                            "carDropoffTime": null,
-                                                            "numItineraries": null,
+                                                            "driveDistanceReluctance": null,
+                                                            "itineraryFilters": Object {
+                                                              "nonTransitGeneralizedCostLimit": null,
+                                                            },
                                                             "requestLogFile": null,
                                                             "stairsReluctance": null,
                                                             "updaters": null,
@@ -4412,8 +4426,10 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                           "peliasWebhookUrl": null,
                                                           "pinnedDeploymentId": null,
                                                           "routerConfig": Object {
-                                                            "carDropoffTime": null,
-                                                            "numItineraries": null,
+                                                            "driveDistanceReluctance": null,
+                                                            "itineraryFilters": Object {
+                                                              "nonTransitGeneralizedCostLimit": null,
+                                                            },
                                                             "requestLogFile": null,
                                                             "stairsReluctance": null,
                                                             "updaters": null,

--- a/lib/manager/containers/__tests__/__snapshots__/DeploymentsPanel.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/DeploymentsPanel.js.snap
@@ -236,8 +236,10 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
         "peliasWebhookUrl": null,
         "pinnedDeploymentId": "mock-deployment-id-0",
         "routerConfig": Object {
-          "carDropoffTime": null,
-          "numItineraries": null,
+          "driveDistanceReluctance": null,
+          "itineraryFilters": Object {
+            "nonTransitGeneralizedCostLimit": null,
+          },
           "requestLogFile": null,
           "stairsReluctance": null,
           "updaters": null,
@@ -473,8 +475,10 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
           "peliasWebhookUrl": null,
           "pinnedDeploymentId": "mock-deployment-id-0",
           "routerConfig": Object {
-            "carDropoffTime": null,
-            "numItineraries": null,
+            "driveDistanceReluctance": null,
+            "itineraryFilters": Object {
+              "nonTransitGeneralizedCostLimit": null,
+            },
             "requestLogFile": null,
             "stairsReluctance": null,
             "updaters": null,
@@ -932,8 +936,10 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                     "peliasWebhookUrl": null,
                     "pinnedDeploymentId": "mock-deployment-id-0",
                     "routerConfig": Object {
-                      "carDropoffTime": null,
-                      "numItineraries": null,
+                      "driveDistanceReluctance": null,
+                      "itineraryFilters": Object {
+                        "nonTransitGeneralizedCostLimit": null,
+                      },
                       "requestLogFile": null,
                       "stairsReluctance": null,
                       "updaters": null,
@@ -1415,8 +1421,10 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                   "peliasWebhookUrl": null,
                                   "pinnedDeploymentId": "mock-deployment-id-0",
                                   "routerConfig": Object {
-                                    "carDropoffTime": null,
-                                    "numItineraries": null,
+                                    "driveDistanceReluctance": null,
+                                    "itineraryFilters": Object {
+                                      "nonTransitGeneralizedCostLimit": null,
+                                    },
                                     "requestLogFile": null,
                                     "stairsReluctance": null,
                                     "updaters": null,
@@ -1824,8 +1832,10 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                   "peliasWebhookUrl": null,
                                   "pinnedDeploymentId": "mock-deployment-id-0",
                                   "routerConfig": Object {
-                                    "carDropoffTime": null,
-                                    "numItineraries": null,
+                                    "driveDistanceReluctance": null,
+                                    "itineraryFilters": Object {
+                                      "nonTransitGeneralizedCostLimit": null,
+                                    },
                                     "requestLogFile": null,
                                     "stairsReluctance": null,
                                     "updaters": null,

--- a/lib/manager/containers/__tests__/__snapshots__/FeedSourceTable.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/FeedSourceTable.js.snap
@@ -200,8 +200,10 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
         "peliasWebhookUrl": null,
         "pinnedDeploymentId": null,
         "routerConfig": Object {
-          "carDropoffTime": null,
-          "numItineraries": null,
+          "driveDistanceReluctance": null,
+          "itineraryFilters": Object {
+            "nonTransitGeneralizedCostLimit": null,
+          },
           "requestLogFile": null,
           "stairsReluctance": null,
           "updaters": null,
@@ -500,8 +502,10 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
           "peliasWebhookUrl": null,
           "pinnedDeploymentId": null,
           "routerConfig": Object {
-            "carDropoffTime": null,
-            "numItineraries": null,
+            "driveDistanceReluctance": null,
+            "itineraryFilters": Object {
+              "nonTransitGeneralizedCostLimit": null,
+            },
             "requestLogFile": null,
             "stairsReluctance": null,
             "updaters": null,
@@ -794,8 +798,10 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                           "peliasWebhookUrl": null,
                           "pinnedDeploymentId": null,
                           "routerConfig": Object {
-                            "carDropoffTime": null,
-                            "numItineraries": null,
+                            "driveDistanceReluctance": null,
+                            "itineraryFilters": Object {
+                              "nonTransitGeneralizedCostLimit": null,
+                            },
                             "requestLogFile": null,
                             "stairsReluctance": null,
                             "updaters": null,
@@ -1021,8 +1027,10 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                             "peliasWebhookUrl": null,
                             "pinnedDeploymentId": null,
                             "routerConfig": Object {
-                              "carDropoffTime": null,
-                              "numItineraries": null,
+                              "driveDistanceReluctance": null,
+                              "itineraryFilters": Object {
+                                "nonTransitGeneralizedCostLimit": null,
+                              },
                               "requestLogFile": null,
                               "stairsReluctance": null,
                               "updaters": null,
@@ -3147,8 +3155,10 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                           "peliasWebhookUrl": null,
                           "pinnedDeploymentId": null,
                           "routerConfig": Object {
-                            "carDropoffTime": null,
-                            "numItineraries": null,
+                            "driveDistanceReluctance": null,
+                            "itineraryFilters": Object {
+                              "nonTransitGeneralizedCostLimit": null,
+                            },
                             "requestLogFile": null,
                             "stairsReluctance": null,
                             "updaters": null,
@@ -3420,8 +3430,10 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                             "peliasWebhookUrl": null,
                             "pinnedDeploymentId": null,
                             "routerConfig": Object {
-                              "carDropoffTime": null,
-                              "numItineraries": null,
+                              "driveDistanceReluctance": null,
+                              "itineraryFilters": Object {
+                                "nonTransitGeneralizedCostLimit": null,
+                              },
                               "requestLogFile": null,
                               "stairsReluctance": null,
                               "updaters": null,
@@ -3746,8 +3758,10 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                   "peliasWebhookUrl": null,
                                   "pinnedDeploymentId": null,
                                   "routerConfig": Object {
-                                    "carDropoffTime": null,
-                                    "numItineraries": null,
+                                    "driveDistanceReluctance": null,
+                                    "itineraryFilters": Object {
+                                      "nonTransitGeneralizedCostLimit": null,
+                                    },
                                     "requestLogFile": null,
                                     "stairsReluctance": null,
                                     "updaters": null,
@@ -4146,8 +4160,10 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                                 "peliasWebhookUrl": null,
                                                 "pinnedDeploymentId": null,
                                                 "routerConfig": Object {
-                                                  "carDropoffTime": null,
-                                                  "numItineraries": null,
+                                                  "driveDistanceReluctance": null,
+                                                  "itineraryFilters": Object {
+                                                    "nonTransitGeneralizedCostLimit": null,
+                                                  },
                                                   "requestLogFile": null,
                                                   "stairsReluctance": null,
                                                   "updaters": null,
@@ -4564,8 +4580,10 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                   "peliasWebhookUrl": null,
                                   "pinnedDeploymentId": null,
                                   "routerConfig": Object {
-                                    "carDropoffTime": null,
-                                    "numItineraries": null,
+                                    "driveDistanceReluctance": null,
+                                    "itineraryFilters": Object {
+                                      "nonTransitGeneralizedCostLimit": null,
+                                    },
                                     "requestLogFile": null,
                                     "stairsReluctance": null,
                                     "updaters": null,

--- a/lib/manager/util/deployment.js
+++ b/lib/manager/util/deployment.js
@@ -34,15 +34,16 @@ export const FIELDS: Array<FormProps> = [
     placeholder: 'pdx',
     type: 'text',
     width: 12
-  }, {
-    name: 'routerConfig.driveDistanceReluctance',
-    type: 'number',
-    placeholder: '1.5'
-  }, {
-    name: 'routerConfig.stairsReluctance',
-    type: 'number',
-    placeholder: '2.0'
   },
+  // {
+  //   name: 'routerConfig.driveDistanceReluctance',
+  //   type: 'number',
+  //   placeholder: '1.5'
+  // }, {
+  //   name: 'routerConfig.stairsReluctance',
+  //   type: 'number',
+  //   placeholder: '2.0'
+  // },
   // {
   //   name: 'routerConfig.itineraryFilters.nonTransitGeneralizedCostLimit',
   //   type: 'text',

--- a/lib/manager/util/deployment.js
+++ b/lib/manager/util/deployment.js
@@ -43,11 +43,11 @@ export const FIELDS: Array<FormProps> = [
     type: 'number',
     placeholder: '2.0'
   },
-  {
-    name: 'routerConfig.itineraryFilters.nonTransitGeneralizedCostLimit',
-    type: 'text',
-    placeholder: '0 + 1.0x'
-  },
+  // {
+  //   name: 'routerConfig.itineraryFilters.nonTransitGeneralizedCostLimit',
+  //   type: 'text',
+  //   placeholder: '0 + 1.0x'
+  // },
   {
     name: 'routerConfig.requestLogFile',
     type: 'text',

--- a/lib/manager/util/deployment.js
+++ b/lib/manager/util/deployment.js
@@ -35,23 +35,20 @@ export const FIELDS: Array<FormProps> = [
     type: 'text',
     width: 12
   }, {
-    name: 'routerConfig.numItineraries',
+    name: 'routerConfig.driveDistanceReluctance',
     type: 'number',
-    step: '1', // integer
-    placeholder: '6'
-  }, {
-    name: 'routerConfig.walkSpeed',
-    type: 'number',
-    placeholder: '3.0'
+    placeholder: '1.5'
   }, {
     name: 'routerConfig.stairsReluctance',
     type: 'number',
     placeholder: '2.0'
-  }, {
-    name: 'routerConfig.carDropoffTime',
-    type: 'number',
-    placeholder: '240 (sec)'
-  }, {
+  },
+  {
+    name: 'routerConfig.itineraryFilters.nonTransitGeneralizedCostLimit',
+    type: 'text',
+    placeholder: '0 + 1.0x'
+  },
+  {
     name: 'routerConfig.requestLogFile',
     type: 'text',
     placeholder: '/var/otp/request.log',
@@ -66,11 +63,13 @@ export const UPDATER_FIELDS: Array<FormProps> = [
     componentClass: 'select',
     children: [
       {disabled: true, value: '', children: '[select value]'},
+      {value: 'real-time-alerts', children: 'real-time-alerts'},
+      {value: 'stop-time-updater', children: 'stop-time-updater'},
+      {value: 'vehicle-positions', children: 'vehicle-positions'},
+      {value: 'vehicle-rental', children: 'vehicle-rental'},
       {value: 'bike-rental', children: 'bike-rental'},
       {value: 'bike-park', children: 'bike-park'},
-      {value: 'stop-time-updater', children: 'stop-time-updater'},
       {value: 'websocket-gtfs-rt-updater', children: 'websocket-gtfs-rt-updater'},
-      {value: 'real-time-alerts', children: 'real-time-alerts'},
       {value: 'example-updater', children: 'example-updater'},
       {value: 'example-polling-updater', children: 'example-polling-updater'},
       {value: 'winkki-polling-updater', children: 'winkki-polling-updater'},
@@ -88,7 +87,8 @@ export const UPDATER_FIELDS: Array<FormProps> = [
     type: 'select',
     componentClass: 'select',
     children: [
-      {value: '', children: '[optional]'},
+      {value: 'gtfs-http', children: 'gtfs-http'},
+      {value: 'gbfs', children: 'gbfs'},
       {value: 'jcdecaux', children: 'jcdecaux'},
       {value: 'b-cycle', children: 'b-cycle'},
       {value: 'bixi', children: 'bixi'},
@@ -102,17 +102,15 @@ export const UPDATER_FIELDS: Array<FormProps> = [
       {value: 'sf-bay-area', children: 'sf-bay-area'},
       {value: 'share-bike', children: 'share-bike'},
       {value: 'kml-placemarks', children: 'kml-placemarks'},
-      {value: 'gbfs', children: 'gbfs'},
-      {value: 'gtfs-file', children: 'gtfs-file'},
-      {value: 'gtfs-http', children: 'gtfs-http'}
+      {value: 'gtfs-file', children: 'gtfs-file'}
     ]
   }, {
     name: 'routerConfig.updaters.$index.url',
     placeholder: 'https://agency.com/realtime/tripupdates',
     type: 'text'
   }, {
-    name: 'routerConfig.updaters.$index.defaultAgencyId',
-    placeholder: 'TriMet',
+    name: 'routerConfig.updaters.$index.feedId',
+    placeholder: '[optional]',
     type: 'text'
   }
 ]

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -789,8 +789,8 @@ export type BuildConfig = {
 }
 
 export type RouterConfig = {
-  carDropoffTime?: ?any, // TODO: define more specific type
-  numItineraries?: ?any, // TODO: define more specific type
+  driveDistanceReluctance?: ?any, // TODO: define more specific type
+  itineraryFilters?: ?any, // TODO: define more specific type
   requestLogFile?: ?any, // TODO: define more specific type
   stairsReluctance?: ?any, // TODO: define more specific type
   updaters?: ?any, // TODO: define more specific type


### PR DESCRIPTION
### Checklist

- [X] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Datatools has a cool router-config gui. Unfortunately, it was unusable because it didn't support any OTP2 parameters. Given that it's entirely out of use at the moment, this PR permanently shifts it to use OTP2 parameters instead. The exposed parameters do not cover every case, but they do cover most of them.

Needs https://github.com/ibi-group/datatools-server/pull/533