### PR TITLE
Add custom file and preserve fields transformations

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -7,6 +7,10 @@ components:
     errorWithStatus: Error (%status%) making %method% request to %url%
     networkError: Network error (%status%)!\n\n(%method% request on %url%)
     noFile: No file to upload!
+  AddCustomFile: 
+    addCustomCsvData: Add the custom CSV data.
+    customFileName: Custom file name
+    saveCsvAndFileName: Save CSV and file name
   AdminPage:
     applicationLogs: Application logs
     backToDashboard: Back to dashboard
@@ -91,12 +95,7 @@ components:
     ok: OK
     title: Create a new snapshot
   CustomCSVForm:
-    addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
-    addCsvWithCustomFields: "Add the CSV data with custom fields to preserve in the final output."
-    addCustomCsvData: Add the custom CSV data.
     numLines: "%numLines% lines."
-    saveCsv: Save CSV
-    saveCsvAndFileName: Save CSV and file name
   DatatoolsNavbar:
     account: My Account
     alerts: Alerts
@@ -876,6 +875,9 @@ components:
     edit-alert: Edit GTFS-RT Alerts
     edit-gtfs: Edit GTFS Feeds
     manage-feed: Manage Feed Configuration
+  PreserveCustomFields: 
+    addCsvWithCustomFields: "Add the CSV data with custom fields to preserve in the final output."
+    saveCsv: Save CSV
   ProjectAccessSettings:
     admin: Admin
     cannotFetchFeeds: Cannot fetch feeds
@@ -1131,6 +1133,9 @@ components:
     viewDashboard: View dashboard
   RegionSearch:
     placeholder: Search for regions or agencies
+  ReplaceFileFromString:
+    addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
+    saveCsv: Save CSV
   ResultTable:
     affectedIds: Affected ID(s)
     description: Description

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -488,6 +488,10 @@ components:
       filePlaceholder: Choose the file/table to replace
       label: Replace %tablePlaceholder% from %versionPlaceholder%
       name: Replace file from version transformation
+  FeedTransformationErrors: 
+    csvMissingName: Custom CSV must have a name.
+    undefinedCSVData: CSV data must be defined.
+    undefinedTable: Table must be defined
   FeedVersionNavigator:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
     confirmLoad: 'This will override all active GTFS Editor data for this Feed Source with the data from this version. If there is unsaved work in the Editor you want to keep, you must snapshot the current Editor data first. Are you sure you want to continue?'

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -90,6 +90,12 @@ components:
     missingNameAlert: Must give snapshot a valid name!
     ok: OK
     title: Create a new snapshot
+  CustomCSVForm:
+    addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
+    addCustomCsvData: Add the custom CSV data.
+    numLines: "%numLines% lines."
+    saveCsv: Save CSV
+    saveCsvAndFileName: Save CSV and file name
   DatatoolsNavbar:
     account: My Account
     alerts: Alerts
@@ -453,6 +459,9 @@ components:
     properties: properties
     warning: Warning!
   FeedTransformationDescriptions:
+    AddCustomFileTransformation: 
+      label: Add custom file in GTFS.
+      name: Add custom file transformation
     general:
       fileDefined: below text
       filePlaceholder: '[choose file]'

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -467,6 +467,10 @@ components:
       filePlaceholder: Choose file/table to normalize
       label: Normalize field
       name: Normalize field transformation
+    PreserveCustomFieldsTransformation:
+      filePlaceholder: Choose the file/table with custom field
+      label: Preserve fields in %tablePlaceholder% from %filePlaceholder%
+      name: Preserve custom fields transformation
     ReplaceFileFromStringTransformation:
       filePlaceholder: Choose the file/table to replace
       label: Replace %tablePlaceholder% from %filePlaceholder%

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -92,6 +92,7 @@ components:
     title: Create a new snapshot
   CustomCSVForm:
     addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
+    addCsvWithCustomFields: "Add the CSV data with custom fields to preserve in the final output."
     addCustomCsvData: Add the custom CSV data.
     numLines: "%numLines% lines."
     saveCsv: Save CSV

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -489,10 +489,10 @@ components:
       label: Replace %tablePlaceholder% from %versionPlaceholder%
       name: Replace file from version transformation
   FeedTransformationErrors: 
-    csvNameContainsTxt: Custom CSV name cannot contain .txt
+    csvNameContainsTxt: Custom CSV file name cannot end with ".txt".
     csvMissingName: Custom CSV must have a name.
     undefinedCSVData: CSV data must be defined.
-    undefinedTable: Table must be defined
+    undefinedTable: Table must be defined.
   FeedVersionNavigator:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
     confirmLoad: 'This will override all active GTFS Editor data for this Feed Source with the data from this version. If there is unsaved work in the Editor you want to keep, you must snapshot the current Editor data first. Are you sure you want to continue?'
@@ -1310,7 +1310,7 @@ components:
     tableModified: Table Modified 
     tableAdded: Table Added
     tableReplaced: Table Replaced
-    tableDeleted: TableDeleted
+    tableDeleted: Table Deleted
     transformationsTitle: Transformations
   TripSeriesModal:
     close: Close

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1300,6 +1300,17 @@ components:
     title: Timetable editor keyboard shortcuts
   TimezoneSelect:
     placeholder: Select timezone...
+  TransformationsViewer:
+    columnsAdded: "Custom columns added: %columns%"
+    noTransformationApplied: No transformations applied.
+    rowsAdded: "Rows added: %rows%"
+    rowsDeleted: "Rows deleted: %rows%"
+    rowsUpdated: "Rows updated: %rows%"
+    tableModified: Table Modified 
+    tableAdded: Table Added
+    tableReplaced: Table Replaced
+    tableDeleted: TableDeleted
+    transformationsTitle: Transformations
   TripSeriesModal:
     close: Close
     createTripSeriesBody: Enter the start and end time for the trip series (24 hour time) and headway between trips. Click generate to create the series of trips. 

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -489,6 +489,7 @@ components:
       label: Replace %tablePlaceholder% from %versionPlaceholder%
       name: Replace file from version transformation
   FeedTransformationErrors: 
+    csvNameContainsTxt: Custom CSV name cannot contain .txt
     csvMissingName: Custom CSV must have a name.
     undefinedCSVData: CSV data must be defined.
     undefinedTable: Table must be defined

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -492,6 +492,13 @@ components:
       tablePlaceholder: '[Tabelle auswählen]'
       version: Version
       versionPlaceholder: '[Version auswählen]'
+    AddCustomFileTransformation:
+      label: Add custom file in GTFS.
+      name: Add custom file transformation
+    PreserveCustomFieldsTransformation:
+      filePlaceholder: Choose the file/table with custom field
+      label: Preserve fields in %tablePlaceholder% from %filePlaceholder%
+      name: Preserve custom fields transformation
   FeedVersionNavigator:
     confirmDelete: Sind Sie sicher, dass sie diese Version endgültig löschen möchten?
     confirmLoad: Dies wird alle aktiven GTFS Editor Daten dieser Feed-Quelle mit den
@@ -1430,3 +1437,49 @@ components:
   WrapComponentInAuthStrategy:
     adminTestFailed: Sie haben versucht, eine eingeschränkt sichtbare Seite aufzurufen,
       verfügen jedoch nicht über die erforderlichen Rechte.
+  CustomCSVForm:
+    addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
+    addCsvWithCustomFields: "Add the CSV data with custom fields to preserve in the
+      final output."
+    addCustomCsvData: Add the custom CSV data.
+    numLines: "%numLines% lines."
+    saveCsv: Save CSV
+    saveCsvAndFileName: Save CSV and file name
+  FeedTransformationErrors:
+    csvMissingName: Custom CSV must have a name.
+    undefinedCSVData: CSV data must be defined.
+    undefinedTable: Table must be defined
+  PatternStopCard:
+    PatternStopContents:
+      defaultDwellTime: Default dwell time
+      defaultTravelTime: Default travel time
+      firstStopTravelTime: Travel time for first stop must be zero
+      stopHeadsignPlaceholder: Outbound
+      stopHeadsignText: Stop headsign
+      stopHeadsignTitle: Headsign that overrides trip headsign between stops.
+      timepoint: Timepoint?
+      travelTimeHelp: Define the default time it takes to travel to this stop from
+        the previous stop.
+    PickupDropOffSelect:
+      available: Available (0)
+      continuousDropOffTitle: Indicates whether a rider can alight from the transit
+        vehicle at any point along the vehicle's travel path.
+      continuousPickupTitle: Indicates whether a rider can board the transit vehicle
+        anywhere along the vehicle's travel path.
+      continuousServiceDefault: (Inherit from route)
+      dropOffTitle: Define the dropff method/availability at this stop.
+      mustCoordinate: Must coordinate with driver to arrange (3)
+      mustPhoneAgency: Must phone agency to arrange (2)
+      notAvailable: Not available (1)
+      pickupDropOffDefault: (Default - Available)
+      pickupTitle: Define the pickup method/availability at this stop.
+  TripSeriesModal:
+    close: Close
+    createTripSeriesBody: Enter the start and end time for the trip series (24 hour
+      time) and headway between trips. Click generate to create the series of trips.
+    createTripSeriesQuestion: Create a series of trips
+    disabledTooltip: There is an issue with the input data
+    endTime: "End Time:"
+    generateTrips: Generate Trips
+    headway: "Headway:"
+    startTime: "Start Time:"

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -7,6 +7,10 @@ components:
     errorWithStatus: Fehler (%status%) beim %method% Aufruf von %url%
     networkError: Netzwerk-Fehler (%status%)!\n\n(%method% Aufruf von %url%)
     noFile: Keine Datei zum Hochladen!
