### PR TITLE
Allow exception range overlap

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -324,9 +324,10 @@ components:
     dateRemoved: ⓘ Date has been removed. Date entered is already included in an existing range or single date!
     selectDate: Select date
   ExceptionDateRange:
-    andOtherErrors: ...and %errors% other errors
     deleteEndDate: Delete end date
     deleteRange: Delete range
+  ExceptionValidationErrorsList: 
+    andOtherErrors: ...and %errors% other errors
   FeedFetchFrequency:
     DAYS: days
     fetchFeedEvery: Fetch feed every

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -322,7 +322,6 @@ components:
   ExceptionDateRange:
     deleteEndDate: Delete end date
     deleteRange: Delete range
-    overlapError: One or more dates between %startDate% and %endDate% appears in another schedule exception. Please choose another date.
   FeedFetchFrequency:
     DAYS: days
     fetchFeedEvery: Fetch feed every
@@ -1375,6 +1374,23 @@ components:
       custom: Custom
       noAccess: No Access
     save: Save
+  Validation:
+    agencyRequired: Field must be populated for feeds with more than one agency.
+    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (&serviceId%) combination cannot appear more than once for all exceptions
+    idMustBeUnique: Identifier must be unique
+    idRequired: Identifier is required if more than one agency exists
+    invalidEmail: Field must contain valid email address.
+    invalidLatitude: Field must be valid latitude.
+    invalidLongitude: Field must be valid longitude.
+    invalidRouteType: Field must be a valid route type
+    invalidUrl: Field must contain valid URL.
+    latLonRequired: Latitude and Longitude are required for your current location type.
+    mustBePositiveNumber: Field must be a positive number
+    mustBeValidNumber: Field must be a valid number
+    nameAlreadyUsed: "%name% is already used in another exception"
+    serviceRequired: Calendar must have service for at least one day
+    stopNameRequired: Stop name is required for stop, station, and entrance location types.
+    requiredFieldEmpty: Required field must not be empty
   VersionButtonToolbar:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
     confirmLoad: 'This will override all active GTFS Editor data for this Feed Source with the data from this version. If there is unsaved work in the Editor you want to keep, you must snapshot the current Editor data first. Are you sure you want to continue?'

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1382,22 +1382,22 @@ components:
     save: Save
   Validation:
     agencyRequired: Field must be populated for feeds with more than one agency.
-    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (%serviceId%) combination cannot appear more than once for all exceptions
-    idMustBeUnique: Identifier must be unique
-    idRequired: Identifier is required if more than one agency exists
+    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (%serviceId%) combination cannot appear more than once for all exceptions.
+    idMustBeUnique: Identifier must be unique.
+    idRequired: Identifier is required if more than one agency exists.
     invalidEmail: Field must contain valid email address.
     invalidLatitude: Field must be valid latitude.
     invalidLongitude: Field must be valid longitude.
-    invalidRouteType: Field must be a valid route type
+    invalidRouteType: Field must be a valid route type.
     invalidUrl: Field must contain valid URL.
     latLonRequired: Latitude and Longitude are required for your current location type.
-    mustBePositiveInteger: Field must be a positive integer
-    mustBePositiveNumber: Field must be a positive number
-    mustBeValidNumber: Field must be a valid number
-    nameAlreadyUsed: "%name% is already used in another exception"
-    serviceRequired: Calendar must have service for at least one day
+    mustBePositiveInteger: Field must be a positive integer.
+    mustBePositiveNumber: Field must be a positive number.
+    mustBeValidNumber: Field must be a valid number.
+    nameAlreadyUsed: "%name% is already used in another exception,"
+    serviceRequired: Calendar must have service for at least one day.
     stopNameRequired: Stop name is required for stop, station, and entrance location types.
-    requiredFieldEmpty: Required field must not be empty
+    requiredFieldEmpty: Required field must not be empty.
   VersionButtonToolbar:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
     confirmLoad: 'This will override all active GTFS Editor data for this Feed Source with the data from this version. If there is unsaved work in the Editor you want to keep, you must snapshot the current Editor data first. Are you sure you want to continue?'

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -319,6 +319,10 @@ components:
     createStop: Right-click a location on map to create a new stop
     editSchedules: Edit schedules
     name: Name
+  ExceptionDate: 
+    addRange: Add range
+    dateRemoved: ⓘ Date has been removed. Date entered is already included in an existing range or single date!
+    selectDate: Select date
   ExceptionDateRange:
     andOtherErrors: ...and %errors% other errors
     deleteEndDate: Delete end date

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1385,6 +1385,7 @@ components:
     invalidRouteType: Field must be a valid route type
     invalidUrl: Field must contain valid URL.
     latLonRequired: Latitude and Longitude are required for your current location type.
+    mustBePositiveInteger: Field must be a positive integer
     mustBePositiveNumber: Field must be a positive number
     mustBeValidNumber: Field must be a valid number
     nameAlreadyUsed: "%name% is already used in another exception"

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -319,6 +319,10 @@ components:
     createStop: Right-click a location on map to create a new stop
     editSchedules: Edit schedules
     name: Name
+  ExceptionDateRange:
+    deleteEndDate: Delete end date
+    deleteRange: Delete range
+    overlapError: One or more dates between %startDate% and %endDate% appears in another schedule exception. Please choose another date.
   FeedFetchFrequency:
     DAYS: days
     fetchFeedEvery: Fetch feed every

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -320,6 +320,7 @@ components:
     editSchedules: Edit schedules
     name: Name
   ExceptionDateRange:
