### PR TITLE
Update valhalla.js Graphhopper to V7

### DIFF
--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -11,6 +11,8 @@ SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key
 # Optional override to use a custom service instead of the graphhopper.com hosted service.
 # GRAPH_HOPPER_URL: http://localhost:8989/
+# If your'e hosting a version 7 graphhopper instance set this to yes, default is No
+# GRAPH_HOPPER_V7: Yes
 # Optional overrides to use custom service or different api key for certain bounding boxes.
 # (uncomment below to enable)
 # GRAPH_HOPPER_ALTERNATES:

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -11,8 +11,8 @@ SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key
 # Optional override to use a custom service instead of the graphhopper.com hosted service.
 # GRAPH_HOPPER_URL: http://localhost:8989/
-# If your'e hosting a version 7 graphhopper instance set this to yes, default is No
-# GRAPH_HOPPER_V7: Yes
+# If your'e hosting a version 7 graphhopper instance set this to yes, default is false or not configured
+# GRAPH_HOPPER_V7: true
 # Optional overrides to use custom service or different api key for certain bounding boxes.
 # (uncomment below to enable)
 # GRAPH_HOPPER_ALTERNATES:

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -257,12 +257,12 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   }
 
   // Version 7 of the graphhopper api uses profile instead of vehicle.
-  let profilecar = boolean(false)
-  let profileveh = boolean(true)
+  let profilecar = Boolean(false)
+  let profileveh = Boolean(true)
   // Only check for definition not the value.
   if (process.env.GRAPH_HOPPER_V7) {
-    profilecar = boolean(true)
-    profileveh = boolean(false)
+    profilecar = Boolean(true)
+    profileveh = Boolean(false)
   }
   const params = {
     key: graphHopperKey,

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -257,12 +257,12 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   }
 
   // Version 7 of the graphhopper api uses profile instead of vehicle.
-  let profilecar = false
-  let profileveh = true
+  let profilecar = boolean(false)
+  let profileveh = boolean(true)
   // Only check for definition not the value.
   if (process.env.GRAPH_HOPPER_V7) {
-    profilecar = true
-    profileveh = false
+    profilecar = boolean(true)
+    profileveh = boolean(false)
   }
   const params = {
     key: graphHopperKey,

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -269,14 +269,14 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     // Custom model disincentives motorways
     custom_model: {
       'priority': [{
-         'if': 'road_class == MOTORWAY',
-         'multiply_by': 0.1
-        }]
-      },
-      debug: params.debug,
-      points: points.map(p => [p.lng, p.lat])  
+        'if': 'road_class == MOTORWAY',
+        'multiply_by': 0.1
+      }]
+    },
+    debug: params.debug,
+    points: points.map(p => [p.lng, p.lat])
   }
-  
+
   // Version 7 of the graphhopper api will not allow the inclusion of the old vehicle parameter, it needs the profile paramater set.
   if (process.env.GRAPH_HOPPER_V7) {
     params['profile'] = 'car'

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -257,12 +257,12 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   }
 
   // Version 7 of the graphhopper api uses profile instead of vehicle.
-  let profilecar = false;
-  let profileveh = true;
+  let profilecar = 0
+  let profileveh = 1
   // Only check for definition not the value.
   if (process.env.GRAPH_HOPPER_V7) {
-    profilecar = true;
-    profileveh = false;
+    profilecar = 1
+    profileveh = 0
   }
   const params = {
     key: graphHopperKey,

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -261,7 +261,6 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     debug: true,
     type: 'json'
   }
-  
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   // Avoiding motorways requires a POST request with a formatted body
   const avoidmotorwaysbody = {

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -281,8 +281,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   if (process.env.GRAPH_HOPPER_V7) {
     params['profile'] = 'car'
     avoidmotorwaysbody['profile'] = 'car'
-  }
-  else {
+  } else {
     params['vehicle'] = 'car'
     avoidmotorwaysbody['vehicle'] = 'car'
   }

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -280,8 +280,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     points: points.map(p => [p.lng, p.lat]),
     ...(process.env.GRAPH_HOPPER_V7 && { profile: 'car' }),
     ...(!process.env.GRAPH_HOPPER_V7 && { vehicle: 'car' })
-  }
-  
+  }  
   const graphHopperRequest = avoidMotorways
     ? fetch(`${graphHopperUrl}route?key=${params.key}`,
       {

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -219,6 +219,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   // Use custom url if it exists, otherwise default to the hosted service.
   let graphHopperUrl = process.env.GRAPH_HOPPER_URL || 'https://graphhopper.com/api/1/'
   let graphHopperKey = process.env.GRAPH_HOPPER_KEY
+  let grapghhoperV7 = process.env.GRAPH_HOPPER_V7 || false
 
   if (process.env.GRAPH_HOPPER_ALTERNATES) {
     // $FlowFixMe This is a bit of a hack and now how env variables are supposed to work, but the yaml loader supports it.
@@ -262,8 +263,8 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     key: graphHopperKey,
     debug: true,
     type: 'json',
-    ...(process.env.GRAPH_HOPPER_V7 && { profile: 'car' }),
-    ...(!process.env.GRAPH_HOPPER_V7 && { vehicle: 'car' })
+    ...(grapghhoperV7 && { profile: 'car' }),
+    ...(!grapghhoperV7 && { vehicle: 'car' })
   }
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   // Avoiding motorways requires a POST request with a formatted body
@@ -278,8 +279,8 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     },
     debug: params.debug,
     points: points.map(p => [p.lng, p.lat]),
-    ...(process.env.GRAPH_HOPPER_V7 && { profile: 'car' }),
-    ...(!process.env.GRAPH_HOPPER_V7 && { vehicle: 'car' })
+    ...(grapghhoperV7 && { profile: 'car' }),
+    ...(!grapghhoperV7 && { vehicle: 'car' })
   }
   const graphHopperRequest = avoidMotorways
     ? fetch(`${graphHopperUrl}route?key=${params.key}`,

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -257,12 +257,12 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   }
 
   // Version 7 of the graphhopper api uses profile instead of vehicle.
