### PR TITLE
Reinstate "Same as Deployed" label

### DIFF
--- a/lib/manager/components/FeedSourceTableRow.js
+++ b/lib/manager/components/FeedSourceTableRow.js
@@ -185,11 +185,12 @@ export default class FeedSourceTableRow extends PureComponent<Props> {
 
     // data for latest validation columns
     const currentVersionData = this.getVersionDisplayData(feedSource.latestValidation)
+    const latestVersionId = feedSource.latestValidation && feedSource.latestValidation.feedVersionId
 
     if (
-      feedSource.latestVersionId &&
+      latestVersionId &&
         comparisonValidationSummary &&
-        feedSource.latestVersionId === comparisonValidationSummary.feedVersionId
+        latestVersionId === comparisonValidationSummary.feedVersionId
     ) {
       currentVersionData.status = comparisonColumn === 'DEPLOYED'
         ? 'same-as-deployed'

--- a/lib/manager/components/FeedSourceTableRow.js
+++ b/lib/manager/components/FeedSourceTableRow.js
@@ -186,12 +186,9 @@ export default class FeedSourceTableRow extends PureComponent<Props> {
     // data for latest validation columns
     const currentVersionData = this.getVersionDisplayData(feedSource.latestValidation)
     const latestVersionId = feedSource.latestValidation && feedSource.latestValidation.feedVersionId
+    const comparisonVersionId = comparisonValidationSummary && comparisonValidationSummary.feedVersionId
 
-    if (
-      latestVersionId &&
-        comparisonValidationSummary &&
-        latestVersionId === comparisonValidationSummary.feedVersionId
-    ) {
+    if (latestVersionId && latestVersionId === comparisonVersionId) {
       currentVersionData.status = comparisonColumn === 'DEPLOYED'
         ? 'same-as-deployed'
         : 'same-as-published'


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

There was a regression with the FeedSourceSummary update, which avoided using the "Same As Deployed" label when comparing the latest deployed feedsource with the latest version in the FeedSourceTable. The oversight was just missing using the new latestVersionId parameter, which is now located inside of the validation result, but which is effectively the same. 
