### PR TITLE
Fix flex duration inputs

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -821,8 +821,13 @@ components:
   PatternStopCard:
     PatternStopContents:
       defaultDwellTime: Default dwell time
+      defaultTimeInLocation: Default time in location
       defaultTravelTime: Default travel time
       firstStopTravelTime: Travel time for first stop must be zero
+      meanDurationFactor: Mean Duration Factor
+      meanDurationOffset: Mean Duration Offset
+      safeDurationFactor: Safe Duration Factor
+      safeDurationOffset: Safe Duration Offset
       stopHeadsignPlaceholder: Outbound
       stopHeadsignText: Stop headsign
       stopHeadsignTitle: Headsign that overrides trip headsign between stops.

--- a/lib/editor/components/pattern/PatternStopCard.js
+++ b/lib/editor/components/pattern/PatternStopCard.js
@@ -397,12 +397,13 @@ class PatternStopContents extends Component<Props, State> {
     updatePatternStops(activePattern, patternStops)
   }
 
-  _onTextFieldChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+  _onNumberFieldChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     // FLEX TODO: Validation
     const {activePattern, index, updatePatternStops} = this.props
     // This can also include locations and location groups
     const patternStops = this.getPatternHaltsFromActivePattern()
-    patternStops[index][evt.target.id] = evt.target.value
+    patternStops[index][evt.target.id] = +evt.target.value
+    this.setState({update: true})
     updatePatternStops(activePattern, patternStops)
   }
 
