### PR TITLE
Fix public feed link formatting

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1019,7 +1019,7 @@ components:
     mergeFeeds: Merge all
     noProjectFound: No project found for
     note: "Note:"
-    publicViewed: Public feeds page can be viewed
+    publicViewed: "Public feeds page can be viewed "
     returnToProjects: Return to list of projects
     settings: Settings
   ProjectFeedListToolbar:

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1104,7 +1104,7 @@ components:
     mergeFeeds: Alle zusammeführen
     noProjectFound: Keine Projekte gefunden für
     note: 'Hinweis:'
-    publicViewed: Öffentliche Feed-Seite ist sichtbar
+    publicViewed: "Öffentliche Feed-Seite ist sichtbar "
     returnToProjects: Zurück zur Projektliste
     settings: Einstellungen
   ProjectsList:

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1089,7 +1089,7 @@ components:
     mergeFeeds: Merge all
     noProjectFound: No project found for
     note: 'Note:'
-    publicViewed: Public feeds page can be viewed
+    publicViewed: "Public feeds page can be viewed "
     returnToProjects: Return to list of projects
     settings: Settings
   ProjectsList:

--- a/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
@@ -4175,7 +4175,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                           Note:
                                                         </strong>
                                                          
-                                                        Public feeds page can be viewed
+                                                        Public feeds page can be viewed 
                                                         <a
                                                           href="https://s3.amazonaws.com/bucket-name/public/index.html"
                                                           target="_blank"


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Another dauntingly large fix, when we did the second large round of i18n, the "Note: Public feeds page can be viewed here" text lost its space.