+  AddCustomFile: 
+    addCustomCsvData: Add the custom CSV data.
+    customFileName: Custom file name
+    saveCsvAndFileName: Save CSV and file name
   AdminPage:
     applicationLogs: Anwendungs-Logs
     backToDashboard: Zurück zum Dashboard
@@ -864,6 +868,9 @@ components:
     edit-alert: GTFS-RT Alerts bearbeiten
     edit-gtfs: GTFS Feeds bearbeiten
     manage-feed: Feed-Konfiguration verwalten
+  PreserveCustomFields: 
+    addCsvWithCustomFields: "Add the CSV data with custom fields to preserve in the final output."
+    saveCsv: Save CSV
   ProjectAccessSettings:
     admin: Admin
     cannotFetchFeeds: Feeds nicht abrufbar
@@ -1123,6 +1130,9 @@ components:
     viewDashboard: Dashboard ansehen
   RegionSearch:
     placeholder: Suche nach Regionen oder Unternehmen
+  ReplaceFileFromString:
+    addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
+    saveCsv: Save CSV
   ResultTable:
     affectedIds: Betroffene ID(s)
     description: Beschreibung
@@ -1438,13 +1448,7 @@ components:
     adminTestFailed: Sie haben versucht, eine eingeschränkt sichtbare Seite aufzurufen,
       verfügen jedoch nicht über die erforderlichen Rechte.
   CustomCSVForm:
-    addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
-    addCsvWithCustomFields: "Add the CSV data with custom fields to preserve in the
-      final output."
-    addCustomCsvData: Add the custom CSV data.
     numLines: "%numLines% lines."
-    saveCsv: Save CSV
-    saveCsvAndFileName: Save CSV and file name
   FeedTransformationErrors:
     csvMissingName: Custom CSV must have a name.
     undefinedCSVData: CSV data must be defined.

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1462,6 +1462,7 @@ components:
     numLines: "%numLines% lines."
   FeedTransformationErrors:
     csvMissingName: Custom CSV must have a name.
+    csvNameContainsTxt: Custom CSV name cannot contain .txt
     undefinedCSVData: CSV data must be defined.
     undefinedTable: Table must be defined
   PatternStopCard:

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1322,6 +1322,17 @@ components:
     title: Abfahrtszeiten-Editor Tastatur-Shortcuts
   TimezoneSelect:
     placeholder: Zeitzone auswählen...
+  TransformationsViewer:
+    columnsAdded: "Custom columns added: %columns%"
+    noTransformationApplied: No transformations applied.
+    rowsAdded: "Rows added: %rows%"
+    rowsDeleted: "Rows deleted: %rows%"
+    rowsUpdated: "Rows updated: %rows%"
+    tableModified: Table Modified 
+    tableAdded: Table Added
+    tableReplaced: Table Replaced
+    tableDeleted: TableDeleted
+    transformationsTitle: Transformations
   UserAccount:
     account:
       title: Konto

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -7,6 +7,10 @@ components:
     errorWithStatus: Error (%status%) making %method% request to %url%
     networkError: Network error (%status%)!\n\n(%method% request on %url%)
     noFile: No file to upload!
+  AddCustomFile: 
+    addCustomCsvData: Add the custom CSV data.
+    customFileName: Custom file name
+    saveCsvAndFileName: Save CSV and file name
   AdminPage:
     applicationLogs: Application logs
     backToDashboard: Back to dashboard
@@ -90,12 +94,7 @@ components:
       placeholder: Enter password for new user
     title: Create User
   CustomCSVForm:
-    addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
-    addCsvWithCustomFields: "Add the CSV data with custom fields to preserve in the final output."
-    addCustomCsvData: Add the custom CSV data.
     numLines: "%numLines% lines."
-    saveCsv: Save CSV
-    saveCsvAndFileName: Save CSV and file name
   DatatoolsNavbar:
     account: Moje konto
     alerts: Alerty
@@ -857,6 +856,9 @@ components:
     edit-alert: Edit GTFS-RT Alerts
     edit-gtfs: Edit GTFS Feeds
     manage-feed: Manage Feed Configuration
+  PreserveCustomFields: 
+    addCsvWithCustomFields: "Add the CSV data with custom fields to preserve in the final output."
+    saveCsv: Save CSV
   ProjectAccessSettings:
     admin: Admin
     cannotFetchFeeds: Cannot fetch feeds
@@ -1113,6 +1115,9 @@ components:
     viewDashboard: View dashboard
   RegionSearch:
     placeholder: Search for regions or agencies
+  ReplaceFileFromString:
+    addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
+    saveCsv: Save CSV
   ResultTable:
     affectedIds: Affected ID(s)
     description: Description

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -490,6 +490,13 @@ components:
       tablePlaceholder: '[choose table]'
       version: version
       versionPlaceholder: '[choose version]'
+    AddCustomFileTransformation:
+      label: Add custom file in GTFS.
+      name: Add custom file transformation
+    PreserveCustomFieldsTransformation:
+      filePlaceholder: Choose the file/table with custom field
+      label: Preserve fields in %tablePlaceholder% from %filePlaceholder%
+      name: Preserve custom fields transformation
   FeedVersionNavigator:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
     confirmLoad: This will override all active GTFS Editor data for this Feed Source
@@ -1232,6 +1239,7 @@ components:
     UPLOADING_FEED: Uploading feed...
     UPLOADING_GTFSPLUS_FEED: Saving GTFS+ data...
     VALIDATING_GTFSPLUS_FEED: Updating GTFS+ validation...
+    RUNNING_FETCH_FEED: Fetching feed...
   StatusModal:
     close: Close
     login: Log in
@@ -1407,3 +1415,41 @@ components:
     watch: Watch
   WrapComponentInAuthStrategy:
     adminTestFailed: You have attempted to view a restricted page without proper credentials
+  FeedTransformationErrors:
+    csvMissingName: Custom CSV must have a name.
+    undefinedCSVData: CSV data must be defined.
+    undefinedTable: Table must be defined
+  PatternStopCard:
+    PatternStopContents:
+      defaultDwellTime: Default dwell time
+      defaultTravelTime: Default travel time
+      firstStopTravelTime: Travel time for first stop must be zero
+      stopHeadsignPlaceholder: Outbound
+      stopHeadsignText: Stop headsign
+      stopHeadsignTitle: Headsign that overrides trip headsign between stops.
+      timepoint: Timepoint?
+      travelTimeHelp: Define the default time it takes to travel to this stop from
+        the previous stop.
+    PickupDropOffSelect:
+      available: Available (0)
+      continuousDropOffTitle: Indicates whether a rider can alight from the transit
+        vehicle at any point along the vehicle's travel path.
+      continuousPickupTitle: Indicates whether a rider can board the transit vehicle
+        anywhere along the vehicle's travel path.
+      continuousServiceDefault: (Inherit from route)
+      dropOffTitle: Define the dropff method/availability at this stop.
+      mustCoordinate: Must coordinate with driver to arrange (3)
+      mustPhoneAgency: Must phone agency to arrange (2)
+      notAvailable: Not available (1)
+      pickupDropOffDefault: (Default - Available)
+      pickupTitle: Define the pickup method/availability at this stop.
+  TripSeriesModal:
+    close: Close
+    createTripSeriesBody: Enter the start and end time for the trip series (24 hour
+      time) and headway between trips. Click generate to create the series of trips.
+    createTripSeriesQuestion: Create a series of trips
+    disabledTooltip: There is an issue with the input data
+    endTime: "End Time:"
+    generateTrips: Generate Trips
+    headway: "Headway:"
+    startTime: "Start Time:"

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -89,6 +89,13 @@ components:
       label: Password
       placeholder: Enter password for new user
     title: Create User
+  CustomCSVForm:
+    addCsvData: "Add the CSV data to add to/replace in the incoming GTFS:"
+    addCsvWithCustomFields: "Add the CSV data with custom fields to preserve in the final output."
+    addCustomCsvData: Add the custom CSV data.
+    numLines: "%numLines% lines."
+    saveCsv: Save CSV
+    saveCsvAndFileName: Save CSV and file name
   DatatoolsNavbar:
     account: Moje konto
     alerts: Alerty

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1433,6 +1433,7 @@ components:
     adminTestFailed: You have attempted to view a restricted page without proper credentials
   FeedTransformationErrors:
     csvMissingName: Custom CSV must have a name.