@@ -599,7 +600,7 @@ class PatternStopContents extends Component<Props, State> {
         <Row>
           <Col xs={6}>
             <FormGroup bsSize='small'>
-              <ControlLabel className='small'>Default travel time</ControlLabel>
+              <ControlLabel className='small'>{patternStopCardMessages('PatternStopContents.defaultTravelTime')}</ControlLabel>
               <MinuteSecondInput
                 seconds={this.state.flexDefaultTravelTime}
                 onChange={(newValue) => this._onMinuteSecondInputChange(
@@ -611,7 +612,7 @@ class PatternStopContents extends Component<Props, State> {
           </Col>
           <Col xs={6}>
             <FormGroup bsSize='small'>
-              <ControlLabel className='small'>Default time in location</ControlLabel>
+              <ControlLabel className='small'>{patternStopCardMessages('PatternStopContents.defaultTimeInLocation')}</ControlLabel>
               <MinuteSecondInput
                 seconds={this.state.flexDefaultZoneTime}
                 onChange={(newValue) => this._onMinuteSecondInputChange(
@@ -626,20 +627,22 @@ class PatternStopContents extends Component<Props, State> {
         <Row>
           <Col xs={6}>
             <FormGroup controlId='meanDurationFactor'>
-              <ControlLabel className='small'>Mean Duration Factor</ControlLabel>
+              <ControlLabel className='small'>{patternStopCardMessages('PatternStopContents.meanDurationFactor')}</ControlLabel>
               <FormControl
-                value={this.state.meanDurationFactor}
-                onChange={this._onTextFieldChange}
+                // $FlowFixMe: Flow doesn't recognize type checks
+                value={patternStop.meanDurationFactor}
+                onChange={this._onNumberFieldChange}
                 type='number'
               />
             </FormGroup>
           </Col>
           <Col xs={6}>
             <FormGroup controlId='meanDurationOffset'>
-              <ControlLabel className='small'>Mean Duration Offset</ControlLabel>
+              <ControlLabel className='small'>{patternStopCardMessages('PatternStopContents.meanDurationOffset')}</ControlLabel>
               <FormControl
-                value={this.state.meanDurationOffset}
-                onChange={this._onTextFieldChange}
+                // $FlowFixMe: Flow doesn't recognize type checks
+                value={patternStop.meanDurationOffset}
+                onChange={this._onNumberFieldChange}
                 type='number'
               />
             </FormGroup>
@@ -648,20 +651,22 @@ class PatternStopContents extends Component<Props, State> {
         <Row>
           <Col xs={6}>
             <FormGroup controlId='safeDurationFactor'>
-              <ControlLabel className='small'>Safe Duration Factor</ControlLabel>
+              <ControlLabel className='small'>{patternStopCardMessages('PatternStopCardMessages.safeDurationFactor')}</ControlLabel>
               <FormControl
-                value={this.state.safeDurationFactor}
-                onChange={this._onTextFieldChange}
+                // $FlowFixMe: Flow doesn't recognize type checks
+                value={patternStop.safeDurationFactor}
+                onChange={this._onNumberFieldChange}
                 type='number'
               />
             </FormGroup>
           </Col>
           <Col xs={6}>
             <FormGroup controlId='safeDurationOffset'>
-              <ControlLabel className='small'>Safe Duration Offset</ControlLabel>
+              <ControlLabel className='small'>{patternStopCardMessages('PatternStopCardMessages.safeDurationOffset')}</ControlLabel>
               <FormControl
-                value={this.state.safeDurationOffset}
-                onChange={this._onTextFieldChange}
+                // $FlowFixMe: Flow doesn't recognize type checks
+                value={patternStop.safeDurationOffset}
+                onChange={this._onNumberFieldChange}
                 type='number'
               />
             </FormGroup>

--- a/lib/editor/components/pattern/PatternStopCard.js
+++ b/lib/editor/components/pattern/PatternStopCard.js
@@ -629,10 +629,10 @@ class PatternStopContents extends Component<Props, State> {
             <FormGroup controlId='meanDurationFactor'>
               <ControlLabel className='small'>{patternStopCardMessages('PatternStopContents.meanDurationFactor')}</ControlLabel>
               <FormControl
-                // $FlowFixMe: Flow doesn't recognize type checks
-                value={patternStop.meanDurationFactor}
                 onChange={this._onNumberFieldChange}
                 type='number'
+                // $FlowFixMe: Flow doesn't recognize type checks
+                value={patternStop.meanDurationFactor}
               />
             </FormGroup>
           </Col>
@@ -640,10 +640,10 @@ class PatternStopContents extends Component<Props, State> {
             <FormGroup controlId='meanDurationOffset'>
               <ControlLabel className='small'>{patternStopCardMessages('PatternStopContents.meanDurationOffset')}</ControlLabel>
               <FormControl
-                // $FlowFixMe: Flow doesn't recognize type checks
-                value={patternStop.meanDurationOffset}
                 onChange={this._onNumberFieldChange}
                 type='number'
+                // $FlowFixMe: Flow doesn't recognize type checks
+                value={patternStop.meanDurationOffset}
               />
             </FormGroup>
           </Col>
@@ -653,10 +653,10 @@ class PatternStopContents extends Component<Props, State> {
             <FormGroup controlId='safeDurationFactor'>
               <ControlLabel className='small'>{patternStopCardMessages('PatternStopCardMessages.safeDurationFactor')}</ControlLabel>
               <FormControl
-                // $FlowFixMe: Flow doesn't recognize type checks
-                value={patternStop.safeDurationFactor}
                 onChange={this._onNumberFieldChange}
                 type='number'
+                // $FlowFixMe: Flow doesn't recognize type checks
+                value={patternStop.safeDurationFactor}
               />
             </FormGroup>
           </Col>
@@ -664,10 +664,10 @@ class PatternStopContents extends Component<Props, State> {
             <FormGroup controlId='safeDurationOffset'>
               <ControlLabel className='small'>{patternStopCardMessages('PatternStopCardMessages.safeDurationOffset')}</ControlLabel>
               <FormControl
-                // $FlowFixMe: Flow doesn't recognize type checks
-                value={patternStop.safeDurationOffset}
                 onChange={this._onNumberFieldChange}
                 type='number'
+                // $FlowFixMe: Flow doesn't recognize type checks
+                value={patternStop.safeDurationOffset}
               />
             </FormGroup>
           </Col>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Flex duration input fields broke at some point. This PR fixes them and catches up on some i18n. 