-  let profilecar = 0
-  let profileveh = 1
+  let profilecar = false
+  let profileveh = true
   // Only check for definition not the value.
   if (process.env.GRAPH_HOPPER_V7) {
-    profilecar = 1
-    profileveh = 0
+    profilecar = true
+    profileveh = false
   }
   const params = {
     key: graphHopperKey,

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -219,7 +219,6 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   // Use custom url if it exists, otherwise default to the hosted service.
   let graphHopperUrl = process.env.GRAPH_HOPPER_URL || 'https://graphhopper.com/api/1/'
   let graphHopperKey = process.env.GRAPH_HOPPER_KEY
-  let grapghhoperV7 = process.env.GRAPH_HOPPER_V7 || false
 
   if (process.env.GRAPH_HOPPER_ALTERNATES) {
     // $FlowFixMe This is a bit of a hack and now how env variables are supposed to work, but the yaml loader supports it.
@@ -258,13 +257,19 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   }
 
   // Version 7 of the graphhopper api uses profile instead of vehicle.
-
+  let profilecar = false
+  let profileveh = true
+  // Only check for definition not the value.
+  if (process.env.GRAPH_HOPPER_V7) {
+    profilecar = true
+    profileveh = false
+  }
   const params = {
     key: graphHopperKey,
     debug: true,
     type: 'json',
-    ...(grapghhoperV7 && { profile: 'car' }),
-    ...(!grapghhoperV7 && { vehicle: 'car' })
+    ...(profilecar && { profile: 'car' }),
+    ...(profileveh && { vehicle: 'car' })
   }
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   // Avoiding motorways requires a POST request with a formatted body
@@ -279,8 +284,8 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     },
     debug: params.debug,
     points: points.map(p => [p.lng, p.lat]),
-    ...(grapghhoperV7 && { profile: 'car' }),
-    ...(!grapghhoperV7 && { vehicle: 'car' })
+    ...(profilecar && { profile: 'car' }),
+    ...(profileveh && { vehicle: 'car' })
   }
   const graphHopperRequest = avoidMotorways
     ? fetch(`${graphHopperUrl}route?key=${params.key}`,

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -257,7 +257,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
 
   const params = {
     key: graphHopperKey,
-    vehicle: 'car',
+    profile: 'car',
     debug: true,
     type: 'json'
   }
@@ -277,7 +277,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
           },
           debug: params.debug,
           points: points.map(p => [p.lng, p.lat]),
-          profile: params.vehicle
+          profile: params.profile
         }),
         headers: {
           'Content-Type': 'application/json'

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -261,7 +261,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   const params = {
     key: graphHopperKey,
     debug: true,
-    type: 'json'
+    type: 'json',
     ...(process.env.GRAPH_HOPPER_V7 && { profile: 'car' }),
     ...(!process.env.GRAPH_HOPPER_V7 && { vehicle: 'car' })
   }

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -256,10 +256,14 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     })
   }
 
+  // Version 7 of the graphhopper api uses profile instead of vehicle.
+
   const params = {
     key: graphHopperKey,
     debug: true,
     type: 'json'
+    ...(process.env.GRAPH_HOPPER_V7 && { profile: 'car' }),
+    ...(!process.env.GRAPH_HOPPER_V7 && { vehicle: 'car' })
   }
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   // Avoiding motorways requires a POST request with a formatted body
@@ -273,18 +277,11 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
       }]
     },
     debug: params.debug,
-    points: points.map(p => [p.lng, p.lat])
+    points: points.map(p => [p.lng, p.lat]),
+    ...(process.env.GRAPH_HOPPER_V7 && { profile: 'car' }),
+    ...(!process.env.GRAPH_HOPPER_V7 && { vehicle: 'car' })
   }
