### PR TITLE
Add auto assigning of trip IDs as option in TripSeriesModal

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1313,6 +1313,7 @@ components:
     tableDeleted: Table Deleted
     transformationsTitle: Transformations
   TripSeriesModal:
+    automaticallyUpdateTripIds: Automatically update Trip IDs for trips created in series?
     close: Close
     createTripSeriesBody: Enter the start and end time for the trip series (24 hour time) and headway between trips. Click generate to create the series of trips. 
     createTripSeriesQuestion: Create a series of trips
@@ -1320,6 +1321,10 @@ components:
     endTime: "End Time:"
     generateTrips: Generate Trips
     headway: "Headway:"
+    incrementAmountPlaceholder: Increment amount
+    incrementBy: inc. by
+    incrementStartPlaceholder: Increment start (default 0)
+    prefixPlaceholder: Trip ID prefix (optional)
     startTime: "Start Time:"
   UserAccount:
     account:

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1490,6 +1490,7 @@ components:
       pickupDropOffDefault: (Default - Available)
       pickupTitle: Define the pickup method/availability at this stop.
   TripSeriesModal:
+    automaticallyUpdateTripIds: Automatically update Trip IDs for trips created in series?
     close: Close
     createTripSeriesBody: Enter the start and end time for the trip series (24 hour
       time) and headway between trips. Click generate to create the series of trips.
@@ -1498,4 +1499,8 @@ components:
     endTime: "End Time:"
     generateTrips: Generate Trips
     headway: "Headway:"
+    incrementAmountPlaceholder: Increment amount
+    incrementBy: inc. by
+    incrementStartPlaceholder: Increment start (default 0)
+    prefixPlaceholder: Trip ID prefix (optional)
     startTime: "Start Time:"

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1461,6 +1461,7 @@ components:
       pickupDropOffDefault: (Default - Available)
       pickupTitle: Define the pickup method/availability at this stop.
   TripSeriesModal:
+    automaticallyUpdateTripIds: Automatically update Trip IDs for trips created in series?
     close: Close
     createTripSeriesBody: Enter the start and end time for the trip series (24 hour
       time) and headway between trips. Click generate to create the series of trips.
@@ -1469,4 +1470,8 @@ components:
     endTime: "End Time:"
     generateTrips: Generate Trips
     headway: "Headway:"
