### PR TITLE
Support pelias synonyms file

### DIFF
--- a/__tests__/test-utils/mock-data/manager.js
+++ b/__tests__/test-utils/mock-data/manager.js
@@ -71,6 +71,7 @@ export function makeMockDeployment (
     peliasCsvFiles: [],
     peliasResetDb: null,
     peliasUpdate: null,
+    peliasSynonymsBase64: null,
     pinnedfeedVersionIds: [],
     projectBounds: {east: 0, west: 0, north: 0, south: 0},
     projectId: project.id,

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -301,10 +301,11 @@ class PeliasPanel extends Component<Props, State> {
             />
             <div>
               <Button
+                style={{ marginTop: 15 }}
                 disabled={peliasButtonsDisabled}
                 onClick={() => this.refs.uploadSynonymsModal.open()}
               >
-                Upload Synonyms File
+                {deployment.peliasSynonymsBase64 ? 'Replace' : 'Upload'} Synonyms File
               </Button>
               {deployment.peliasSynonymsBase64 &&
                 <span style={{paddingLeft: '1ch'}}>Synonyms file currently loaded</span>}
@@ -312,12 +313,18 @@ class PeliasPanel extends Component<Props, State> {
             <Button
               style={{ marginTop: 5 }}
               onClick={() => {
-                // TODO: add modal with confirmation
-                this._updateDeployment({ peliasSynonymsBase64: null })
+                this.refs.confirm.open({
+                  title: `Are you sure you want to remove this file?`,
+                  body: 'This is irreversible',
+                  onConfirm: () => {
+                    this._updateDeployment({ peliasSynonymsBase64: null })
+                  }
+                })
               }}
             >
               Remove Synonyms File
             </Button>
+            <ConfirmModal ref='confirm' />
           </ListGroupItem>
         </ListGroup>
       </Panel>

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -139,6 +139,16 @@ componentDidUpdate = (newProps) => {
     }
   }
 
+  _onCustomNameCancel = () => {
+    this.refs.confirm.open({
+      title: `Are you sure you want to remove this file?`,
+      body: 'This is irreversible',
+      onConfirm: () => {
+        this._updateDeployment({ peliasSynonymsBase64: null })
+      }
+    })
+  }
+
   /**
    * Takes files submitted via the file uploader modal and sends them to datatools server where they are
    * uploaded to S3
@@ -354,9 +364,9 @@ componentDidUpdate = (newProps) => {
             />
             <div>
               <Button
-                style={{ marginTop: 15 }}
                 disabled={peliasButtonsDisabled}
                 onClick={() => this.refs.uploadSynonymsModal.open()}
+                style={{ marginTop: 15 }}
               >
                 {deployment.peliasSynonymsBase64 ? 'Replace' : 'Upload'} Synonyms File
               </Button>
@@ -364,16 +374,9 @@ componentDidUpdate = (newProps) => {
                 <span style={{paddingLeft: '1ch'}}>Synonyms file currently loaded</span>}
             </div>
             <Button
+              disabled={peliasButtonsDisabled || !deployment.peliasSynonymsBase64}
               style={{ marginTop: 5 }}
-              onClick={() => {
-                this.refs.confirm.open({
-                  title: `Are you sure you want to remove this file?`,
-                  body: 'This is irreversible',
-                  onConfirm: () => {
-                    this._updateDeployment({ peliasSynonymsBase64: null })
-                  }
-                })
-              }}
+              onClick={this._onCustomNameCancel}
             >
               Remove Synonyms File
             </Button>

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -125,6 +125,9 @@ class PeliasPanel extends Component<Props, State> {
      const file = files[0]
 
      if (!file) return false
+     if (file.type !== 'text/plain') {
+       return false
+     }
 
      // Attempt base64 encode
      const toBase64 = file => new Promise((resolve, reject) => {
@@ -294,7 +297,7 @@ class PeliasPanel extends Component<Props, State> {
             <div>Upload your synonyms file here</div>
             <SelectFileModal
               body='Select a synonms file to upload:'
-              errorMessage='Selected file was invalid.'
+              errorMessage='Selected file was invalid. It must be a plain text file.'
               onConfirm={async (files) => this._onConfirmSynonymsUpload(files)}
               ref='uploadSynonymsModal'
               title='Upload Synonyms File'

--- a/lib/manager/components/deployment/PeliasPanel.js
+++ b/lib/manager/components/deployment/PeliasPanel.js
@@ -115,6 +115,36 @@ class PeliasPanel extends Component<Props, State> {
     return uploadSuccess
   }
 
+   /**
+    * Takes files submitted via the file uploader modal and encodes it to base64, then
+    * adds it to the deployment object
+    * @param files Array of files returned by the file upload henmodal
+    * @returns     True or false depending on if the upload was a success
+    */
+   _onConfirmSynonymsUpload = async (files: Array<File>) => {
+     const file = files[0]
+
+     if (!file) return false
+
+     // Attempt base64 encode
+     const toBase64 = file => new Promise((resolve, reject) => {
+       const reader = new FileReader()
+       reader.readAsDataURL(file)
+       reader.onload = () => resolve(reader.result)
+       reader.onerror = reject
+     })
+
+     try {
+       const encoded = await toBase64(file)
+       this._updateDeployment({
+         peliasSynonymsBase64: encoded
+       })
+       return true
+     } catch {
+       return false
+     }
+   }
+
   /**
    * Removes a csv file from the list of Pelias csv files associated with a deployment
    * WARNING: DOES NOT REMOVE THE FILE FROM S3!
@@ -191,14 +221,22 @@ class PeliasPanel extends Component<Props, State> {
 
     return (
       <Panel>
-        <Panel.Heading><Panel.Title componentClass='h3'>
-          <Icon type='map-marker' /> Local Places Index Settings
-        </Panel.Title></Panel.Heading>
+        <Panel.Heading>
+          <Panel.Title componentClass='h3'>
+            <Icon type='map-marker' /> Local Places Index Settings
+          </Panel.Title>
+        </Panel.Heading>
         <ListGroup>
           <ListGroupItem>
-            <ButtonToolbar style={{display: 'flex', flexDirection: 'row'}}>
+            <ButtonToolbar style={{ display: 'flex', flexDirection: 'row' }}>
               <h5>Local Places Index</h5>
-              <ButtonGroup title={peliasButtonsDisabled ? 'Local Places Index can only be updated if there is a running OTP instance' : ''}>
+              <ButtonGroup
+                title={
+                  peliasButtonsDisabled
+                    ? 'Local Places Index can only be updated if there is a running OTP instance'
+                    : ''
+                }
+              >
                 {/* If there are no deployments don't allow user to update Pelias yet */}
                 <Button
                   disabled={peliasButtonsDisabled}
@@ -209,7 +247,9 @@ class PeliasPanel extends Component<Props, State> {
                 <Button
                   disabled={peliasButtonsDisabled}
                   onClick={() => this.refs.reInitPeliasModal.open()}
-                >Reset</Button>
+                >
+                  Reset
+                </Button>
               </ButtonGroup>
             </ButtonToolbar>
             <ConfirmModal
@@ -219,9 +259,12 @@ class PeliasPanel extends Component<Props, State> {
               title='Are you sure you want to rebuild the Local Places Index database?'
             />
           </ListGroupItem>
-          <ListGroupItem >
+          <ListGroupItem>
             <h5>Custom Point Of Interest CSV Files</h5>
-            <p>These files are sent to the Local Places Index when it is updated or reset</p>
+            <p>
+              These files are sent to the Local Places Index when it is updated
+              or reset
+            </p>
             <SelectFileModal
               body='Select a CSV file of local places/points of interest to upload:'
               errorMessage='Uploaded file must be a valid csv file (.csv).'
@@ -244,6 +287,36 @@ class PeliasPanel extends Component<Props, State> {
               style={{ marginTop: '5px' }}
             >
               Upload New CSV File
+            </Button>
+          </ListGroupItem>
+          <ListGroupItem>
+            <h5>Synonyms File</h5>
+            <div>Upload your synonyms file here</div>
+            <SelectFileModal
+              body='Select a synonms file to upload:'
+              errorMessage='Selected file was invalid.'
+              onConfirm={async (files) => this._onConfirmSynonymsUpload(files)}
+              ref='uploadSynonymsModal'
+              title='Upload Synonyms File'
+            />
+            <div>
+              <Button
+                disabled={peliasButtonsDisabled}
+                onClick={() => this.refs.uploadSynonymsModal.open()}
+              >
+                Upload Synonyms File
+              </Button>
+              {deployment.peliasSynonymsBase64 &&
+                <span style={{paddingLeft: '1ch'}}>Synonyms file currently loaded</span>}
+            </div>
+            <Button
+              style={{ marginTop: 5 }}
+              onClick={() => {
+                // TODO: add modal with confirmation
+                this._updateDeployment({ peliasSynonymsBase64: null })
+              }}
+            >
+              Remove Synonyms File
             </Button>
           </ListGroupItem>
         </ListGroup>

--- a/lib/manager/containers/__tests__/__snapshots__/DeploymentsPanel.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/DeploymentsPanel.js.snap
@@ -130,6 +130,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
             "otpVersion": null,
             "peliasCsvFiles": Array [],
             "peliasResetDb": null,
+            "peliasSynonymsBase64": null,
             "peliasUpdate": null,
             "pinnedfeedVersionIds": Array [],
             "projectBounds": Object {
@@ -165,6 +166,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
             "otpVersion": null,
             "peliasCsvFiles": Array [],
             "peliasResetDb": null,
+            "peliasSynonymsBase64": null,
             "peliasUpdate": null,
             "pinnedfeedVersionIds": Array [],
             "projectBounds": Object {
@@ -369,6 +371,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
               "otpVersion": null,
               "peliasCsvFiles": Array [],
               "peliasResetDb": null,
+              "peliasSynonymsBase64": null,
               "peliasUpdate": null,
               "pinnedfeedVersionIds": Array [],
               "projectBounds": Object {
@@ -404,6 +407,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
               "otpVersion": null,
               "peliasCsvFiles": Array [],
               "peliasResetDb": null,
+              "peliasSynonymsBase64": null,
               "peliasUpdate": null,
               "pinnedfeedVersionIds": Array [],
               "projectBounds": Object {
@@ -665,6 +669,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                       "otpVersion": null,
                       "peliasCsvFiles": Array [],
                       "peliasResetDb": null,
+                      "peliasSynonymsBase64": null,
                       "peliasUpdate": null,
                       "pinnedfeedVersionIds": Array [],
                       "projectBounds": Object {
@@ -700,6 +705,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                       "otpVersion": null,
                       "peliasCsvFiles": Array [],
                       "peliasResetDb": null,
+                      "peliasSynonymsBase64": null,
                       "peliasUpdate": null,
                       "pinnedfeedVersionIds": Array [],
                       "projectBounds": Object {
@@ -830,6 +836,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                         "otpVersion": null,
                         "peliasCsvFiles": Array [],
                         "peliasResetDb": null,
+                        "peliasSynonymsBase64": null,
                         "peliasUpdate": null,
                         "pinnedfeedVersionIds": Array [],
                         "projectBounds": Object {
@@ -865,6 +872,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                         "otpVersion": null,
                         "peliasCsvFiles": Array [],
                         "peliasResetDb": null,
+                        "peliasSynonymsBase64": null,
                         "peliasUpdate": null,
                         "pinnedfeedVersionIds": Array [],
                         "projectBounds": Object {
@@ -1185,6 +1193,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                   "otpVersion": null,
                                   "peliasCsvFiles": Array [],
                                   "peliasResetDb": null,
+                                  "peliasSynonymsBase64": null,
                                   "peliasUpdate": null,
                                   "pinnedfeedVersionIds": Array [],
                                   "projectBounds": Object {
@@ -1315,6 +1324,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                       "otpVersion": null,
                                       "peliasCsvFiles": Array [],
                                       "peliasResetDb": null,
+                                      "peliasSynonymsBase64": null,
                                       "peliasUpdate": null,
                                       "pinnedfeedVersionIds": Array [],
                                       "projectBounds": Object {
@@ -1350,6 +1360,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                       "otpVersion": null,
                                       "peliasCsvFiles": Array [],
                                       "peliasResetDb": null,
+                                      "peliasSynonymsBase64": null,
                                       "peliasUpdate": null,
                                       "pinnedfeedVersionIds": Array [],
                                       "projectBounds": Object {
@@ -1596,6 +1607,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                   "otpVersion": null,
                                   "peliasCsvFiles": Array [],
                                   "peliasResetDb": null,
+                                  "peliasSynonymsBase64": null,
                                   "peliasUpdate": null,
                                   "pinnedfeedVersionIds": Array [],
                                   "projectBounds": Object {
@@ -1726,6 +1738,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                       "otpVersion": null,
                                       "peliasCsvFiles": Array [],
                                       "peliasResetDb": null,
+                                      "peliasSynonymsBase64": null,
                                       "peliasUpdate": null,
                                       "pinnedfeedVersionIds": Array [],
                                       "projectBounds": Object {
@@ -1761,6 +1774,7 @@ exports[`lib > manager > DeploymentsPanel should render with the list of deploym
                                       "otpVersion": null,
                                       "peliasCsvFiles": Array [],
                                       "peliasResetDb": null,
+                                      "peliasSynonymsBase64": null,
                                       "peliasUpdate": null,
                                       "pinnedfeedVersionIds": Array [],
                                       "projectBounds": Object {

--- a/lib/manager/containers/__tests__/__snapshots__/FeedSourceTable.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/FeedSourceTable.js.snap
@@ -129,6 +129,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
             "otpVersion": null,
             "peliasCsvFiles": Array [],
             "peliasResetDb": null,
+            "peliasSynonymsBase64": null,
             "peliasUpdate": null,
             "pinnedfeedVersionIds": Array [],
             "projectBounds": Object {
@@ -431,6 +432,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
               "otpVersion": null,
               "peliasCsvFiles": Array [],
               "peliasResetDb": null,
+              "peliasSynonymsBase64": null,
               "peliasUpdate": null,
               "pinnedfeedVersionIds": Array [],
               "projectBounds": Object {
@@ -727,6 +729,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                               "otpVersion": null,
                               "peliasCsvFiles": Array [],
                               "peliasResetDb": null,
+                              "peliasSynonymsBase64": null,
                               "peliasUpdate": null,
                               "pinnedfeedVersionIds": Array [],
                               "projectBounds": Object {
@@ -956,6 +959,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                 "otpVersion": null,
                                 "peliasCsvFiles": Array [],
                                 "peliasResetDb": null,
+                                "peliasSynonymsBase64": null,
                                 "peliasUpdate": null,
                                 "pinnedfeedVersionIds": Array [],
                                 "projectBounds": Object {
@@ -3084,6 +3088,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                               "otpVersion": null,
                               "peliasCsvFiles": Array [],
                               "peliasResetDb": null,
+                              "peliasSynonymsBase64": null,
                               "peliasUpdate": null,
                               "pinnedfeedVersionIds": Array [],
                               "projectBounds": Object {
@@ -3359,6 +3364,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                 "otpVersion": null,
                                 "peliasCsvFiles": Array [],
                                 "peliasResetDb": null,
+                                "peliasSynonymsBase64": null,
                                 "peliasUpdate": null,
                                 "pinnedfeedVersionIds": Array [],
                                 "projectBounds": Object {
@@ -3687,6 +3693,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                       "otpVersion": null,
                                       "peliasCsvFiles": Array [],
                                       "peliasResetDb": null,
+                                      "peliasSynonymsBase64": null,
                                       "peliasUpdate": null,
                                       "pinnedfeedVersionIds": Array [],
                                       "projectBounds": Object {
@@ -4089,6 +4096,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                                     "otpVersion": null,
                                                     "peliasCsvFiles": Array [],
                                                     "peliasResetDb": null,
+                                                    "peliasSynonymsBase64": null,
                                                     "peliasUpdate": null,
                                                     "pinnedfeedVersionIds": Array [],
                                                     "projectBounds": Object {
@@ -4509,6 +4517,7 @@ exports[`lib > manager > FeedSourceTable should render with a project with feeds
                                       "otpVersion": null,
                                       "peliasCsvFiles": Array [],
                                       "peliasResetDb": null,
+                                      "peliasSynonymsBase64": null,
                                       "peliasUpdate": null,
                                       "pinnedfeedVersionIds": Array [],
                                       "projectBounds": Object {

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -264,6 +264,7 @@ export type Deployment = {
   otpVersion: ?string,
   peliasCsvFiles: ?Array<string>,
   peliasResetDb: ?boolean,
+  peliasSynonymsBase64: ?string,
   peliasUpdate: ?boolean,
   pinnedfeedVersionIds: Array<string>,
   projectBounds: Bounds,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

- [x] e2e tests are all passing _(remove this if not merging to master)_

### Description

This PR adds support for datatools to keep track of a Pelias custom_name.txt file. Along with https://github.com/ibi-group/datatools-server/pull/547

At the moment, we base64 encode the file.