+    csvNameContainsTxt: Custom CSV name cannot contain .txt
     undefinedCSVData: CSV data must be defined.
     undefinedTable: Table must be defined
   PatternStopCard:

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1298,6 +1298,17 @@ components:
     title: Timetable editor keyboard shortcuts
   TimezoneSelect:
     placeholder: Select timezone...
+  TransformationsViewer:
+    columnsAdded: "Custom columns added: %columns%"
+    noTransformationApplied: No transformations applied.
+    rowsAdded: "Rows added: %rows%"
+    rowsDeleted: "Rows deleted: %rows%"
+    rowsUpdated: "Rows updated: %rows%"
+    tableModified: Table Modified 
+    tableAdded: Table Added
+    tableReplaced: Table Replaced
+    tableDeleted: TableDeleted
+    transformationsTitle: Transformations
   UserAccount:
     account:
       title: Account

--- a/lib/manager/components/TransformationsViewer.js
+++ b/lib/manager/components/TransformationsViewer.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import Icon from '@conveyal/woonerf/components/icon'
 import { Col, ListGroup, Panel, Row, ListGroupItem, Label as BsLabel } from 'react-bootstrap'
 
+import { getComponentMessages } from '../../common/util/config'
 import type { FeedVersion, TableTransformResult } from '../../types'
 
 type Props = {
@@ -11,16 +12,17 @@ type Props = {
 }
 
 export default class TransformationsViewer extends Component<Props> {
+  messages = getComponentMessages('TransformationsViewer')
   _getBadge (transformResult: TableTransformResult) {
     switch (transformResult.transformType) {
       case 'TABLE_MODIFIED':
-        return <BsLabel bsStyle='primary'>Table Modified</BsLabel>
+        return <BsLabel bsStyle='primary'>{this.messages('tableModified')}</BsLabel>
       case 'TABLE_ADDED':
-        return <BsLabel bsStyle='success'>Table Added</BsLabel>
+        return <BsLabel bsStyle='success'>{this.messages('tableAdded')}</BsLabel>
       case 'TABLE_REPLACED':
-        return <BsLabel bsStyle='warning'>Table Replaced</BsLabel>
+        return <BsLabel bsStyle='warning'>{this.messages('tableReplaced')}</BsLabel>
       case 'TABLE_DELETED':
-        return <BsLabel bsStyle='danger'>Table Deleted</BsLabel>
+        return <BsLabel bsStyle='danger'>{this.messages('tableDeleted')}</BsLabel>
     }
   }
 
@@ -34,26 +36,28 @@ export default class TransformationsViewer extends Component<Props> {
       const transformContent = tableTransformResults.map(res => {
         const badge = this._getBadge(res)
         return (
-          <ListGroupItem key={res.tableName} style={{maxWidth: '720px'}}>
+          <ListGroupItem key={res.tableName}>
             <h4 style={{marginTop: '5px'}}>{res.tableName} {badge}</h4>
-            <Row style={{textAlign: 'center'}}>
-              <Col xs={4}><Icon type='plus-square' />Rows added: {res.addedCount}</Col>
-              <Col xs={4}><Icon type='minus-square' />Rows deleted: {res.deletedCount}</Col>
-              <Col xs={4}><Icon type='exchange' />Rows updated: {res.updatedCount}</Col>
+            <Row style={{maxWidth: '950px', textAlign: 'center'}}>
+              {/* Use toString on numbers to make flow happy */}
+              <Col xs={3}><Icon type='plus-square' />{this.messages('rowsAdded').replace('%rows%', res.addedCount.toString())}</Col>
+              <Col xs={3}><Icon type='minus-square' />{this.messages('rowsDeleted').replace('%rows%', res.deletedCount.toString())}</Col>
+              <Col xs={3}><Icon type='exchange' />{this.messages('rowsUpdated').replace('%rows%', res.updatedCount.toString())}</Col>
+              <Col xs={3}><Icon type='user-plus' />{this.messages('columnsAdded').replace('%columns%', res.customColumnsAdded.toString())}</Col>
             </Row>
           </ListGroupItem>
         )
       })
       return (
         <Panel>
-          <Panel.Heading><Panel.Title componentClass='h3'>Transformations</Panel.Title></Panel.Heading>
+          <Panel.Heading><Panel.Title componentClass='h3'>{this.messages('transformationsTitle')}</Panel.Title></Panel.Heading>
           <ListGroup>
             {transformContent}
           </ListGroup>
         </Panel>
       )
     } else {
-      return <h3>No transformations applied.</h3>
+      return <h3>{this.messages('noTransformationApplied')}</h3>
     }
   }
 }

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -61,7 +61,7 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
   render () {
     const {transformation} = this.props
     const {csvData, table} = this.state
-    const inputIsUnchanged = csvData === transformation.csvData && table === transformation.table
+    const inputIsSame = csvData === transformation.csvData && table === transformation.table
     return (
       <div>
         <div>
@@ -74,7 +74,7 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
         </div>
         <CustomCSVForm
           csvData={csvData}
-          inputIsUnchanged={inputIsUnchanged}
+          inputIsSame={inputIsSame}
           onChangeCsvData={this._onChangeCsvData}
           onSaveCsvData={this._onSaveCsvData}
           type='AddCustomFile' // TODO: pass the classname directly?

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -25,22 +25,26 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
     this._updateErrors()
   }
 
+  componentDidUpdate (prevProps: TransformProps<AddCustomFileProps>, prevState: AddCustomFileProps) {
+    if (prevState !== this.state) {
+      this._updateErrors()
+    }
+  }
+
   _handleChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     const newState = {...this.state, table: evt.target.value}
     this.setState(newState)
-    this._updateErrors(newState)
   }
 
   _onSaveCsvData = () => {
     const csvData = this.state.csvData || null
-    const table = this.state.table || null
+    const table = this.state.table
     this.props.onSave({csvData, table}, this.props.index)
   }
 
   _onChangeCsvData = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     const newState = {...this.state, csvData: evt.target.value}
     this.setState(newState)
