### PR TITLE
Remove locations instruction

### DIFF
--- a/lib/editor/components/EntityDetails.js
+++ b/lib/editor/components/EntityDetails.js
@@ -123,12 +123,6 @@ export default class EntityDetails extends Component<Props, State> {
             editFareRules={this.state.editFareRules}
             toggleEditFareRules={this._toggleFareRules}
             {...this.props} />
-          { /* Render editor instructions for locations */ }
-          {activeComponent === 'location' &&
-            <div className='location-polygon-instructions'>
-              <small>Use the polygon editor at the top left of the map to create flex areas</small>
-            </div>
-          }
           {/* Entity Details Body */}
           <div className='entity-details-body'>
             {/* Render relevant form based on entity type */}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Removing the locations instruction as most users did are not finding it useful, and it's not the most attractive component ever. Could be replaced by a more thorough design where a toast alert or etc. is shown on the user's first location, although this seems like more work than it's worth.