+    andOtherErrors: ...and %errors% other errors
     deleteEndDate: Delete end date
     deleteRange: Delete range
   FeedFetchFrequency:
@@ -1376,7 +1377,7 @@ components:
     save: Save
   Validation:
     agencyRequired: Field must be populated for feeds with more than one agency.
-    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (&serviceId%) combination cannot appear more than once for all exceptions
+    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (%serviceId%) combination cannot appear more than once for all exceptions
     idMustBeUnique: Identifier must be unique
     idRequired: Identifier is required if more than one agency exists
     invalidEmail: Field must contain valid email address.

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1406,22 +1406,22 @@ components:
     save: Speichern
   Validation:
     agencyRequired: Field must be populated for feeds with more than one agency.
-    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (%serviceId%) combination cannot appear more than once for all exceptions
-    idMustBeUnique: Identifier must be unique
-    idRequired: Identifier is required if more than one agency exists
+    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (%serviceId%) combination cannot appear more than once for all exceptions.
+    idMustBeUnique: Identifier must be unique.
+    idRequired: Identifier is required if more than one agency exists.
     invalidEmail: Field must contain valid email address.
     invalidLatitude: Field must be valid latitude.
     invalidLongitude: Field must be valid longitude.
-    invalidRouteType: Field must be a valid route type
+    invalidRouteType: Field must be a valid route type.
     invalidUrl: Field must contain valid URL.
     latLonRequired: Latitude and Longitude are required for your current location type.
-    mustBePositiveInteger: Field must be a positive integer
-    mustBePositiveNumber: Field must be a positive number
-    mustBeValidNumber: Field must be a valid number
-    nameAlreadyUsed: "%name% is already used in another exception"
-    serviceRequired: Calendar must have service for at least one day
+    mustBePositiveInteger: Field must be a positive integer.
+    mustBePositiveNumber: Field must be a positive number.
+    mustBeValidNumber: Field must be a valid number.
+    nameAlreadyUsed: "%name% is already used in another exception."
+    serviceRequired: Calendar must have service for at least one day.
     stopNameRequired: Stop name is required for stop, station, and entrance location types.
-    requiredFieldEmpty: Required field must not be empty
+    requiredFieldEmpty: Required field must not be empty.
   VersionButtonToolbar:
     confirmDelete: Sind Sie sicher, dass sie diese Version endgültig löschen möchten?
     confirmLoad: Dies wird alle aktiven GTFS Editor Daten dieser Feed-Quelle mit den

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -333,6 +333,7 @@ components:
     editSchedules: Abfahrzeiten erstellen
     name: Name
   ExceptionDateRange: 
+    andOtherErrors: ...and %errors% other errors
     deleteEndDate: Delete end date
     deleteRange: Delete range
   FeedActionsDropdown:
@@ -1399,7 +1400,7 @@ components:
     save: Speichern
   Validation:
     agencyRequired: Field must be populated for feeds with more than one agency.
-    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (&serviceId%) combination cannot appear more than once for all exceptions
+    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (%serviceId%) combination cannot appear more than once for all exceptions
     idMustBeUnique: Identifier must be unique
     idRequired: Identifier is required if more than one agency exists
     invalidEmail: Field must contain valid email address.

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1408,6 +1408,7 @@ components:
     invalidRouteType: Field must be a valid route type
     invalidUrl: Field must contain valid URL.
     latLonRequired: Latitude and Longitude are required for your current location type.
+    mustBePositiveInteger: Field must be a positive integer
     mustBePositiveNumber: Field must be a positive number
     mustBeValidNumber: Field must be a valid number
     nameAlreadyUsed: "%name% is already used in another exception"

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -340,6 +340,8 @@ components:
     andOtherErrors: ...and %errors% other errors
     deleteEndDate: Delete end date
     deleteRange: Delete range
+  ExceptionValidationErrorsList: 
+    andOtherErrors: ...and %errors% other errors
   FeedActionsDropdown:
     delete: Löschen
     deleteFeedSource: Feed-Quelle löschen?

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -332,6 +332,9 @@ components:
       auf eine Örtlickeit in der Karte
     editSchedules: Abfahrzeiten erstellen
     name: Name
+  ExceptionDateRange: 
+    deleteEndDate: Delete end date
+    deleteRange: Delete range
   FeedActionsDropdown:
     delete: Löschen
     deleteFeedSource: Feed-Quelle löschen?
@@ -1394,6 +1397,23 @@ components:
       custom: Benutzerdefiniert
       noAccess: Kein Zugriff
     save: Speichern
+  Validation:
+    agencyRequired: Field must be populated for feeds with more than one agency.
+    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (&serviceId%) combination cannot appear more than once for all exceptions
+    idMustBeUnique: Identifier must be unique
+    idRequired: Identifier is required if more than one agency exists
+    invalidEmail: Field must contain valid email address.
+    invalidLatitude: Field must be valid latitude.
+    invalidLongitude: Field must be valid longitude.
+    invalidRouteType: Field must be a valid route type
+    invalidUrl: Field must contain valid URL.
+    latLonRequired: Latitude and Longitude are required for your current location type.
+    mustBePositiveNumber: Field must be a positive number
+    mustBeValidNumber: Field must be a valid number
+    nameAlreadyUsed: "%name% is already used in another exception"
+    serviceRequired: Calendar must have service for at least one day
+    stopNameRequired: Stop name is required for stop, station, and entrance location types.
+    requiredFieldEmpty: Required field must not be empty
   VersionButtonToolbar:
     confirmDelete: Sind Sie sicher, dass sie diese Version endgültig löschen möchten?
     confirmLoad: Dies wird alle aktiven GTFS Editor Daten dieser Feed-Quelle mit den

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -332,6 +332,10 @@ components:
       auf eine Örtlickeit in der Karte
     editSchedules: Abfahrzeiten erstellen
     name: Name
