### PR TITLE
Add route short names to stop deletion warning

### DIFF
--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -142,8 +142,8 @@ function getErrorMessageFromJson (
       if (patternsMatch) {
         const patterns = patternsMatch.split(',').map(pattern => {
           pattern = pattern.slice(1, -1) // Remove curly braces
-          const [patternId, routeId, routeShortName] = pattern.split('-')
-          return {patternId, routeId, routeShortName}
+          const [patternId, internalRouteId, routeShortName, routeId] = pattern.split('-')
+          return {patternId, internalRouteId, routeShortName, routeId}
         })
         detail = <PatternLinkErrorMessage detail={detail} patterns={patterns} />
       }
@@ -179,11 +179,12 @@ const PatternLinkErrorMessage = (props) => {
       padding: '5px 10px'
     }}>
       {patterns.map((pattern, index) => {
-        const patternPath = `../edit/route/${pattern.routeId}/trippattern/${pattern.patternId}`
+        // The URL path requires the internal ID for the route record rather than the actual GTFS Route ID.
+        const patternPath = `../edit/route/${pattern.internalRouteId}/trippattern/${pattern.patternId}`
         return (
           <li style={{listStyle: 'none', margin: '3px 0px'}}>
             <a href={patternPath}>
-              {`Route ${pattern.routeShortName}, Pattern ${pattern.patternId}`}
+              {`Route ${pattern.routeShortName || pattern.routeId}, Pattern ${pattern.patternId}`}
             </a>
           </li>
         )

--- a/lib/common/actions/index.js
+++ b/lib/common/actions/index.js
@@ -142,8 +142,8 @@ function getErrorMessageFromJson (
       if (patternsMatch) {
         const patterns = patternsMatch.split(',').map(pattern => {
           pattern = pattern.slice(1, -1) // Remove curly braces
-          const [patternId, routeId] = pattern.split('-')
-          return {patternId, routeId}
+          const [patternId, routeId, routeShortName] = pattern.split('-')
+          return {patternId, routeId, routeShortName}
         })
         detail = <PatternLinkErrorMessage detail={detail} patterns={patterns} />
       }
@@ -183,7 +183,7 @@ const PatternLinkErrorMessage = (props) => {
         return (
           <li style={{listStyle: 'none', margin: '3px 0px'}}>
             <a href={patternPath}>
-              {`Route ${pattern.routeId}, Pattern ${pattern.patternId}`}
+              {`Route ${pattern.routeShortName}, Pattern ${pattern.patternId}`}
             </a>
           </li>
         )


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Companion PR to https://github.com/conveyal/gtfs-lib/pull/396 to make use of route short names in deletion error messages
