### PR TITLE
Update shape_dist_traveled after stop removal

### DIFF
--- a/lib/editor/actions/map/index.js
+++ b/lib/editor/actions/map/index.js
@@ -251,6 +251,7 @@ export function removeControlPoint (controlPoints: Array<ControlPoint>, index: n
     const {
       coordinates,
       updatedControlPoints
+    // $FlowFixMe: Flow does not recognize patterns within returned Promise type
     } = await recalculateShape({
       avoidMotorways,
       controlPoints,

--- a/lib/editor/actions/map/index.js
+++ b/lib/editor/actions/map/index.js
@@ -10,8 +10,9 @@ import lineString from 'turf-linestring'
 import nearestPointOnLine from '@turf/nearest-point-on-line'
 import point from 'turf-point'
 
+import {updatePatternStops, setActivePatternSegment} from '../tripPattern'
+import {saveActiveGtfsEntity} from '../active'
 import {POINT_TYPE} from '../../constants'
-import {setActivePatternSegment} from '../tripPattern'
 import {setErrorMessage} from '../../../manager/actions/status'
 import {
   getLineSlices,
@@ -21,6 +22,8 @@ import {
 } from '../../util/map'
 import type {Feed, LatLng, Pattern, ControlPoint} from '../../../types'
 import type {dispatchFn, getStateFn} from '../../../types/reducers'
+
+import {updateShapeDistTraveled} from './stopStrategies'
 
 export const controlPointDragOrEnd = createAction(
   'CONTROL_POINT_DRAG_START_OR_END',
@@ -256,10 +259,18 @@ export function removeControlPoint (controlPoints: Array<ControlPoint>, index: n
       followStreets,
       patternCoordinates
     })
+
+    // Update the shape_dist_traveled values to reflect the new pattern that the bus follows
+    updateShapeDistTraveled(updatedControlPoints, coordinates, pattern.patternStops)
+
     // Update active pattern in store (does not save to server).
     dispatch(updatePatternGeometry({
       controlPoints: updatedControlPoints,
       patternSegments: coordinates
     }))
+
+    // Ensure that all updates are reflected in exports.
+    dispatch(updatePatternStops(pattern, pattern.patternStops))
+    dispatch(saveActiveGtfsEntity('trippattern'))
   }
 }

--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -595,7 +595,7 @@ const generateSegmentAndInsert = async (segments: Array<Coordinates>, fromPoint:
  * These values must also be updated in the patternStops which will be used to create the shapeDistTraveled
  * values in stop_times.txt
  */
-const updateShapeDistTraveled = (controlPoints: Array<ControlPoint | null>, segments: Array<Coordinate>, patternStops: Array<PatternStop>): void => {
+export const updateShapeDistTraveled = (controlPoints: Array<ControlPoint | null>, segments: Array<Coordinate>, patternStops: Array<PatternStop>): void => {
   // $FlowFixMe
   const stopControlPoints = getControlPointsForStops(controlPoints)
 

--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -532,6 +532,7 @@ export function removeStopFromPattern (pattern: Pattern, stop: GtfsStop, index: 
       const {avoidMotorways, followStreets} = getState().editor.editSettings.present
       let result
       try {
+        // $FlowFixMe: Flow does not recognize controlpoints within returned Promise type
         result = await recalculateShape({
           avoidMotorways,
           controlPoints: clonedControlPoints,

--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -527,6 +527,7 @@ export function removeStopFromPattern (pattern: Pattern, stop: GtfsStop, index: 
     if (!shapePoints || shapePoints.length === 0) {
       // If pattern has no shape points, don't attempt to refactor pattern shape
       console.log('pattern coordinates do not exist')
+      patternStops.splice(index, 1)
     } else {
       const {avoidMotorways, followStreets} = getState().editor.editSettings.present
       let result
@@ -550,14 +551,16 @@ export function removeStopFromPattern (pattern: Pattern, stop: GtfsStop, index: 
         dispatch(setErrorMessage({message: `Could not remove stop from pattern:`}))
         return
       }
+      patternStops.splice(index, 1)
+      // Update the shape_dist_traveled values if we're removing the first stop (no control point will be left in this case)
+      if (index === 0) updateShapeDistTraveled(result.updatedControlPoints, result.coordinates, patternStops)
+
       // Update pattern geometry
       dispatch(updatePatternGeometry({
         controlPoints: result.updatedControlPoints,
         patternSegments: result.coordinates
       }))
     }
-    // Update pattern stops (whether or not geometry exists)
-    patternStops.splice(index, 1)
     dispatch(updatePatternStops(pattern, patternStops))
     dispatch(saveActiveGtfsEntity('trippattern'))
   }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Fix #941 Previously, when a stop was removed from a pattern, the relevant shape_dist_traveled values were not updated. This PR adjusts the removal process to update all shape_dist_traveled values and save the activeGTFSEntity after update, so that change are reflected in an immediate export. 
