### PR TITLE
Don’t allow users to see all projects

### DIFF
--- a/lib/public/components/UserAccount.js
+++ b/lib/public/components/UserAccount.js
@@ -68,6 +68,7 @@ export default class UserAccount extends Component<Props> {
 
   _onResetPassword = () => this.props.sendPasswordReset(this.props.user)
 
+  // eslint-disable-next-line complexity
   render () {
     const {accountTypes = {}, activeComponent, projectId, projects, user} = this.props
     const {profile} = user
@@ -86,6 +87,10 @@ export default class UserAccount extends Component<Props> {
         ? <span style={{ color: 'red' }}>Account type not configured ({accountType})</span>
         : defaultAccountType && defaultAccountType.name)
     const accountTermsUrl = accountTypeObject && accountTypeObject.terms_url
+
+    const userProjects = user && projects.filter(p => {
+      return user && user.permissions && user.permissions.hasProject(p.id, p.organizationId)
+    })
 
     const subscriptions: ?Array<Subscription> = userSettings && userSettings.subscriptions
     const ACCOUNT_SECTIONS = [
@@ -235,7 +240,7 @@ export default class UserAccount extends Component<Props> {
               <Panel>
                 <Panel.Heading><Panel.Title componentClass='h3'>{this.messages('organizationSettings')}</Panel.Title></Panel.Heading>
                 <ListGroup>
-                  {projects && projects.map(project => {
+                  {userProjects && userProjects.map(project => {
                     return (
                       <LinkContainer key={project.id} to={`/project/${project.id}/settings`}>
                         <ListGroupItem active={projectId === project.id}>


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

This PR resolves a bug where any user could see the full list of projects by visiting their "My Account" page. The code used is lifted from elsewhere.

I tried to make it a shared method, but the existing uses doing it via map, and this via filter made the shared implementation impractical.

It should also be noted this is not a complete solution -- the filtering really needs to happen server-side to avoid the data being leaked to the client to begin with