-    this._updateErrors(newState)
   }
 
   _getValidationErrors (fields: AddCustomFileProps): Array<string> {

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -13,19 +13,19 @@ import CustomCSVForm from './CustomCSVForm'
 export default class AddCustomFile extends Component<TransformProps<AddCustomFileProps>, AddCustomFileProps> {
   constructor (props: TransformProps<AddCustomFileProps>) {
     super(props)
-    this.state = {csvData: props.transformation.csvData, customFileName: props.transformation.customFileName}
+    this.state = {csvData: props.transformation.csvData, table: props.transformation.table}
   }
 
   // $FlowFixMe: Flow doesn't recognize return type for these arrow functions
   _handleChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    this.setState({...this.state, customFileName: evt.target.value})
+    this.setState({...this.state, table: evt.target.value})
   }
 
   // $FlowFixMe[signature-verification-failure]
   _onSaveCsvData = () => {
     const csvData = this.state.csvData || null
-    const customFileName = this.state.customFileName || null
-    this.props.onSave({csvData, customFileName}, this.props.index)
+    const table = this.state.table || null
+    this.props.onSave({csvData, table}, this.props.index)
   }
 
   // $FlowFixMe[signature-verification-failure]
@@ -42,7 +42,7 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
     // CSV data must be defined.
     if (!csvData || csvData.length === 0) {
       issues.push('CSV data must be defined.')
-    } else if (!this.state.customFileName) {
+    } else if (!this.state.table) {
       issues.push('Custom CSV must have a name.')
     }
     return issues
@@ -60,7 +60,7 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
 
   render () {
     const {transformation} = this.props
-    const {csvData, customFileName} = this.state
+    const {csvData, table} = this.state
     const inputIsUnchanged = csvData === transformation.csvData
     return (
       <div>
@@ -69,7 +69,7 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
             onChange={this._handleChange}
             placeholder='Custom file name'
             type='text'
-            value={customFileName || null}
+            value={table || null}
           />.txt
         </div>
         <CustomCSVForm

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 
 import type { AddCustomFileProps, TransformProps } from '../../../types'
 import CSV_VALIDATION_ERRORS from '../../util/enums/transform'
+import { getComponentMessages } from '../../../common/util/config'
 
 import CustomCSVForm from './CustomCSVForm'
 
@@ -12,9 +13,16 @@ import CustomCSVForm from './CustomCSVForm'
  * TODO: adapt this transformation to include a file upload for larger custom files?
  */
 export default class AddCustomFile extends Component<TransformProps<AddCustomFileProps>, AddCustomFileProps> {
+  // Messages are for the child CSV Form component but since messages are shared across transformation types,
+  // the messages are being grouped under that component.
+  messages = getComponentMessages('CustomCSVForm')
   constructor (props: TransformProps<AddCustomFileProps>) {
     super(props)
     this.state = {csvData: props.transformation.csvData, table: props.transformation.table}
+  }
+
+  componentDidMount () {
+    this._updateErrors()
   }
 
   _handleChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
@@ -73,11 +81,12 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
           />.txt
         </div>
         <CustomCSVForm
+          buttonText={this.messages('saveCsvAndFileName')}
           csvData={csvData}
+          headerText={this.messages('addCustomCsvData')}
           inputIsSame={inputIsSame}
           onChangeCsvData={this._onChangeCsvData}
           onSaveCsvData={this._onSaveCsvData}
-          type='AddCustomFile' // TODO: pass the classname directly?
         />
       </div>
     )

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -15,7 +15,7 @@ import CustomCSVForm from './CustomCSVForm'
 export default class AddCustomFile extends Component<TransformProps<AddCustomFileProps>, AddCustomFileProps> {
   // Messages are for the child CSV Form component but since messages are shared across transformation types,
   // the messages are being grouped under that component.
-  messages = getComponentMessages('CustomCSVForm')
+  messages = getComponentMessages('AddCustomFile')
   constructor (props: TransformProps<AddCustomFileProps>) {
     super(props)
     this.state = {csvData: props.transformation.csvData, table: props.transformation.table}
@@ -75,7 +75,7 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
         <div>
           <input
             onChange={this._handleChange}
-            placeholder='Custom file name'
+            placeholder={this.messages('customFileName')}
             type='text'
             value={table || null}
           />.txt

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -1,0 +1,85 @@
+// @flow
+
+import React, { Component } from 'react'
+
+import type { AddCustomFileProps, ReplaceFileFromStringFields, TransformProps } from '../../../types'
+
+import CustomCSVForm from './CustomCSVForm'
+
+/**
+ * Component that renders fields for AddCustomFile. This transformation shares csvData props with the ReplaceFileFromString transformation.
+ * TODO: adapt this transformation to include a file upload for larger custom files?
+ */
+export default class AddCustomFile extends Component<TransformProps<AddCustomFileProps>, AddCustomFileProps> {
+  constructor (props: TransformProps<AddCustomFileProps>) {
+    super(props)
+    this.state = {csvData: props.transformation.csvData, customFileName: props.transformation.customFileName}
+  }
+
+  // $FlowFixMe: Flow doesn't recognize return type for these arrow functions
+  _handleChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    this.setState({...this.state, customFileName: evt.target.value})
+  }
+
+  // $FlowFixMe[signature-verification-failure]
+  _onSaveCsvData = () => {
+    const csvData = this.state.csvData || null
+    const customFileName = this.state.customFileName || null
+    this.props.onSave({csvData, customFileName}, this.props.index)
+  }
+
+  // $FlowFixMe[signature-verification-failure]
+  _onChangeCsvData = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    const newState = {...this.state, csvData: evt.target.value}
+    this.setState(newState)
+    this._updateErrors(newState)
+  }
+
+  _getValidationErrors (fields: ReplaceFileFromStringFields): Array<string> {
+    const issues = []
+    const { csvData } = fields
+
+    // CSV data must be defined.
+    if (!csvData || csvData.length === 0) {
+      issues.push('CSV data must be defined.')
+    } else if (!this.state.customFileName) {
+      issues.push('Custom CSV must have a name.')
+    }
+    return issues
+  }
+
+  /**
+   * Notify containing component of the resulting validation errors if any.
+   * @param fields: The updated state. If not set, the component state will be used.
+   */
+  // $FlowFixMe[signature-verification-failure]
+  _updateErrors = (fields?: ReplaceFileFromStringFields) => {
+    const { onValidationErrors } = this.props
+    onValidationErrors(this._getValidationErrors(fields || this.state))
+  }
+
+  render () {
+    const {transformation} = this.props
+    const {csvData, customFileName} = this.state
+    const inputIsUnchanged = csvData === transformation.csvData
+    return (
+      <div>
+        <div>
+          <input
+            onChange={this._handleChange}
+            placeholder='Custom file name'
+            type='text'
+            value={customFileName || null}
+          />.txt
+        </div>
+        <CustomCSVForm
+          csvData={csvData}
+          inputIsUnchanged={inputIsUnchanged}
+          onChangeCsvData={this._onChangeCsvData}
+          onSaveCsvData={this._onSaveCsvData}
+          type='AddCustomFile' // TODO: pass the classname directly?
+        />
+      </div>
+    )
+  }
+}

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -3,6 +3,7 @@
 import React, { Component } from 'react'
 
 import type { AddCustomFileProps, ReplaceFileFromStringFields, TransformProps } from '../../../types'
+import CSV_VALIDATION_ERRORS from '../../util/enums/transform'
 
 import CustomCSVForm from './CustomCSVForm'
 
@@ -16,12 +17,12 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
     this.state = {csvData: props.transformation.csvData, table: props.transformation.table}
   }
 
-  // $FlowFixMe: Flow doesn't recognize return type for these arrow functions
   _handleChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    this.setState({...this.state, table: evt.target.value})
+    const newState = {...this.state, table: evt.target.value}
+    this.setState(newState)
+    this._updateErrors(newState)
   }
 
-  // $FlowFixMe[signature-verification-failure]
   _onSaveCsvData = () => {
     const csvData = this.state.csvData || null
     const table = this.state.table || null
@@ -35,15 +36,16 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
     this._updateErrors(newState)
   }
 
-  _getValidationErrors (fields: ReplaceFileFromStringFields): Array<string> {
+  _getValidationErrors (fields: AddCustomFileProps): Array<string> {
     const issues = []
-    const { csvData } = fields
+    const { csvData, table } = fields
 
     // CSV data must be defined.
     if (!csvData || csvData.length === 0) {
-      issues.push('CSV data must be defined.')
-    } else if (!this.state.table) {
-      issues.push('Custom CSV must have a name.')
+      issues.push(CSV_VALIDATION_ERRORS.UNDEFINED_CSV_DATA)
+    }
+    if (!table) {
+      issues.push(CSV_VALIDATION_ERRORS.CSV_MUST_HAVE_NAME)
     }
     return issues
   }
@@ -61,7 +63,7 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
   render () {
     const {transformation} = this.props
     const {csvData, table} = this.state
-    const inputIsUnchanged = csvData === transformation.csvData
+    const inputIsUnchanged = csvData === transformation.csvData && table === transformation.table
     return (
       <div>
         <div>

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react'
 
-import type { AddCustomFileProps, ReplaceFileFromStringFields, TransformProps } from '../../../types'
+import type { AddCustomFileProps, TransformProps } from '../../../types'
 import CSV_VALIDATION_ERRORS from '../../util/enums/transform'
 
 import CustomCSVForm from './CustomCSVForm'
@@ -29,7 +29,6 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
     this.props.onSave({csvData, table}, this.props.index)
   }
 
-  // $FlowFixMe[signature-verification-failure]
   _onChangeCsvData = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     const newState = {...this.state, csvData: evt.target.value}
     this.setState(newState)
@@ -54,8 +53,7 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
    * Notify containing component of the resulting validation errors if any.
    * @param fields: The updated state. If not set, the component state will be used.
    */
-  // $FlowFixMe[signature-verification-failure]
-  _updateErrors = (fields?: ReplaceFileFromStringFields) => {
+  _updateErrors = (fields?: AddCustomFileProps) => {
     const { onValidationErrors } = this.props
     onValidationErrors(this._getValidationErrors(fields || this.state))
   }

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -58,6 +58,9 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
     if (!table) {
       issues.push(CSV_VALIDATION_ERRORS.CSV_MUST_HAVE_NAME)
     }
+    if (table && table.includes('.txt')) {
+      issues.push(CSV_VALIDATION_ERRORS.CSV_NAME_CONTAINS_TXT)
+    }
     return issues
   }
 

--- a/lib/manager/components/transform/AddCustomFile.js
+++ b/lib/manager/components/transform/AddCustomFile.js
@@ -58,7 +58,7 @@ export default class AddCustomFile extends Component<TransformProps<AddCustomFil
     if (!table) {
       issues.push(CSV_VALIDATION_ERRORS.CSV_MUST_HAVE_NAME)
     }
-    if (table && table.includes('.txt')) {
+    if (table && table.endsWith('.txt')) {
       issues.push(CSV_VALIDATION_ERRORS.CSV_NAME_CONTAINS_TXT)
     }
     return issues

--- a/lib/manager/components/transform/CustomCSVForm.js
+++ b/lib/manager/components/transform/CustomCSVForm.js
@@ -18,8 +18,18 @@ const CustomCSVForm = (props: Props) => {
   const numLines = !csvData ? 0 : csvData.split(/\r*\n/).length
   const messages = getComponentMessages('CustomCSVForm')
 
-  // Assign yaml messages based on component
-  const header = type === 'ReplaceFileFromString' ? messages('addCsvData') : messages('addCustomCsvData')
+  let header
+  switch (type) {
+    case 'ReplaceFileFromString':
+      header = messages('addCsvData')
+      break
+    case 'AddCustomFile':
+      header = messages('addCustomCsvData')
+      break
+    case 'PreserveCustomFields':
+      header = messages('addCsvWithCustomFields')
+      break
+  }
   const buttonText = type === 'ReplaceFileFromString' ? messages('saveCsv') : messages('saveCsvAndFileName')
 
   return <div>

--- a/lib/manager/components/transform/CustomCSVForm.js
+++ b/lib/manager/components/transform/CustomCSVForm.js
@@ -7,13 +7,13 @@ import { getComponentMessages } from '../../../common/util/config'
 
 type Props = {
   csvData: ?string,
-  inputIsUnchanged: boolean,
+  inputIsSame: boolean,
   onChangeCsvData: (SyntheticInputEvent<HTMLInputElement>) => void,
   onSaveCsvData: () => void,
   type: string
 }
 const CustomCSVForm = (props: Props) => {
-  const { csvData, inputIsUnchanged, onChangeCsvData, onSaveCsvData, type } = props
+  const { csvData, inputIsSame, onChangeCsvData, onSaveCsvData, type } = props
 
   const numLines = !csvData ? 0 : csvData.split(/\r*\n/).length
   const messages = getComponentMessages('CustomCSVForm')
@@ -51,7 +51,7 @@ const CustomCSVForm = (props: Props) => {
     <div style={{marginBottom: '10px'}}>
       <Button
         bsSize='xsmall'
-        disabled={inputIsUnchanged}
+        disabled={inputIsSame}
         onClick={onSaveCsvData}
         style={{marginRight: '5px'}}
       >

--- a/lib/manager/components/transform/CustomCSVForm.js
+++ b/lib/manager/components/transform/CustomCSVForm.js
@@ -8,7 +8,7 @@ import { getComponentMessages } from '../../../common/util/config'
 type Props = {
   csvData: ?string,
   inputIsUnchanged: boolean,
-  onChangeCsvData: () => void,
+  onChangeCsvData: (SyntheticInputEvent<HTMLInputElement>) => void,
   onSaveCsvData: () => void,
   type: string
 }

--- a/lib/manager/components/transform/CustomCSVForm.js
+++ b/lib/manager/components/transform/CustomCSVForm.js
@@ -15,19 +15,12 @@ type Props = {
 const CustomCSVForm = (props: Props) => {
   const { csvData, inputIsUnchanged, onChangeCsvData, onSaveCsvData, type } = props
 
-  const textValue = csvData || ''
-  const numLines = !textValue ? 0 : textValue.split(/\r*\n/).length
+  const numLines = !csvData ? 0 : csvData.split(/\r*\n/).length
   const messages = getComponentMessages('CustomCSVForm')
 
   // Assign yaml messages based on component
-  let header, buttonText
-  if (type === 'ReplaceFileFromString') {
-    header = messages('addCsvData')
-    buttonText = messages('saveCsv')
-  } else if (type === 'AddCustomFile') {
-    header = messages('addCustomCsvData')
-    buttonText = messages('saveCsvAndFileName')
-  }
+  const header = type === 'ReplaceFileFromString' ? messages('addCsvData') : messages('addCustomCsvData')
+  const buttonText = type === 'ReplaceFileFromString' ? messages('saveCsv') : messages('saveCsvAndFileName')
 
   return <div>
     <label
@@ -53,7 +46,7 @@ const CustomCSVForm = (props: Props) => {
           whiteSpace: 'pre',
           width: '400px'
         }}
-        value={textValue} />
+        value={csvData} />
     </label>
     <div style={{marginBottom: '10px'}}>
       <Button

--- a/lib/manager/components/transform/CustomCSVForm.js
+++ b/lib/manager/components/transform/CustomCSVForm.js
@@ -1,10 +1,18 @@
+// @flow
+
 import React from 'react'
 import { Button } from 'react-bootstrap'
 
 import { getComponentMessages } from '../../../common/util/config'
 
-// TODO: type these props
-const CustomCSVForm = (props) => {
+type Props = {
+  csvData: ?string,
+  inputIsUnchanged: boolean,
+  onChangeCsvData: () => void,
+  onSaveCsvData: () => void,
+  type: string
+}
+const CustomCSVForm = (props: Props) => {
   const { csvData, inputIsUnchanged, onChangeCsvData, onSaveCsvData, type } = props
 
   const textValue = csvData || ''
@@ -35,8 +43,7 @@ const CustomCSVForm = (props) => {
         id='csvData'
         onChange={onChangeCsvData}
         placeholder={
-          `stop_id,stop_code,stop_name,stop_lat,stop_lon
-        1234567,188390987,Broad Ave,33.98768,-87.72686`
+          `stop_id,stop_code,stop_name,stop_lat,stop_lon\n1234567,188390987,Broad Ave,33.98768,-87.72686`
         }
         style={{
           fontFamily: 'monospace',

--- a/lib/manager/components/transform/CustomCSVForm.js
+++ b/lib/manager/components/transform/CustomCSVForm.js
@@ -6,31 +6,18 @@ import { Button } from 'react-bootstrap'
 import { getComponentMessages } from '../../../common/util/config'
 
 type Props = {
+  buttonText: string,
   csvData: ?string,
+  headerText: string,
   inputIsSame: boolean,
   onChangeCsvData: (SyntheticInputEvent<HTMLInputElement>) => void,
   onSaveCsvData: () => void,
-  type: string
 }
 const CustomCSVForm = (props: Props) => {
-  const { csvData, inputIsSame, onChangeCsvData, onSaveCsvData, type } = props
+  const { buttonText, csvData, headerText, inputIsSame, onChangeCsvData, onSaveCsvData } = props
 
   const numLines = !csvData ? 0 : csvData.split(/\r*\n/).length
   const messages = getComponentMessages('CustomCSVForm')
-
-  let header
-  switch (type) {
-    case 'ReplaceFileFromString':
-      header = messages('addCsvData')
-      break
-    case 'AddCustomFile':
-      header = messages('addCustomCsvData')
-      break
-    case 'PreserveCustomFields':
-      header = messages('addCsvWithCustomFields')
-      break
-  }
-  const buttonText = type === 'ReplaceFileFromString' ? messages('saveCsv') : messages('saveCsvAndFileName')
 
   return <div>
     <label
@@ -41,7 +28,7 @@ const CustomCSVForm = (props: Props) => {
         flexDirection: 'column'
       }}
     >
-      {header}
+      {headerText}
       <textarea
         id='csvData'
         onChange={onChangeCsvData}

--- a/lib/manager/components/transform/CustomCSVForm.js
+++ b/lib/manager/components/transform/CustomCSVForm.js
@@ -19,44 +19,46 @@ const CustomCSVForm = (props: Props) => {
   const numLines = !csvData ? 0 : csvData.split(/\r*\n/).length
   const messages = getComponentMessages('CustomCSVForm')
 
-  return <div>
-    <label
-      htmlFor='csvData'
-      style={{
-        display: 'flex',
-        justifyContent: 'space-evenly',
-        flexDirection: 'column'
-      }}
-    >
-      {headerText}
-      <textarea
-        id='csvData'
-        onChange={onChangeCsvData}
-        placeholder={
-          `stop_id,stop_code,stop_name,stop_lat,stop_lon\n1234567,188390987,Broad Ave,33.98768,-87.72686`
-        }
+  return (
+    <div>
+      <label
+        htmlFor='csvData'
         style={{
-          fontFamily: 'monospace',
-          fontSize: 'x-small',
-          height: '80px',
-          overflow: 'auto',
-          whiteSpace: 'pre',
-          width: '400px'
+          display: 'flex',
+          justifyContent: 'space-evenly',
+          flexDirection: 'column'
         }}
-        value={csvData} />
-    </label>
-    <div style={{marginBottom: '10px'}}>
-      <Button
-        bsSize='xsmall'
-        disabled={inputIsSame}
-        onClick={onSaveCsvData}
-        style={{marginRight: '5px'}}
       >
-        {buttonText}
-      </Button>
-      <small>{messages('numLines').replace('%numLines%', numLines.toString())}</small>
+        {headerText}
+        <textarea
+          id='csvData'
+          onChange={onChangeCsvData}
+          placeholder={
+            `stop_id,stop_code,stop_name,stop_lat,stop_lon\n1234567,188390987,Broad Ave,33.98768,-87.72686`
+          }
+          style={{
+            fontFamily: 'monospace',
+            fontSize: 'x-small',
+            height: '80px',
+            overflow: 'auto',
+            whiteSpace: 'pre',
+            width: '400px'
+          }}
+          value={csvData} />
+      </label>
+      <div style={{marginBottom: '10px'}}>
+        <Button
+          bsSize='xsmall'
+          disabled={inputIsSame}
+          onClick={onSaveCsvData}
+          style={{marginRight: '5px'}}
+        >
+          {buttonText}
+        </Button>
+        <small>{messages('numLines').replace('%numLines%', numLines.toString())}</small>
+      </div>
     </div>
-  </div>
+  )
 }
 
 export default CustomCSVForm

--- a/lib/manager/components/transform/CustomCSVForm.js
+++ b/lib/manager/components/transform/CustomCSVForm.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import { Button } from 'react-bootstrap'
+
+import { getComponentMessages } from '../../../common/util/config'
+
+// TODO: type these props
+const CustomCSVForm = (props) => {
+  const { csvData, inputIsUnchanged, onChangeCsvData, onSaveCsvData, type } = props
+
+  const textValue = csvData || ''
+  const numLines = !textValue ? 0 : textValue.split(/\r*\n/).length
+  const messages = getComponentMessages('CustomCSVForm')
+
+  // Assign yaml messages based on component
+  let header, buttonText
+  if (type === 'ReplaceFileFromString') {
+    header = messages('addCsvData')
+    buttonText = messages('saveCsv')
+  } else if (type === 'AddCustomFile') {
+    header = messages('addCustomCsvData')
+    buttonText = messages('saveCsvAndFileName')
+  }
+
+  return <div>
+    <label
+      htmlFor='csvData'
+      style={{
+        display: 'flex',
+        justifyContent: 'space-evenly',
+        flexDirection: 'column'
+      }}
+    >
+      {header}
+      <textarea
+        id='csvData'
+        onChange={onChangeCsvData}
+        placeholder={
+          `stop_id,stop_code,stop_name,stop_lat,stop_lon
+        1234567,188390987,Broad Ave,33.98768,-87.72686`
+        }
+        style={{
+          fontFamily: 'monospace',
+          fontSize: 'x-small',
+          height: '80px',
+          overflow: 'auto',
+          whiteSpace: 'pre',
+          width: '400px'
+        }}
+        value={textValue} />
+    </label>
+    <div style={{marginBottom: '10px'}}>
+      <Button
+        bsSize='xsmall'
+        disabled={inputIsUnchanged}
+        onClick={onSaveCsvData}
+        style={{marginRight: '5px'}}
+      >
+        {buttonText}
+      </Button>
+      <small>{messages('numLines').replace('%numLines%', numLines.toString())}</small>
+    </div>
+  </div>
+}
+
+export default CustomCSVForm

--- a/lib/manager/components/transform/FeedTransformRules.js
+++ b/lib/manager/components/transform/FeedTransformRules.js
@@ -33,7 +33,8 @@ function newFeedTransformation (type: string = 'ReplaceFileFromVersionTransforma
 const feedTransformationTypes = [
   'ReplaceFileFromVersionTransformation',
   'ReplaceFileFromStringTransformation',
-  'NormalizeFieldTransformation'
+  'NormalizeFieldTransformation',
+  'PreserveCustomFieldsTransformation'
 ]
 
 type TransformRulesProps = {

--- a/lib/manager/components/transform/FeedTransformRules.js
+++ b/lib/manager/components/transform/FeedTransformRules.js
@@ -34,7 +34,8 @@ const feedTransformationTypes = [
   'ReplaceFileFromVersionTransformation',
   'ReplaceFileFromStringTransformation',
   'NormalizeFieldTransformation',
-  'PreserveCustomFieldsTransformation'
+  'PreserveCustomFieldsTransformation',
+  'AddCustomFileTransformation'
 ]
 
 type TransformRulesProps = {

--- a/lib/manager/components/transform/FeedTransformation.js
+++ b/lib/manager/components/transform/FeedTransformation.js
@@ -129,13 +129,16 @@ export default class FeedTransformation extends Component<Props, {errors: Array<
           Step {index + 1} - {getTransformationName(transformationType, transformation, feedSource.feedVersionSummaries)}
         </h5>
         <div className='feed-transformation-body'>
-          {transformationType !== 'AddCustomFileTransformation' && <Select
-            style={{margin: '10px 0px', width: '230px'}}
-            clearable={false}
-            placeholder={getTransformationPlaceholder(transformationType, 'filePlaceholder')}
-            options={tables.map(table => ({value: table.name.split('.txt')[0], label: table.name}))}
-            value={transformation.table}
-            onChange={this._onSelectTable} /> }
+          {transformationType !== 'AddCustomFileTransformation' && (
+            <Select
+              style={{margin: '10px 0px', width: '230px'}}
+              clearable={false}
+              placeholder={getTransformationPlaceholder(transformationType, 'filePlaceholder')}
+              options={tables.map(table => ({value: table.name.split('.txt')[0], label: table.name}))}
+              value={transformation.table}
+              onChange={this._onSelectTable}
+            />
+          )}
           {this._getFieldsForType(transformationType)}
           {validationIssues.length > 0
             ? <ul className='list-unstyled'>

--- a/lib/manager/components/transform/FeedTransformation.js
+++ b/lib/manager/components/transform/FeedTransformation.js
@@ -16,6 +16,7 @@ import type {
 import NormalizeField from './NormalizeField'
 import ReplaceFileFromString from './ReplaceFileFromString'
 import ReplaceFileFromVersion from './ReplaceFileFromVersion'
+import AddCustomFile from './AddCustomFile'
 
 type Props = {
   feedSource: Feed,
@@ -40,6 +41,9 @@ const transformationTypes = {
   },
   PreserveCustomFieldsTransformation: {
     component: ReplaceFileFromString
+  },
+  AddCustomFileTransformation: {
+    component: AddCustomFile
   }
 }
 
@@ -123,13 +127,13 @@ export default class FeedTransformation extends Component<Props, {errors: Array<
           Step {index + 1} - {getTransformationName(transformationType, transformation, feedSource.feedVersionSummaries)}
         </h5>
         <div className='feed-transformation-body'>
-          <Select
+          {transformationType !== 'AddCustomFileTransformation' && <Select
             style={{margin: '10px 0px', width: '230px'}}
             clearable={false}
             placeholder={getTransformationPlaceholder(transformationType, 'filePlaceholder')}
             options={tables.map(table => ({value: table.name.split('.txt')[0], label: table.name}))}
             value={transformation.table}
-            onChange={this._onSelectTable} />
+            onChange={this._onSelectTable} /> }
           {this._getFieldsForType(transformationType)}
           {validationIssues.length > 0
             ? <ul className='list-unstyled'>

--- a/lib/manager/components/transform/FeedTransformation.js
+++ b/lib/manager/components/transform/FeedTransformation.js
@@ -18,6 +18,7 @@ import NormalizeField from './NormalizeField'
 import ReplaceFileFromString from './ReplaceFileFromString'
 import ReplaceFileFromVersion from './ReplaceFileFromVersion'
 import AddCustomFile from './AddCustomFile'
+import PreserveCustomFields from './PreserveCustomFields'
 
 type Props = {
   feedSource: Feed,
@@ -41,7 +42,7 @@ const transformationTypes = {
     component: ReplaceFileFromVersion
   },
   PreserveCustomFieldsTransformation: {
-    component: ReplaceFileFromString
+    component: PreserveCustomFields
   },
   AddCustomFileTransformation: {
     component: AddCustomFile

--- a/lib/manager/components/transform/FeedTransformation.js
+++ b/lib/manager/components/transform/FeedTransformation.js
@@ -37,6 +37,9 @@ const transformationTypes = {
   },
   ReplaceFileFromVersionTransformation: {
     component: ReplaceFileFromVersion
+  },
+  PreserveCustomFieldsTransformation: {
+    component: ReplaceFileFromString
   }
 }
 

--- a/lib/manager/components/transform/FeedTransformation.js
+++ b/lib/manager/components/transform/FeedTransformation.js
@@ -5,8 +5,9 @@ import React, {Component} from 'react'
 import {Button} from 'react-bootstrap'
 import Select from 'react-select'
 
-import {getGtfsSpec, getGtfsPlusSpec, isModuleEnabled} from '../../../common/util/config'
+import {getComponentMessages, getGtfsSpec, getGtfsPlusSpec, isModuleEnabled} from '../../../common/util/config'
 import {getTransformationName, getTransformationPlaceholder} from '../../util/transform'
+import CSV_VALIDATION_ERRORS from '../../util/enums/transform'
 import type {
   Feed,
   FeedTransformation as FeedTransformationType,
@@ -47,8 +48,6 @@ const transformationTypes = {
   }
 }
 
-const TABLE_MUST_BE_DEFINED_ERROR = 'Table must be defined'
-
 /**
  * Component that renders fields for one feed transformation
  * (e.g., ReplaceFileFromStringTransformation).
@@ -63,7 +62,7 @@ export default class FeedTransformation extends Component<Props, {errors: Array<
     // and 'Table must be defined' no longer applies.
     const { table } = this.props.transformation
     if (table && prevProps.transformation.table !== table) {
-      this.setState({ errors: this.state.errors.filter(e => e !== TABLE_MUST_BE_DEFINED_ERROR) })
+      this.setState({ errors: this.state.errors.filter(e => e !== CSV_VALIDATION_ERRORS.TABLE_MUST_BE_DEFINED) })
     }
   }
 
@@ -83,8 +82,9 @@ export default class FeedTransformation extends Component<Props, {errors: Array<
 
   _onValidationErrors = (errors: Array<string>) => {
     const issues: Array<string> = []
-    if (!this.props.transformation.table) {
-      issues.push(TABLE_MUST_BE_DEFINED_ERROR)
+    const { transformation } = this.props
+    if (!transformation.table && transformation['@type'] !== 'AddCustomFileTransformation') {
+      issues.push(CSV_VALIDATION_ERRORS.TABLE_MUST_BE_DEFINED)
     }
     this.setState({ errors: issues.concat(errors) })
   }
@@ -102,6 +102,7 @@ export default class FeedTransformation extends Component<Props, {errors: Array<
   render () {
     const {feedSource, index, transformation} = this.props
     const tables = [...getGtfsSpec()].filter(t => !t.datatools)
+    const errorMessages = getComponentMessages('FeedTransformationErrors')
     if (isModuleEnabled('gtfsplus')) tables.push(...getGtfsPlusSpec())
     const transformationType = transformation['@type']
     const {errors: validationIssues} = this.state
@@ -141,7 +142,7 @@ export default class FeedTransformation extends Component<Props, {errors: Array<
               {validationIssues.map((issue, i) => {
                 return (
                   <li style={{marginLeft: '10px'}} key={`issue-${i}`}>
-                    {issue}
+                    {errorMessages(issue)}
                   </li>
                 )
               })}

--- a/lib/manager/components/transform/PreserveCustomFields.js
+++ b/lib/manager/components/transform/PreserveCustomFields.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import ReplaceFileFromString from './ReplaceFileFromString'
+import CustomCSVForm from './CustomCSVForm'
+
+export default class PreserveCustomFields extends ReplaceFileFromString {
+  render () {
+    const {transformation} = this.props
+    const {csvData} = this.state
+    const inputIsSame = csvData === transformation.csvData
+
+    return <CustomCSVForm
+      csvData={csvData}
+      inputIsSame={inputIsSame}
+      onChangeCsvData={this._onChangeCsvData}
+      onSaveCsvData={this._onSaveCsvData}
+      type='PreserveCustomFields'
+    />
+  }
+}

--- a/lib/manager/components/transform/PreserveCustomFields.js
+++ b/lib/manager/components/transform/PreserveCustomFields.js
@@ -8,7 +8,7 @@ import CustomCSVForm from './CustomCSVForm'
 export default class PreserveCustomFields extends ReplaceFileFromString {
   // Messages are for the child CSV Form component but since messages are shared across transformation types,
   // the messages are being grouped under that component.
-  messages = getComponentMessages('CustomCSVForm')
+  messages = getComponentMessages('PreserveCustomFields')
   render () {
     const {transformation} = this.props
     const {csvData} = this.state

--- a/lib/manager/components/transform/PreserveCustomFields.js
+++ b/lib/manager/components/transform/PreserveCustomFields.js
@@ -1,20 +1,26 @@
 import React from 'react'
 
+import { getComponentMessages } from '../../../common/util/config'
+
 import ReplaceFileFromString from './ReplaceFileFromString'
 import CustomCSVForm from './CustomCSVForm'
 
 export default class PreserveCustomFields extends ReplaceFileFromString {
+  // Messages are for the child CSV Form component but since messages are shared across transformation types,
+  // the messages are being grouped under that component.
+  messages = getComponentMessages('CustomCSVForm')
   render () {
     const {transformation} = this.props
     const {csvData} = this.state
     const inputIsSame = csvData === transformation.csvData
 
     return <CustomCSVForm
+      buttonText={this.messages('saveCsv')}
       csvData={csvData}
+      headerText={this.messages('addCsvWithCustomFields')}
       inputIsSame={inputIsSame}
       onChangeCsvData={this._onChangeCsvData}
       onSaveCsvData={this._onSaveCsvData}
-      type='PreserveCustomFields'
     />
   }
 }

--- a/lib/manager/components/transform/PreserveCustomFields.js
+++ b/lib/manager/components/transform/PreserveCustomFields.js
@@ -14,13 +14,15 @@ export default class PreserveCustomFields extends ReplaceFileFromString {
     const {csvData} = this.state
     const inputIsSame = csvData === transformation.csvData
 
-    return <CustomCSVForm
-      buttonText={this.messages('saveCsv')}
-      csvData={csvData}
-      headerText={this.messages('addCsvWithCustomFields')}
-      inputIsSame={inputIsSame}
-      onChangeCsvData={this._onChangeCsvData}
-      onSaveCsvData={this._onSaveCsvData}
-    />
+    return (
+      <CustomCSVForm
+        buttonText={this.messages('saveCsv')}
+        csvData={csvData}
+        headerText={this.messages('addCsvWithCustomFields')}
+        inputIsSame={inputIsSame}
+        onChangeCsvData={this._onChangeCsvData}
+        onSaveCsvData={this._onSaveCsvData}
+      />
+    )
   }
 }

--- a/lib/manager/components/transform/ReplaceFileFromString.js
+++ b/lib/manager/components/transform/ReplaceFileFromString.js
@@ -14,7 +14,7 @@ import CustomCSVForm from './CustomCSVForm'
 export default class ReplaceFileFromString extends Component<TransformProps<ReplaceFileFromStringFields>, ReplaceFileFromStringFields> {
   // Messages are for the child CSV Form component but since messages are shared across transformation types,
   // the messages are being grouped under that component.
-  messages = getComponentMessages('CustomCSVForm')
+  messages = getComponentMessages('ReplaceFileFromString')
   constructor (props: TransformProps<ReplaceFileFromStringFields>) {
     super(props)
     this.state = {csvData: props.transformation.csvData}

--- a/lib/manager/components/transform/ReplaceFileFromString.js
+++ b/lib/manager/components/transform/ReplaceFileFromString.js
@@ -60,13 +60,15 @@ export default class ReplaceFileFromString extends Component<TransformProps<Repl
     const {csvData} = this.state
     const inputIsSame = csvData === transformation.csvData
 
-    return <CustomCSVForm
-      buttonText={this.messages('saveCsv')}
-      csvData={csvData}
-      headerText={this.messages('addCsvData')}
-      inputIsSame={inputIsSame}
-      onChangeCsvData={this._onChangeCsvData}
-      onSaveCsvData={this._onSaveCsvData}
-    />
+    return (
+      <CustomCSVForm
+        buttonText={this.messages('saveCsv')}
+        csvData={csvData}
+        headerText={this.messages('addCsvData')}
+        inputIsSame={inputIsSame}
+        onChangeCsvData={this._onChangeCsvData}
+        onSaveCsvData={this._onSaveCsvData}
+      />
+    )
   }
 }

--- a/lib/manager/components/transform/ReplaceFileFromString.js
+++ b/lib/manager/components/transform/ReplaceFileFromString.js
@@ -54,11 +54,11 @@ export default class ReplaceFileFromString extends Component<TransformProps<Repl
   render () {
     const {transformation} = this.props
     const {csvData} = this.state
-    const inputIsUnchanged = csvData === transformation.csvData
+    const inputIsSame = csvData === transformation.csvData
 
     return <CustomCSVForm
       csvData={csvData}
-      inputIsUnchanged={inputIsUnchanged}
+      inputIsSame={inputIsSame}
       onChangeCsvData={this._onChangeCsvData}
       onSaveCsvData={this._onSaveCsvData}
       type='ReplaceFileFromString'

--- a/lib/manager/components/transform/ReplaceFileFromString.js
+++ b/lib/manager/components/transform/ReplaceFileFromString.js
@@ -20,14 +20,12 @@ export default class ReplaceFileFromString extends Component<TransformProps<Repl
     this._updateErrors()
   }
 
-  // $FlowFixMe[signature-verification-failure]
   _onChangeCsvData = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     const newState = {csvData: evt.target.value}
     this.setState(newState)
     this._updateErrors(newState)
   }
 
-  // $FlowFixMe[signature-verification-failure]
   _onSaveCsvData = () => {
     const csvData = this.state.csvData || null
     this.props.onSave({csvData}, this.props.index)
@@ -48,7 +46,6 @@ export default class ReplaceFileFromString extends Component<TransformProps<Repl
    * Notify containing component of the resulting validation errors if any.
    * @param fields: The updated state. If not set, the component state will be used.
    */
-  // $FlowFixMe[signature-verification-failure]
   _updateErrors = (fields?: ReplaceFileFromStringFields) => {
     const { onValidationErrors } = this.props
     onValidationErrors(this._getValidationErrors(fields || this.state))

--- a/lib/manager/components/transform/ReplaceFileFromString.js
+++ b/lib/manager/components/transform/ReplaceFileFromString.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 
 import type { ReplaceFileFromStringFields, TransformProps } from '../../../types'
 import CSV_VALIDATION_ERRORS from '../../util/enums/transform'
+import { getComponentMessages } from '../../../common/util/config'
 
 import CustomCSVForm from './CustomCSVForm'
 
@@ -11,6 +12,9 @@ import CustomCSVForm from './CustomCSVForm'
  * Component that renders fields for ReplaceFileFromStringTransformation.
  */
 export default class ReplaceFileFromString extends Component<TransformProps<ReplaceFileFromStringFields>, ReplaceFileFromStringFields> {
+  // Messages are for the child CSV Form component but since messages are shared across transformation types,
+  // the messages are being grouped under that component.
+  messages = getComponentMessages('CustomCSVForm')
   constructor (props: TransformProps<ReplaceFileFromStringFields>) {
     super(props)
     this.state = {csvData: props.transformation.csvData}
@@ -57,11 +61,12 @@ export default class ReplaceFileFromString extends Component<TransformProps<Repl
     const inputIsSame = csvData === transformation.csvData
 
     return <CustomCSVForm
+      buttonText={this.messages('saveCsv')}
       csvData={csvData}
+      headerText={this.messages('addCsvData')}
       inputIsSame={inputIsSame}
       onChangeCsvData={this._onChangeCsvData}
       onSaveCsvData={this._onSaveCsvData}
-      type='ReplaceFileFromString'
     />
   }
 }

--- a/lib/manager/components/transform/ReplaceFileFromString.js
+++ b/lib/manager/components/transform/ReplaceFileFromString.js
@@ -3,6 +3,7 @@
 import React, { Component } from 'react'
 
 import type { ReplaceFileFromStringFields, TransformProps } from '../../../types'
+import CSV_VALIDATION_ERRORS from '../../util/enums/transform'
 
 import CustomCSVForm from './CustomCSVForm'
 
@@ -38,7 +39,7 @@ export default class ReplaceFileFromString extends Component<TransformProps<Repl
 
     // CSV data must be defined.
     if (!csvData || csvData.length === 0) {
-      issues.push('CSV data must be defined.')
+      issues.push(CSV_VALIDATION_ERRORS.UNDEFINED_CSV_DATA)
     }
     return issues
   }

--- a/lib/manager/components/transform/ReplaceFileFromString.js
+++ b/lib/manager/components/transform/ReplaceFileFromString.js
@@ -1,9 +1,10 @@
 // @flow
 
 import React, { Component } from 'react'
-import { Button } from 'react-bootstrap'
 
 import type { ReplaceFileFromStringFields, TransformProps } from '../../../types'
+
+import CustomCSVForm from './CustomCSVForm'
 
 /**
  * Component that renders fields for ReplaceFileFromStringTransformation.
@@ -18,12 +19,14 @@ export default class ReplaceFileFromString extends Component<TransformProps<Repl
     this._updateErrors()
   }
 
+  // $FlowFixMe[signature-verification-failure]
   _onChangeCsvData = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     const newState = {csvData: evt.target.value}
     this.setState(newState)
     this._updateErrors(newState)
   }
 
+  // $FlowFixMe[signature-verification-failure]
   _onSaveCsvData = () => {
     const csvData = this.state.csvData || null
     this.props.onSave({csvData}, this.props.index)
@@ -44,6 +47,7 @@ export default class ReplaceFileFromString extends Component<TransformProps<Repl
    * Notify containing component of the resulting validation errors if any.
    * @param fields: The updated state. If not set, the component state will be used.
    */
+  // $FlowFixMe[signature-verification-failure]
   _updateErrors = (fields?: ReplaceFileFromStringFields) => {
     const { onValidationErrors } = this.props
     onValidationErrors(this._getValidationErrors(fields || this.state))
@@ -53,42 +57,13 @@ export default class ReplaceFileFromString extends Component<TransformProps<Repl
     const {transformation} = this.props
     const {csvData} = this.state
     const inputIsUnchanged = csvData === transformation.csvData
-    const textValue = csvData || ''
-    const numLines = !textValue ? 0 : textValue.split(/\r*\n/).length
 
-    return (
-      <div>
-        <label htmlFor='csvData'>
-          Add the CSV data to add to/replace in the incoming GTFS:
-          <textarea
-            id='csvData'
-            onChange={this._onChangeCsvData}
-            placeholder={
-              `stop_id,stop_code,stop_name,stop_lat,stop_lon
-1234567,188390987,Broad Ave,33.98768,-87.72686`
-            }
-            style={{
-              fontFamily: 'monospace',
-              fontSize: 'x-small',
-              height: '80px',
-              overflow: 'auto',
-              whiteSpace: 'pre',
-              width: '400px'
-            }}
-            value={textValue} />
-        </label>
-        <div style={{marginBottom: '10px'}}>
-          <Button
-            bsSize='xsmall'
-            disabled={inputIsUnchanged}
-            onClick={this._onSaveCsvData}
-            style={{marginRight: '5px'}}
-          >
-            Save CSV
-          </Button>
-          <small>{numLines} lines</small>
-        </div>
-      </div>
-    )
+    return <CustomCSVForm
+      csvData={csvData}
+      inputIsUnchanged={inputIsUnchanged}
+      onChangeCsvData={this._onChangeCsvData}
+      onSaveCsvData={this._onSaveCsvData}
+      type='ReplaceFileFromString'
+    />
   }
 }

--- a/lib/manager/util/enums/transform.js
+++ b/lib/manager/util/enums/transform.js
@@ -1,0 +1,9 @@
+// CSV validation errors for transformations.
+// Values are keys to YAML error messages.
+const CSV_VALIDATION_ERRORS = {
+  CSV_MUST_HAVE_NAME: 'csvMissingName',
+  TABLE_MUST_BE_DEFINED: 'undefinedTable',
+  UNDEFINED_CSV_DATA: 'undefinedCSVData'
+}
+
+export default CSV_VALIDATION_ERRORS

--- a/lib/manager/util/enums/transform.js
+++ b/lib/manager/util/enums/transform.js
@@ -2,6 +2,7 @@
 // Values are keys to YAML error messages.
 const CSV_VALIDATION_ERRORS = {
   CSV_MUST_HAVE_NAME: 'csvMissingName',
+  CSV_NAME_CONTAINS_TXT: 'csvNameContainsTxt',
   TABLE_MUST_BE_DEFINED: 'undefinedTable',
   UNDEFINED_CSV_DATA: 'undefinedCSVData'
 }

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -341,7 +341,7 @@ export type ReplaceFileFromStringFields = {
   csvData?: ?string
 }
 
-export type AddCustomFileProps = ReplaceFileFromStringFields & {customFileName: ?string}
+export type AddCustomFileProps = ReplaceFileFromStringFields & {table: ?string}
 
 export type FeedTransformationBase = {
   '@type': $Values<typeof FEED_TRANSFORMATION_TYPES>,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -341,6 +341,8 @@ export type ReplaceFileFromStringFields = {
   csvData?: ?string
 }
 
+export type AddCustomFileProps = ReplaceFileFromStringFields & {customFileName: ?string}
+
 export type FeedTransformationBase = {
   '@type': $Values<typeof FEED_TRANSFORMATION_TYPES>,
   active: boolean,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -509,6 +509,7 @@ export type SummarizedFeedVersion = {
 
 export type TableTransformResult = {
   addedCount: number,
+  customColumnsAdded: number,
   deletedCount: number,
   tableName: string,
   transformType: 'TABLE_ADDED' | 'TABLE_REPLACED' | 'TABLE_DELETED' | 'TABLE_MODIFIED',


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

For testing, the back end PR can be found here: https://github.com/ibi-group/datatools-server/pull/536
Watch out for your mongo database once new transformations have been created you'll need to remove those when returning to run dev normally.

This PR supports two new transformations on the back end:

`1. Preserve (or add) custom fields to existing GTFS files:`
Allows a user to specify custom fields within existing GTFS tables which will be added after a new version is produced.
For example, certain producers include a platform_track field within the stop_times table. With this PR, that can be
specified using a mapping in the csv input data, and the custom field will be conditionally added to the final
stop_times file.

`2. Add a custom file to the GTFS:`
Allows a user to take csv data and dump it into a custom txt file in the final GTFS product. Essentially uses the
ReplaceFileFromString transformation but does not restrict the table to an existing GTFS table.