+  ExceptionDate: 
+    addRange: Add range
+    dateRemoved: ⓘ Date has been removed. Date entered is already included in an existing range or single date!
+    selectDate: Select date
   ExceptionDateRange: 
     andOtherErrors: ...and %errors% other errors
     deleteEndDate: Delete end date

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -325,6 +325,9 @@ components:
     createStop: Right-click a location on map to create a new stop
     editSchedules: Edit schedules
     name: Name
+  ExceptionDateRange: 
+    deleteEndDate: Delete end date
+    deleteRange: Delete range
   FeedActionsDropdown:
     delete: Delete
     deleteFeedSource: Delete Feed Source?
@@ -1366,6 +1369,23 @@ components:
       custom: Custom
       noAccess: No Access
     save: Save
+  Validation:
+    agencyRequired: Field must be populated for feeds with more than one agency.
+    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (&serviceId%) combination cannot appear more than once for all exceptions
+    idMustBeUnique: Identifier must be unique
+    idRequired: Identifier is required if more than one agency exists
+    invalidEmail: Field must contain valid email address.
+    invalidLatitude: Field must be valid latitude.
+    invalidLongitude: Field must be valid longitude.
+    invalidRouteType: Field must be a valid route type
+    invalidUrl: Field must contain valid URL.
+    latLonRequired: Latitude and Longitude are required for your current location type.
+    mustBePositiveNumber: Field must be a positive number
+    mustBeValidNumber: Field must be a valid number
+    nameAlreadyUsed: "%name% is already used in another exception"
+    serviceRequired: Calendar must have service for at least one day
+    stopNameRequired: Stop name is required for stop, station, and entrance location types.
+    requiredFieldEmpty: Required field must not be empty
   VersionButtonToolbar:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
     confirmLoad: This will override all active GTFS Editor data for this Feed Source

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1378,22 +1378,22 @@ components:
     save: Save
   Validation:
     agencyRequired: Field must be populated for feeds with more than one agency.
-    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (%serviceId%) combination cannot appear more than once for all exceptions
-    idMustBeUnique: Identifier must be unique
-    idRequired: Identifier is required if more than one agency exists
+    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (%serviceId%) combination cannot appear more than once for all exceptions.
+    idMustBeUnique: Identifier must be unique.
+    idRequired: Identifier is required if more than one agency exists.
     invalidEmail: Field must contain valid email address.
     invalidLatitude: Field must be valid latitude.
     invalidLongitude: Field must be valid longitude.
-    invalidRouteType: Field must be a valid route type
+    invalidRouteType: Field must be a valid route type.
     invalidUrl: Field must contain valid URL.
     latLonRequired: Latitude and Longitude are required for your current location type.
-    mustBePositiveInteger: Field must be a positive integer
-    mustBePositiveNumber: Field must be a positive number
-    mustBeValidNumber: Field must be a valid number
-    nameAlreadyUsed: "%name% is already used in another exception"
-    serviceRequired: Calendar must have service for at least one day
+    mustBePositiveInteger: Field must be a positive integer.
+    mustBePositiveNumber: Field must be a positive number.
+    mustBeValidNumber: Field must be a valid number.
+    nameAlreadyUsed: "%name% is already used in another exception."
+    serviceRequired: Calendar must have service for at least one day.
     stopNameRequired: Stop name is required for stop, station, and entrance location types.
-    requiredFieldEmpty: Required field must not be empty
+    requiredFieldEmpty: Required field must not be empty.
   VersionButtonToolbar:
     confirmDelete: Are you sure you want to delete this version? This cannot be undone.
     confirmLoad: This will override all active GTFS Editor data for this Feed Source

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -325,6 +325,10 @@ components:
     createStop: Right-click a location on map to create a new stop
     editSchedules: Edit schedules
     name: Name
+  ExceptionDate: 
+    addRange: Add range
+    dateRemoved: ⓘ Date has been removed. Date entered is already included in an existing range or single date!
+    selectDate: Select date
   ExceptionDateRange: 
     andOtherErrors: ...and %errors% other errors
     deleteEndDate: Delete end date

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -326,6 +326,7 @@ components:
     editSchedules: Edit schedules
     name: Name
   ExceptionDateRange: 
+    andOtherErrors: ...and %errors% other errors
     deleteEndDate: Delete end date
     deleteRange: Delete range
   FeedActionsDropdown:
@@ -1371,7 +1372,7 @@ components:
     save: Save
   Validation:
     agencyRequired: Field must be populated for feeds with more than one agency.
-    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (&serviceId%) combination cannot appear more than once for all exceptions
+    dateServiceIdCombinationDuplicate: Date (%exceptionDate%) and Service ID (%serviceId%) combination cannot appear more than once for all exceptions
     idMustBeUnique: Identifier must be unique
     idRequired: Identifier is required if more than one agency exists
     invalidEmail: Field must contain valid email address.

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -333,6 +333,8 @@ components:
     andOtherErrors: ...and %errors% other errors
     deleteEndDate: Delete end date
     deleteRange: Delete range
