### PR TITLE
refactor: show csv upload time

### DIFF
--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -17,6 +17,9 @@ import ConfirmModal from '../../../common/components/ConfirmModal'
 import { updateDeployment, uploadPeliasWebhookCsvFile, updatePelias } from '../../actions/deployments'
 import { setErrorMessage } from '../../actions/status'
 import type { Deployment, Project } from '../../../types'
+import {
+  formatTimestamp
+} from '../../../common/util/date-time'
 
 type Props = {
   deployment: Deployment,
@@ -29,12 +32,55 @@ type Props = {
 
 type State = {
   fileToDeleteOnSuccesfulUpload: string | null,
+  peliasCsvUploadsDates: Array<string>
 }
 
 class PeliasPanel extends Component<Props, State> {
   state = {
-    fileToDeleteOnSuccesfulUpload: null
+    fileToDeleteOnSuccesfulUpload: null,
+    peliasCsvUploadsDates: []
   };
+
+componentDidUpdate = (newProps) => {
+  const { deployment } = newProps
+  if (!deployment.peliasCsvFiles) {
+    return
+  }
+
+  // Only update if the deployment has changed
+  if (
+    this.props.deployment.peliasCsvFiles &&
+    this.props.deployment.peliasCsvFiles.every(
+      // $FlowFixMe flow is wrong
+      (file) => deployment.peliasCsvFiles.indexOf(file) > -1
+    ) &&
+    deployment.peliasCsvFiles &&
+    // $FlowFixMe flow is wrong
+    deployment.peliasCsvFiles.every(
+    // $FlowFixMe flow is wrong
+      (file) => this.props.deployment.peliasCsvFiles.indexOf(file) > -1
+    // And if there are no upload dates yet
+    ) && this.state.peliasCsvUploadsDates.length > 0
+  ) {
+    return
+  }
+
+  // $FlowFixMe flow is wrong
+  deployment.peliasCsvFiles.forEach(
+    (file, index) => this.fetchAndUpdatePeliasDate(file, index)
+  )
+}
+
+  fetchAndUpdatePeliasDate = (url, index) => {
+    const { peliasCsvUploadsDates } = this.state
+    fetch(url, {method: 'HEAD'}).then(data => {
+      const lastModified = data.headers.get('last-modified')
+      if (!lastModified) return
+
+      peliasCsvUploadsDates[index] = lastModified
+      this.setState({peliasCsvUploadsDates})
+    })
+  }
 
   /**
    * Method fired when Pelias *Update* button is pressed
@@ -141,9 +187,10 @@ class PeliasPanel extends Component<Props, State> {
    * buttons to replace or remove the file
    * @param {*} url     The URL to add to the list of csv files associated with the deployment
    * @param {*} enabled Whether the buttons should be enabled
+   * @param {*} label   An optional label to render next to the buttons
    * @returns           JSX including the file name and buttons
    */
-  renderCsvUrl = (url: string, enabled: boolean) => {
+  renderCsvUrl = (url: string, enabled: boolean, label?: string) => {
     // Usually, files will be rendered by https://github.com/ibi-group/datatools-server/blob/dev/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
     // so we can take advantage of a predictable filename
     // As a fallback, render the full url
@@ -175,6 +222,7 @@ class PeliasPanel extends Component<Props, State> {
         >
           Download
         </Button>
+        {label && <em style={{marginLeft: '1ch'}}>{label}</em>}
       </li>
     )
   }
@@ -234,8 +282,11 @@ class PeliasPanel extends Component<Props, State> {
             />
             <ul>
               {deployment.peliasCsvFiles &&
-                deployment.peliasCsvFiles.map((url) =>
-                  this.renderCsvUrl(url, !peliasButtonsDisabled)
+                deployment.peliasCsvFiles.map((url, index) => {
+                  const uploadDate = this.state.peliasCsvUploadsDates[index]
+                  const label = uploadDate ? formatTimestamp(uploadDate) : ''
+                  return this.renderCsvUrl(url, !peliasButtonsDisabled, label)
+                }
                 )}
             </ul>
             <Button

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -54,7 +54,6 @@ componentDidUpdate = (newProps) => {
       // $FlowFixMe flow is wrong
       (file) => deployment.peliasCsvFiles.indexOf(file) > -1
     ) &&
-    deployment.peliasCsvFiles &&
     // $FlowFixMe flow is wrong
     deployment.peliasCsvFiles.every(
     // $FlowFixMe flow is wrong
@@ -222,7 +221,7 @@ componentDidUpdate = (newProps) => {
         >
           Download
         </Button>
-        {label && <em style={{marginLeft: '1ch'}}>{label}</em>}
+        {label && <em style={{marginLeft: '1ch', verticalAlign: 'middle'}}>{label}</em>}
       </li>
     )
   }


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

This PR adds last modified dates to the csvs uploaded in the Pelias panel.

The dates are grabbed from the S3 headers. Not sure how we feel about that.