+    incrementAmountPlaceholder: Increment amount
+    incrementBy: inc. by
+    incrementStartPlaceholder: Increment start (default 0)
+    prefixPlaceholder: Trip ID prefix (optional)
     startTime: "Start Time:"

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -151,7 +151,7 @@ export default class TimetableEditor extends Component<Props, State> {
 
   cloneSelectedTrips = () => this.duplicateRows(this._getSelectedRowIndexes())
 
-  constructNewRow = (toClone: ?Trip = null, tripSeriesStartTime: ?number): ?Trip => {
+  constructNewRow = (toClone: ?Trip = null, tripSeriesStartTime: ?number, autoTripId: ?string): ?Trip => {
     const {activePatternId, route} = this.props
     const activePattern = route && route.tripPatterns
       ? route.tripPatterns.find(p => p.id === activePatternId)
@@ -228,7 +228,7 @@ export default class TimetableEditor extends Component<Props, State> {
       }
       // IMPORTANT: set id to NEW_ID
       objectPath.set(newRow, 'id', ENTITY.NEW_ID)
-      objectPath.set(newRow, 'tripId', null)
+      objectPath.set(newRow, 'tripId', autoTripId || null)
       objectPath.set(newRow, 'useFrequency', activePattern.useFrequency)
       if (activePattern.useFrequency) {
         // If a frequency-based trip, never use exact times. NOTE: there is no

--- a/lib/editor/components/timetable/TimetableHeader.js
+++ b/lib/editor/components/timetable/TimetableHeader.js
@@ -148,6 +148,7 @@ export default class TimetableHeader extends Component<Props> {
       props: {
         children: <Icon type='calendar-plus-o' />,
         'data-test-id': 'create-trip-series-button',
+        disabled: activePattern && activePattern.useFrequency,
         onClick: showTripSeriesModal
       }
     }, {

--- a/lib/editor/components/timetable/TripSeriesModal.js
+++ b/lib/editor/components/timetable/TripSeriesModal.js
@@ -21,12 +21,15 @@ const TripSeriesModal = (props: Props) => {
   const [endTime, setEndTime] = useState(null)
   const [useAutoTripIds, setUseAutoTripIds] = useState(false)
   const [autoTripIdStart, setAutoTripIdStart] = useState(0)
+  const [autoTripIdIncrement, setAutoTripIdIncrement] = useState(1)
   const [autoTripIdPrefix, setAutoTripIdPrefix] = useState('')
 
   const messages = getComponentMessages('TripSeriesModal')
 
-  const handleIncrementStartUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdStart(evt.target.value)
+  const handleIncrementStartUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdStart(+evt.target.value)
   const handleTripPrefixUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdPrefix(evt.target.value)
+  const handleTripIncrementUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdIncrement(+evt.target.value)
+  const handleCheckBox = () => setUseAutoTripIds(!useAutoTripIds)
 
   const onClickGenerate = useCallback(() => {
     const {addNewTrip, constructNewRow, onClose} = props
@@ -37,19 +40,18 @@ const TripSeriesModal = (props: Props) => {
     let tripId = autoTripIdStart
     for (let time = startTime; time <= adjustedEndTime; time += headway) {
       // If we're upating the trip IDs automatically, increment the trip ID:
-      addNewTrip(constructNewRow(null, time, useAutoTripIds ? autoTripIdPrefix + tripId : null))
-      if (useAutoTripIds) tripId++
+      addNewTrip(constructNewRow(null, time, useAutoTripIds ? `${autoTripIdPrefix}-${tripId}` : null))
+      if (useAutoTripIds) tripId += autoTripIdIncrement
     }
     setStartTime(null)
     setEndTime(null)
     setHeadway(null)
     onClose()
-  }, [endTime, startTime, headway])
+  }, [endTime, startTime, headway, autoTripIdStart, autoTripIdIncrement, autoTripIdPrefix])
 
   const {Body, Footer, Header, Title} = Modal
   const {onClose, show} = props
   const generateTripsDisabled = startTime === null || endTime === null || !headway
-
   return (
     <Modal show={show} onHide={onClose}>
       <Header><Title>{messages('createTripSeriesQuestion')}</Title></Header>
@@ -58,35 +60,40 @@ const TripSeriesModal = (props: Props) => {
         <div style={{
           display: 'flex',
           flexDirection: 'row'
-
         }}>
           <div>{messages('startTime')}<HourMinuteInput onChange={setStartTime} seconds={startTime} standaloneInput /></div>
           <div style={{margin: '0px 0px 0px 20px'}}>{messages('headway')} <HourMinuteInput onChange={setHeadway} seconds={headway} standaloneInput /></div>
           <div style={{margin: '0px 0px 0px 20px'}}>{messages('endTime')} <HourMinuteInput onChange={setEndTime} seconds={endTime} standaloneInput /></div>
         </div>
         <div>
-          <Checkbox checked={useAutoTripIds} onChange={() => setUseAutoTripIds(!useAutoTripIds)}>Automatically increment Trip IDs for trips created in series? </Checkbox>
+          <Checkbox checked={useAutoTripIds} onChange={handleCheckBox}>{messages('automaticallyUpdateTripIds')}</Checkbox>
           <div style={{
             alignItems: 'center',
-            display: 'flex',
-            flexDirection: 'row'
+            display: 'flex'
           }}>
             {useAutoTripIds &&
               <>
                 <FormControl
                   onChange={handleTripPrefixUpdate}
-                  placeholder='Trip ID prefix (optional)'
-                  style={{width: '40%', marginRight: '5px'}}
+                  placeholder={messages('prefixPlaceholder')}
+                  style={{width: '30%', marginRight: '5px'}}
                   type='text'
                 />
                 -
                 <FormControl
                   onChange={handleIncrementStartUpdate}
-                  placeholder='Increment start (default 0)'
-                  style={{width: '40%', marginLeft: '5px'}}
+                  placeholder={messages('incrementStartPlaceholder')}
+                  style={{width: '40%', marginLeft: '5px', marginRight: '5px'}}
                   type='number'
                 />
-
+                {messages('incrementBy')}
+                <FormControl
+                  onChange={handleTripIncrementUpdate}
+                  placeholder={messages('incrementAmountPlaceholder')}
+                  style={{width: '15%', marginLeft: '5px'}}
+                  type='number'
+                  value={autoTripIdIncrement}
+                />
               </>
             }
           </div>

--- a/lib/editor/components/timetable/TripSeriesModal.js
+++ b/lib/editor/components/timetable/TripSeriesModal.js
@@ -1,7 +1,7 @@
 // @flow
 // $FlowFixMe: Flow doesn't know about useState: https://stackoverflow.com/questions/53105954/cannot-import-usestate-because-there-is-no-usestate-export-in-react-flow-with
 import React, {useCallback, useState} from 'react'
-import {Button, Modal} from 'react-bootstrap'
+import {Button, Checkbox, FormControl, Modal} from 'react-bootstrap'
 
 import * as tripActions from '../../actions/trip'
 import {getComponentMessages} from '../../../common/util/config'
@@ -10,7 +10,7 @@ import type {Trip} from '../../../types'
 
 type Props = {
   addNewTrip: typeof tripActions.addNewTrip,
-  constructNewRow: (trip: ?Trip, tripSeriesStartTime: number) => ?Trip,
+  constructNewRow: (trip: ?Trip, tripSeriesStartTime: ?number, autoTripId: ?string) => ?Trip,
   onClose: () => void,
   show: boolean
 }
@@ -19,16 +19,26 @@ const TripSeriesModal = (props: Props) => {
   const [startTime, setStartTime] = useState(null)
   const [headway, setHeadway] = useState(null)
   const [endTime, setEndTime] = useState(null)
+  const [useAutoTripIds, setUseAutoTripIds] = useState(false)
+  const [autoTripIdStart, setAutoTripIdStart] = useState(0)
+  const [autoTripIdPrefix, setAutoTripIdPrefix] = useState('')
 
   const messages = getComponentMessages('TripSeriesModal')
+
+  const handleIncrementStartUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdStart(evt.target.value)
+  const handleTripPrefixUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdPrefix(evt.target.value)
 
   const onClickGenerate = useCallback(() => {
     const {addNewTrip, constructNewRow, onClose} = props
     // Check state variables to make flow happy
     if (startTime === null || endTime === null || headway === null) return
     const adjustedEndTime = startTime < endTime ? endTime : endTime + 24 * 60 * 60
+
+    let tripId = autoTripIdStart
     for (let time = startTime; time <= adjustedEndTime; time += headway) {
-      addNewTrip(constructNewRow(null, time))
+      // If we're upating the trip IDs automatically, increment the trip ID:
+      addNewTrip(constructNewRow(null, time, useAutoTripIds ? autoTripIdPrefix + tripId : null))
+      if (useAutoTripIds) tripId++
     }
     setStartTime(null)
     setEndTime(null)
@@ -39,14 +49,49 @@ const TripSeriesModal = (props: Props) => {
   const {Body, Footer, Header, Title} = Modal
   const {onClose, show} = props
   const generateTripsDisabled = startTime === null || endTime === null || !headway
+
   return (
     <Modal show={show} onHide={onClose}>
       <Header><Title>{messages('createTripSeriesQuestion')}</Title></Header>
       <Body>
         <p>{messages('createTripSeriesBody')}</p>
-        {messages('startTime')} <div><HourMinuteInput onChange={setStartTime} seconds={startTime} standaloneInput /></div>
-        {messages('headway')} <div><HourMinuteInput onChange={setHeadway} seconds={headway} standaloneInput /></div>
-        {messages('endTime')} <div><HourMinuteInput onChange={setEndTime} seconds={endTime} standaloneInput /></div>
+        <div style={{
+          display: 'flex',
+          flexDirection: 'row'
+
+        }}>
+          <div>{messages('startTime')}<HourMinuteInput onChange={setStartTime} seconds={startTime} standaloneInput /></div>
+          <div style={{margin: '0px 0px 0px 20px'}}>{messages('headway')} <HourMinuteInput onChange={setHeadway} seconds={headway} standaloneInput /></div>
+          <div style={{margin: '0px 0px 0px 20px'}}>{messages('endTime')} <HourMinuteInput onChange={setEndTime} seconds={endTime} standaloneInput /></div>
+        </div>
+        <div>
+          <Checkbox checked={useAutoTripIds} onChange={() => setUseAutoTripIds(!useAutoTripIds)}>Automatically increment Trip IDs for trips created in series? </Checkbox>
+          <div style={{
+            alignItems: 'center',
+            display: 'flex',
+            flexDirection: 'row'
+          }}>
+            {useAutoTripIds &&
+              <>
+                <FormControl
+                  onChange={handleTripPrefixUpdate}
+                  placeholder='Trip ID prefix (optional)'
+                  style={{width: '40%', marginRight: '5px'}}
+                  type='text'
+                />
+                -
+                <FormControl
+                  onChange={handleIncrementStartUpdate}
+                  placeholder='Increment start (default 0)'
+                  style={{width: '40%', marginLeft: '5px'}}
+                  type='number'
+                />
+
+              </>
+            }
+          </div>
+        </div>
+
       </Body>
       <Footer>
         <Button


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Some users have requested a tool to automatically assign trip IDs when using the `TripSeries` tool in the timetable editor. The most common use case is to increment the trip id by a number with each trip, which this PR introduces. 