+  ExceptionValidationErrorsList: 
+    andOtherErrors: ...and %errors% other errors
   FeedActionsDropdown:
     delete: Delete
     deleteFeedSource: Delete Feed Source?

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1380,6 +1380,7 @@ components:
     invalidRouteType: Field must be a valid route type
     invalidUrl: Field must contain valid URL.
     latLonRequired: Latitude and Longitude are required for your current location type.
+    mustBePositiveInteger: Field must be a positive integer
     mustBePositiveNumber: Field must be a positive number
     mustBeValidNumber: Field must be a valid number
     nameAlreadyUsed: "%name% is already used in another exception"

--- a/lib/editor/components/ExceptionDate.js
+++ b/lib/editor/components/ExceptionDate.js
@@ -13,6 +13,7 @@ import type {EditorValidationIssue} from '../util/validation'
 import { getComponentMessages } from '../../common/util/config'
 
 import {sortDates} from './ExceptionDateRange'
+import ExceptionValidationErrorsList from './ExceptionValidationErrorsList'
 
 type Props = {
   activeComponent: string,
@@ -163,9 +164,7 @@ export default class ExceptionDate extends Component<Props, State> {
         </Button>
         {validationState === 'error' && date
           ? <small style={{gridColumn: 'span 12'}}>
-            {validationErrors.map(err => {
-              return <div>{err.reason}</div>
-            })}
+            <ExceptionValidationErrorsList validationErrors={validationErrors} />
           </small>
           : null
         }

--- a/lib/editor/components/ExceptionDate.js
+++ b/lib/editor/components/ExceptionDate.js
@@ -10,6 +10,7 @@ import {toast} from 'react-toastify'
 import {updateActiveGtfsEntity} from '../actions/active'
 import type {ScheduleException} from '../../types'
 import type {EditorValidationIssue} from '../util/validation'
+import { getComponentMessages } from '../../common/util/config'
 
 import {sortDates} from './ExceptionDateRange'
 
@@ -34,6 +35,8 @@ export const inputStyleProps = {
 }
 
 export default class ExceptionDate extends Component<Props, State> {
+  messages = getComponentMessages('ExceptionDate')
+
   _addRange = () => {
     const {activeComponent, activeEntity, index, updateActiveGtfsEntity} = this.props
     const dates = [...activeEntity.dates]
@@ -63,7 +66,7 @@ export default class ExceptionDate extends Component<Props, State> {
     if (dates.some(date => date === newDate && date !== 'Invalid date')) {
       dates.splice(index, 1)
       toast.warn(
-        `ⓘ Date has been removed. Date entered is already included in an existing range or single date!`,
+        this.messages('dateRemoved'),
         {
           position: 'top-right',
           autoClose: 4000,
@@ -105,7 +108,7 @@ export default class ExceptionDate extends Component<Props, State> {
     }
 
     if (!date) {
-      dateTimeProps.defaultText = 'Select date'
+      dateTimeProps.defaultText = this.messages('selectDate')
     }
     return (
       <FormGroup
@@ -142,7 +145,7 @@ export default class ExceptionDate extends Component<Props, State> {
             padding: '4'
           }}
         >
-            Add range
+          {this.messages('addRange')}
         </Button>
         <Button
           bsStyle='danger'

--- a/lib/editor/components/ExceptionDate.js
+++ b/lib/editor/components/ExceptionDate.js
@@ -9,6 +9,7 @@ import {toast} from 'react-toastify'
 
 import {updateActiveGtfsEntity} from '../actions/active'
 import type {ScheduleException} from '../../types'
+import type {EditorValidationIssue} from '../util/validation'
 
 import {sortDates} from './ExceptionDateRange'
 
@@ -18,6 +19,7 @@ type Props = {
   date: number | string,
   index: number,
   updateActiveGtfsEntity: typeof updateActiveGtfsEntity,
+  validationErrors: Array<EditorValidationIssue>,
   validationState: string
 }
 
@@ -93,7 +95,7 @@ export default class ExceptionDate extends Component<Props, State> {
   }
 
   render () {
-    const {date, index, validationState} = this.props
+    const {date, index, validationErrors, validationState} = this.props
     const dateTimeProps = {
       mode: 'date',
       dateTime: date ? +moment(date) : undefined,
@@ -158,7 +160,9 @@ export default class ExceptionDate extends Component<Props, State> {
         </Button>
         {validationState === 'error' && date
           ? <small style={{gridColumn: 'span 12'}}>
-            {moment(date).format('MM/DD/YYYY')} appears in another schedule exception. Please choose another date.
+            {validationErrors.map(err => {
+              return <div>{err.reason}</div>
+            })}
           </small>
           : null
         }

--- a/lib/editor/components/ExceptionDateRange.js
+++ b/lib/editor/components/ExceptionDateRange.js
@@ -6,6 +6,7 @@ import DateTimeField from 'react-bootstrap-datetimepicker'
 import moment from 'moment'
 
 import {updateActiveGtfsEntity} from '../actions/active'
+import { getComponentMessages } from '../../common/util/config'
 import {modifyRangeOfDates, updateDates} from '../../common/util/exceptions'
 import type {ExceptionDate, ScheduleException, ScheduleExceptionDateRange} from '../../types'
 
@@ -27,6 +28,8 @@ type State = {
 export const sortDates = (dates: Array<ExceptionDate>): void => { dates.sort((a, b) => moment(a).diff(moment(b))) }
 
 export default class ExceptionDateRange extends Component<Props, State> {
+  messages = getComponentMessages('ExceptionDateRange')
+
   state = {
     forceErrorState: false
   }
@@ -169,13 +172,13 @@ export default class ExceptionDateRange extends Component<Props, State> {
             }}
             title={<i className='fa fa-times' />}
           >
-            <MenuItem eventKey='range'>Delete range</MenuItem>
-            <MenuItem eventKey='end-date'>Delete end date</MenuItem>
+            <MenuItem eventKey='range'>{this.messages('deleteRange')}</MenuItem>
+            <MenuItem eventKey='end-date'>{this.messages('deleteEndDate')}</MenuItem>
           </DropdownButton>
         </div>
         {validationState === 'error' && startMoment && endMoment
           ? <small style={{gridColumn: 'span 12'}}>
-            One or more dates between {startMoment.format('MM/DD/YYYY')} and {endMoment.format('MM/DD/YYYY')} appears in another schedule exception. Please choose another date.
+            {this.messages('overlapError').replace('%startDate%', startMoment.format('MM/DD/YYYY')).replace('%endDate%', endMoment.format('MM/DD/YYYY'))}
           </small>
           : null
         }

--- a/lib/editor/components/ExceptionDateRange.js
+++ b/lib/editor/components/ExceptionDateRange.js
@@ -9,6 +9,7 @@ import {updateActiveGtfsEntity} from '../actions/active'
 import { getComponentMessages } from '../../common/util/config'
 import {modifyRangeOfDates, updateDates} from '../../common/util/exceptions'
 import type {ExceptionDate, ScheduleException, ScheduleExceptionDateRange} from '../../types'
+import type {EditorValidationIssue} from '../util/validation'
 
 import {inputStyleProps} from './ExceptionDate'
 
@@ -18,6 +19,7 @@ type Props = {
   index: number,
   range: ScheduleExceptionDateRange,
   updateActiveGtfsEntity: typeof updateActiveGtfsEntity,
+  validationErrors: Array<EditorValidationIssue>,
   validationState: string
 }
 
@@ -102,7 +104,7 @@ export default class ExceptionDateRange extends Component<Props, State> {
   }
 
   render () {
-    const {index, range, validationState} = this.props
+    const {index, range, validationErrors, validationState} = this.props
     const endMoment = range.endDate ? moment(range.endDate) : moment(range.startDate).add(1, 'days')
     const startMoment = range.startDate ? moment(range.startDate) : undefined
 
@@ -178,7 +180,10 @@ export default class ExceptionDateRange extends Component<Props, State> {
         </div>
         {validationState === 'error' && startMoment && endMoment
           ? <small style={{gridColumn: 'span 12'}}>
-            {this.messages('overlapError').replace('%startDate%', startMoment.format('MM/DD/YYYY')).replace('%endDate%', endMoment.format('MM/DD/YYYY'))}
+            {/* TODO: limit the number of exceptions displayed to 3 or so... */}
+            {validationErrors.map(err => {
+              return <div>{err.reason}</div>
+            })}
           </small>
           : null
         }

--- a/lib/editor/components/ExceptionDateRange.js
+++ b/lib/editor/components/ExceptionDateRange.js
@@ -12,6 +12,7 @@ import type {ExceptionDate, ScheduleException, ScheduleExceptionDateRange} from 
 import type {EditorValidationIssue} from '../util/validation'
 
 import {inputStyleProps} from './ExceptionDate'
+import ExceptionValidationErrorsList from './ExceptionValidationErrorsList'
 
 type Props = {
   activeComponent: string,
@@ -26,8 +27,6 @@ type Props = {
 type State = {
   forceErrorState: boolean
 }
-
-const VALIDATION_ERROR_LIMIT = 3
 
 export const sortDates = (dates: Array<ExceptionDate>): void => { dates.sort((a, b) => moment(a).diff(moment(b))) }
 
@@ -182,14 +181,7 @@ export default class ExceptionDateRange extends Component<Props, State> {
         </div>
         {validationState === 'error' && startMoment && endMoment
           ? <small style={{gridColumn: 'span 12'}}>
-            {validationErrors.map((err, index) => {
-              if (index < VALIDATION_ERROR_LIMIT) return <div style={{color: 'darkred', margin: '5px 0px'}}>{err.reason}</div>
-            })}
-            {validationErrors.length - VALIDATION_ERROR_LIMIT > 0 && (
-              <div style={{color: 'darkred'}}>
-                {this.messages('andOtherErrors').replace('%errors%', (validationErrors.length - VALIDATION_ERROR_LIMIT).toString())}
-              </div>
-            )}
+            <ExceptionValidationErrorsList validationErrors={validationErrors} />
           </small>
           : null
         }

--- a/lib/editor/components/ExceptionDateRange.js
+++ b/lib/editor/components/ExceptionDateRange.js
@@ -27,6 +27,8 @@ type State = {
   forceErrorState: boolean
 }
 
+const VALIDATION_ERROR_LIMIT = 3
+
 export const sortDates = (dates: Array<ExceptionDate>): void => { dates.sort((a, b) => moment(a).diff(moment(b))) }
 
 export default class ExceptionDateRange extends Component<Props, State> {
@@ -180,10 +182,14 @@ export default class ExceptionDateRange extends Component<Props, State> {
         </div>
         {validationState === 'error' && startMoment && endMoment
           ? <small style={{gridColumn: 'span 12'}}>
-            {/* TODO: limit the number of exceptions displayed to 3 or so... */}
-            {validationErrors.map(err => {
-              return <div>{err.reason}</div>
+            {validationErrors.map((err, index) => {
+              if (index < VALIDATION_ERROR_LIMIT) return <div style={{color: 'darkred', margin: '5px 0px'}}>{err.reason}</div>
             })}
+            {validationErrors.length - VALIDATION_ERROR_LIMIT > 0 && (
+              <div style={{color: 'darkred'}}>
+                {this.messages('andOtherErrors').replace('%errors%', (validationErrors.length - VALIDATION_ERROR_LIMIT).toString())}
+              </div>
+            )}
           </small>
           : null
         }

--- a/lib/editor/components/ExceptionValidationErrorsList.js
+++ b/lib/editor/components/ExceptionValidationErrorsList.js
@@ -1,0 +1,28 @@
+// @flow
+
+import React from 'react'
+
+import { getComponentMessages } from '../../common/util/config'
+import type { EditorValidationIssue } from '../util/validation'
+
+const VALIDATION_ERROR_LIMIT = 3
+
+const ExceptionValidationErrorsList = (props: {validationErrors: Array<EditorValidationIssue>}) => {
+  const messages = getComponentMessages('ExceptionValidationErrorsList')
+  const { validationErrors } = props
+
+  return (
+    <div>
+      {validationErrors.map((err, index) => {
+        if (index < VALIDATION_ERROR_LIMIT) return <div style={{color: 'darkred', margin: '5px 0px'}}>{err.reason}</div>
+      })}
+      {validationErrors.length - VALIDATION_ERROR_LIMIT > 0 && (
+        <div style={{color: 'darkred'}}>
+          {messages('andOtherErrors').replace('%errors%', (validationErrors.length - VALIDATION_ERROR_LIMIT).toString())}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ExceptionValidationErrorsList

--- a/lib/editor/components/ExceptionValidationErrorsList.js
+++ b/lib/editor/components/ExceptionValidationErrorsList.js
@@ -7,21 +7,27 @@ import type { EditorValidationIssue } from '../util/validation'
 
 const VALIDATION_ERROR_LIMIT = 3
 
-const ExceptionValidationErrorsList = (props: {validationErrors: Array<EditorValidationIssue>}) => {
+const ExceptionValidationErrorsList = ({validationErrors}: {validationErrors: Array<EditorValidationIssue>}) => {
   const messages = getComponentMessages('ExceptionValidationErrorsList')
-  const { validationErrors } = props
+  const excessValidationErrors = validationErrors.length - VALIDATION_ERROR_LIMIT
 
   return (
-    <div>
+    <ul style={{listStyleType: 'none', paddingLeft: '0'}}>
       {validationErrors.map((err, index) => {
-        if (index < VALIDATION_ERROR_LIMIT) return <div style={{color: 'darkred', margin: '5px 0px'}}>{err.reason}</div>
+        if (index < VALIDATION_ERROR_LIMIT) {
+          return (
+            <li style={{color: 'darkred', margin: '5px 0px'}}>
+              {err.reason}
+            </li>
+          )
+        }
       })}
-      {validationErrors.length - VALIDATION_ERROR_LIMIT > 0 && (
-        <div style={{color: 'darkred'}}>
-          {messages('andOtherErrors').replace('%errors%', (validationErrors.length - VALIDATION_ERROR_LIMIT).toString())}
-        </div>
+      {excessValidationErrors > 0 && (
+        <li style={{color: 'darkred'}}>
+          {messages('andOtherErrors').replace('%errors%', excessValidationErrors.toString())}
+        </li>
       )}
-    </div>
+    </ul>
   )
 }
 

--- a/lib/editor/util/__tests__/validation.js
+++ b/lib/editor/util/__tests__/validation.js
@@ -43,7 +43,7 @@ describe('editor > util > gtfs >', () => {
         ).toEqual({
           field: 'stop_sequence',
           invalid: true,
-          reason: 'Required field must not be empty'
+          reason: 'Required field must not be empty.'
         })
       })
 
@@ -53,7 +53,7 @@ describe('editor > util > gtfs >', () => {
         ).toEqual({
           field: 'stop_sequence',
           invalid: true,
-          reason: 'Required field must not be empty'
+          reason: 'Required field must not be empty.'
         })
       })
 
@@ -69,7 +69,7 @@ describe('editor > util > gtfs >', () => {
         ).toEqual({
           field: 'stop_sequence',
           invalid: true,
-          reason: 'Field must be a valid number'
+          reason: 'Field must be a valid number.'
         })
       })
 
@@ -79,7 +79,7 @@ describe('editor > util > gtfs >', () => {
         ).toEqual({
           field: 'route_sort_order',
           invalid: true,
-          reason: 'Field must be a positive number'
+          reason: 'Field must be a positive number.'
         })
       })
 
@@ -95,7 +95,7 @@ describe('editor > util > gtfs >', () => {
         ).toEqual({
           field: 'route_sort_order',
           invalid: true,
-          reason: 'Field must be a positive integer'
+          reason: 'Field must be a positive integer.'
         })
       })
 
@@ -105,7 +105,7 @@ describe('editor > util > gtfs >', () => {
         ).toEqual({
           field: 'route_sort_order',
           invalid: true,
-          reason: 'Field must be a positive integer'
+          reason: 'Field must be a positive integer.'
         })
       })
 
@@ -115,7 +115,7 @@ describe('editor > util > gtfs >', () => {
         ).toEqual({
           field: 'route_sort_order',
           invalid: true,
-          reason: 'Field must be a positive integer'
+          reason: 'Field must be a positive integer.'
         })
       })
     })
@@ -127,7 +127,7 @@ describe('editor > util > gtfs >', () => {
         ).toEqual({
           field: 'shape_dist_traveled',
           invalid: true,
-          reason: 'Field must be a positive number'
+          reason: 'Field must be a positive number.'
         })
       })
 
@@ -151,7 +151,7 @@ describe('editor > util > gtfs >', () => {
         ).toEqual({
           field: 'route_type',
           invalid: true,
-          reason: 'Field must be a valid route type'
+          reason: 'Field must be a valid route type.'
         })
       })
 

--- a/lib/editor/util/validation.js
+++ b/lib/editor/util/validation.js
@@ -6,6 +6,7 @@ import validator from 'validator'
 
 import type {Entity, GtfsSpecField, ScheduleException} from '../../types'
 import type {EditorTables} from '../../types/reducers'
+import { getComponentMessages } from '../../common/util/config'
 
 import {getTableById} from './gtfs'
 
@@ -32,6 +33,7 @@ export function validate (
   entity: ?Entity,
   tableData: EditorTables
 ): EditorValidationIssue | false | Array<EditorValidationIssue> {
+  const messages = getComponentMessages('Validation') // TODO: move all strings to components, errors should use codes
   const {inputType, required, name} = field
   const valueDoesNotExist = doesNotExist(value)
   const isRequiredButEmpty = required && valueDoesNotExist
@@ -63,7 +65,7 @@ export function validate (
    * and has an empty value.
    */
   function emptyFieldValidationIssue (field = name) {
-    return validationIssue('Required field must not be empty', field)
+    return validationIssue(messages('requiredFieldEmpty'), field)
   }
 
   /**
@@ -84,14 +86,14 @@ export function validate (
     // make sure value is parseable to a number
     if (isNaN(num)) {
       return {
-        result: validationIssue('Field must be a valid number')
+        result: validationIssue(messages('mustBeValidNumber'))
       }
     }
 
     // make sure value is positive
     if (num < 0) {
       return {
-        result: validationIssue('Field must be a positive number')
+        result: validationIssue(messages('mustBePositiveNumber'))
       }
     }
 
@@ -118,7 +120,7 @@ export function validate (
     )
     if (!isValid) {
       return {
-        result: validationIssue('Field must be a valid route type')
+        result: validationIssue(messages('invalidRouteType'))
       }
     }
 
@@ -126,6 +128,14 @@ export function validate (
       num,
       result: false
     }
+  }
+
+  function getExceptionServiceIds (exception) {
+    return [
+      ...(exception.added_service || []),
+      ...(exception.removed_service || []),
+      ...(exception.custom_schedule || [])
+    ]
   }
 
   switch (inputType) {
@@ -153,12 +163,12 @@ export function validate (
         idList.length > 1 &&
         valueDoesNotExist
       ) {
-        return validationIssue('Identifier is required if more than one agency exists')
+        return validationIssue(messages('idRequired'))
       }
       if (isRequiredButEmpty) {
         return emptyFieldValidationIssue()
       } else if (isNotUnique) {
-        return validationIssue('Identifier must be unique')
+        return validationIssue(messages('idMustBeUnique'))
       } else {
         return false
       }
@@ -169,7 +179,7 @@ export function validate (
         locationType !== null &&
         (typeof locationType === 'number' && locationType <= 2)
       ) {
-        return validationIssue('Stop name is required for stop, station, and entrance location types.')
+        return validationIssue(messages('stopNameRequired'))
       }
       if (name === 'route_short_name' && !value && entity && entity.route_long_name) {
         return false
@@ -202,7 +212,7 @@ export function validate (
       if (isRequiredButEmpty) {
         return emptyFieldValidationIssue()
       } else if (isNotUrl) {
-        return validationIssue('Field must contain valid URL.')
+        return validationIssue(messages('invalidUrl'))
       } else {
         return false
       }
@@ -211,7 +221,7 @@ export function validate (
       if (isRequiredButEmpty) {
         return emptyFieldValidationIssue()
       } else if (isNotEmail) {
-        return validationIssue('Field must contain valid email address.')
+        return validationIssue(messages('invalidEmail'))
       } else {
         return false
       }
@@ -236,19 +246,19 @@ export function validate (
     case 'LATITUDE':
       const isNotLat = value > 90 || value < -90
       if (isNotLat) {
-        return validationIssue('Field must be valid latitude.')
+        return validationIssue(messages('invalidLatitude'))
       }
       if (isOptionalAndEmpty && locationType !== null && (typeof locationType === 'number' && locationType <= 2)) {
-        return validationIssue('Latitude and Longitude are required for your current location type')
+        return validationIssue(messages('latLonRequired'))
       }
       return false
     case 'LONGITUDE':
       const isNotLng = value > 180 || value < -180
       if (isNotLng) {
-        return validationIssue('Field must be valid longitude.')
+        return validationIssue(messages('invalidLongitude'))
       }
       if (isOptionalAndEmpty && typeof locationType === 'number' && locationType <= 2) {
-        return validationIssue('Latitude and Longitude are required for your current location type')
+        return validationIssue(messages('latLonRequired'))
       }
       return false
     case 'TIME':
@@ -257,7 +267,7 @@ export function validate (
       if (isRequiredButEmpty) {
         return emptyFieldValidationIssue()
       } else if (isNotANumber) {
-        return validationIssue('Field must be valid number')
+        return validationIssue(messages('mustBeValidNumber'))
       } else {
         return false
       }
@@ -279,7 +289,7 @@ export function validate (
       }
       if (!hasService && name === 'monday') {
         // only add validation issue for one day of week (monday)
-        return validationIssue('Calendar must have service for at least one day')
+        return validationIssue(messages('serviceRequired'))
       }
       return false
     case 'DROPDOWN':
@@ -298,13 +308,14 @@ export function validate (
         agencies.length > 1
       ) {
         if (valueDoesNotExist) {
-          return validationIssue('Field must be populated for feeds with more than one agency.')
+          return validationIssue(messages('agencyRequired'))
         }
       }
       return false
     case 'EXCEPTION_DATE': // a date cannot be selected more than once (for all exceptions)
       const valErrors = []
-      const dateMap = {}
+      const exceptionMap = {}
+      const entityServiceIds = []
       // Clone exceptions to avoid mutating table in store.
       const scheduleExceptions: Array<ScheduleException> = clone(getTableById(tableData, 'scheduleexception'))
       if (entity) {
@@ -313,21 +324,23 @@ export function validate (
         if (exceptionIndex !== -1) {
           scheduleExceptions.splice(exceptionIndex, 1)
         }
+        entityServiceIds.push(...getExceptionServiceIds(entity))
         const castedScheduleException: ScheduleException = ((entity: any): ScheduleException)
         if (scheduleExceptions.map(ex => ex.name).includes(castedScheduleException.name)) {
-          const reason = `"${castedScheduleException.name}" is already used in another exception`
+          const reason = messages('nameAlreadyUsed').replace('%name%', castedScheduleException.name)
           valErrors.push(validationIssue(reason, 'name'))
         }
-        scheduleExceptions.push(castedScheduleException)
       }
 
       for (let i = 0; i < scheduleExceptions.length; i++) {
-        if (scheduleExceptions[i].dates) {
+        const scheduleException = scheduleExceptions[i]
+        const serviceIds = getExceptionServiceIds(scheduleException)
+        if (serviceIds && scheduleExceptions[i].dates) {
           scheduleExceptions[i].dates.map(d => {
-            if (typeof dateMap[d] === 'undefined') {
-              dateMap[d] = []
+            if (typeof exceptionMap[d] === 'undefined') {
+              exceptionMap[d] = new Set()
             }
-            dateMap[d].push(scheduleExceptions[i].id)
+            serviceIds.forEach(s => exceptionMap[d].add(s))
           })
         }
       }
@@ -335,16 +348,23 @@ export function validate (
         valErrors.push(emptyFieldValidationIssue('dates'))
       }
       // check if date already exists in this or other exceptions
-      for (let i = 0; i < value.length; i++) {
-        const dateItemName = `dates-${i}`
-        if (dateMap[value[i]] && dateMap[value[i]].length > 1) {
-          // eslint-disable-next-line standard/computed-property-even-spacing
-          const reason = `Date (${value[
-            i
-          ]}) cannot appear more than once for all exceptions`
-          valErrors.push(validationIssue(reason, dateItemName))
-        } else if (!moment(value[i], 'YYYYMMDD', true).isValid()) {
-          valErrors.push(emptyFieldValidationIssue(dateItemName))
+      if (entityServiceIds) {
+        for (let i = 0; i < value.length; i++) {
+          const dateItemName = `dates-${i}`
+          const exceptionDate = value[i]
+          if (exceptionMap[exceptionDate]) {
+            entityServiceIds.forEach(s => {
+              if (exceptionMap[exceptionDate].has(s)) {
+                // eslint-disable-next-line standard/computed-property-even-spacing
+                const reason = messages('dateServiceIdCombinationDuplicate')
+                  .replace('%exceptionDate%', exceptionDate)
+                  .replace('%serviceId%', s)
+                valErrors.push(validationIssue(reason, dateItemName))
+              }
+            })
+          } else if (!moment(exceptionDate, 'YYYYMMDD', true).isValid()) {
+            valErrors.push(emptyFieldValidationIssue(dateItemName))
+          }
         }
       }
       return valErrors
@@ -364,7 +384,7 @@ export function validate (
           )
         )
       ) {
-        return validationIssue('Field must be a positive integer')
+        return validationIssue(messages('mustBePositiveNumber'))
       }
       return false
     case 'POSITIVE_NUM':

--- a/lib/editor/util/validation.js
+++ b/lib/editor/util/validation.js
@@ -384,7 +384,7 @@ export function validate (
           )
         )
       ) {
-        return validationIssue(messages('mustBePositiveNumber'))
+        return validationIssue(messages('mustBePositiveInteger'))
       }
       return false
     case 'POSITIVE_NUM':


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR is resolving an issue with exception ranges where creating overlapping exception ranges were forbidden because of duplicate dates. Previously, exceptions were being conceptualized as a single date with all modified service attached, but as we begin to allow more calendar_dates oriented cases like large ranges of service removal exceptions need to be conceptualized more as attached to a specific set of service IDs, rather than to that range of dates. 

An example of a use case for this is St. Lawrence Public Transit Company which runs university service and is looking to remove service during the summer months. However, they have two college services, both with a different period of outage (say e.g. July 1 - Sept 1 for one and Aug 1 - Oct 15 for another). These two exceptions could be broken up into the smaller overlapping subset which would be one range and the non-overlapping sections into two separate ranges, but this is harder for the user to manage. Thus, we look to allow the definition of ranges which overlap, but that affect different service IDs. 

Companion GTFS lib PR: https://github.com/conveyal/gtfs-lib/pull/387