### PR TITLE
Make Timepoint Default Value 0

### DIFF
--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -774,7 +774,7 @@ export function stopToPatternStop (
     stopHeadsign: '',
     stopId: stop.stop_id,
     stopSequence,
-    timepoint: null
+    timepoint: 0
   }
 }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Right now, unassigned timepoints are exported as empty, which is interpreted as a real timepoint. The default value to adhere to expected behaviour should be 0 for "Times are considered approximate."