-
-  // Version 7 of the graphhopper api will not allow the inclusion of the old vehicle parameter, it needs the profile paramater set.
-  if (process.env.GRAPH_HOPPER_V7) {
-    params['profile'] = 'car'
-    avoidmotorwaysbody['profile'] = 'car'
-  } else {
-    params['vehicle'] = 'car'
-    avoidmotorwaysbody['vehicle'] = 'car'
-  }
-
+  
   const graphHopperRequest = avoidMotorways
     ? fetch(`${graphHopperUrl}route?key=${params.key}`,
       {

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -204,7 +204,8 @@ export async function getSegment (
 /**
  * Call GraphHopper routing service with lat/lng coordinates.
  *
- * Example URL: https://graphhopper.com/api/1/route?point=49.932707,11.588051&point=50.3404,11.64705&vehicle=car&debug=true&&type=json
+ * Example URL V5/6: https://graphhopper.com/api/1/route?point=49.932707,11.588051&point=50.3404,11.64705&vehicle=car&debug=true&type=json
+ * Example URL V7: https://graphhopper.com/api/1/route?point=49.932707,11.588051&point=50.3404,11.64705&profile=car&debug=true&type=json
  */
 export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: boolean): ?Promise<GraphHopperResponse> {
   if (points.length < 2) {
@@ -256,17 +257,14 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   }
 
   const params = {
-    key: graphHopperKey,
-    profile: 'car',
+    key: graphHopperKey,    
     debug: true,
     type: 'json'
-  }
+  } 
+  
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   // Avoiding motorways requires a POST request with a formatted body
-  const graphHopperRequest = avoidMotorways
-    ? fetch(`${graphHopperUrl}route?key=${params.key}`,
-      {
-        body: JSON.stringify({
+  const avoidmotorwaysbody = {
           'ch.disable': true,
           // Custom model disincentives motorways
           custom_model: {
@@ -276,9 +274,23 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
             }]
           },
           debug: params.debug,
-          points: points.map(p => [p.lng, p.lat]),
-          profile: params.profile
-        }),
+          points: points.map(p => [p.lng, p.lat])          
+        }
+  
+  // Version 7 of the graphhopper api will not allow the inclusion of the old vehicle parameter, it needs the profile paramater set.
+  if (process.env.GRAPH_HOPPER_V7) {
+    params['profile'] = 'car'
+    avoidmotorwaysbody['profile'] = 'car'
+  }
+  else {
+    params['vehicle'] = 'car'
+    avoidmotorwaysbody['vehicle'] = 'car'
+  }
+  
+  const graphHopperRequest = avoidMotorways
+    ? fetch(`${graphHopperUrl}route?key=${params.key}`,
+      {
+        body: JSON.stringify(avoidmotorwaysbody),
         headers: {
           'Content-Type': 'application/json'
         },

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -257,25 +257,25 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   }
 
   const params = {
-    key: graphHopperKey,    
+    key: graphHopperKey,
     debug: true,
     type: 'json'
-  } 
+  }
   
   const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
   // Avoiding motorways requires a POST request with a formatted body
   const avoidmotorwaysbody = {
-          'ch.disable': true,
-          // Custom model disincentives motorways
-          custom_model: {
-            'priority': [{
-              'if': 'road_class == MOTORWAY',
-              'multiply_by': 0.1
-            }]
-          },
-          debug: params.debug,
-          points: points.map(p => [p.lng, p.lat])          
-        }
+    'ch.disable': true,
+    // Custom model disincentives motorways
+    custom_model: {
+      'priority': [{
+         'if': 'road_class == MOTORWAY',
+         'multiply_by': 0.1
+        }]
+      },
+      debug: params.debug,
+      points: points.map(p => [p.lng, p.lat])  
+  }
   
   // Version 7 of the graphhopper api will not allow the inclusion of the old vehicle parameter, it needs the profile paramater set.
   if (process.env.GRAPH_HOPPER_V7) {
@@ -286,7 +286,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     params['vehicle'] = 'car'
     avoidmotorwaysbody['vehicle'] = 'car'
   }
-  
+
   const graphHopperRequest = avoidMotorways
     ? fetch(`${graphHopperUrl}route?key=${params.key}`,
       {

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -257,12 +257,12 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
   }
 
   // Version 7 of the graphhopper api uses profile instead of vehicle.
-  let profilecar = Boolean(false)
-  let profileveh = Boolean(true)
+  let profilecar = false;
+  let profileveh = true;
   // Only check for definition not the value.
   if (process.env.GRAPH_HOPPER_V7) {
-    profilecar = Boolean(true)
-    profileveh = Boolean(false)
+    profilecar = true;
+    profileveh = false;
   }
   const params = {
     key: graphHopperKey,

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -280,7 +280,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     points: points.map(p => [p.lng, p.lat]),
     ...(process.env.GRAPH_HOPPER_V7 && { profile: 'car' }),
     ...(!process.env.GRAPH_HOPPER_V7 && { vehicle: 'car' })
-  }  
+  }
   const graphHopperRequest = avoidMotorways
     ? fetch(`${graphHopperUrl}route?key=${params.key}`,
       {


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

Version 7 of graphhopper api no longer supported vehicle, you have to use profile paramter instead. 

See: https://github.com/graphhopper/graphhopper/blob/master/CHANGELOG.md