### PR TITLE
Add option for publishing patterns

### DIFF
--- a/__tests__/end-to-end.js
+++ b/__tests__/end-to-end.js
@@ -2776,6 +2776,10 @@ describe('end-to-end', () => {
 
       // wait for snapshots tab to load and publish snapshot
       await waitForAndClick('[data-test-id="publish-snapshot-button"]')
+
+      // wait for snapshot export modal and click "no" to proprietary file export
+      await waitForAndClick('[data-test-id="export-patterns-modal-no"]')
+
       // wait for version to get created
       await waitAndClearCompletedJobs()
 

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -87,6 +87,8 @@ components:
         placeholder: Additional information (optional)
       publishNewVersion:
         label: Publish snapshot as new feed version
+      publishProprietaryFiles: 
+        label: Publish new feed version with proprietary (extra) datatools files.
       confirmPublishWithUnapproved:
         label: Confirm publish with unapproved routes 
     unapprovedRoutesHeader: "The following routes are not approved"

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -340,7 +340,6 @@ components:
     andOtherErrors: ...and %errors% other errors
   ExportPatternsModal: 
     exportPatterns: Publish version with proprietary patterns?
-    exportPatternsBody: A lot of text
     no: No
     yes: Yes
   FeedFetchFrequency:

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -88,6 +88,7 @@ components:
       publishNewVersion:
         label: Publish snapshot as new feed version
       publishProprietaryFiles: 
+        helpText: Proprietary files allow you to maintain Datatools certain proprietary features across feed version, e.g. Pattern names.
         label: Publish new feed version with proprietary (extra) datatools files.
       confirmPublishWithUnapproved:
         label: Confirm publish with unapproved routes 

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -88,7 +88,7 @@ components:
       publishNewVersion:
         label: Publish snapshot as new feed version
       publishProprietaryFiles: 
-        helpText: Proprietary files allow you to maintain certain Datatools features when re-importing, such as pattern names.
+        helpText: Proprietary files allow you to maintain certain Datatools features, such as pattern names, when re-importing a feed.
         label: Publish new feed version with proprietary (extra) Datatools files.
       confirmPublishWithUnapproved:
         label: Confirm publish with unapproved routes 

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -88,8 +88,8 @@ components:
       publishNewVersion:
         label: Publish snapshot as new feed version
       publishProprietaryFiles: 
-        helpText: Proprietary files allow you to maintain certain proprietary Datatools features across feed version, e.g. Pattern names.
-        label: Publish new feed version with proprietary (extra) datatools files.
+        helpText: Proprietary files allow you to maintain certain Datatools features when re-importing, such as pattern names.
+        label: Publish new feed version with proprietary (extra) Datatools files.
       confirmPublishWithUnapproved:
         label: Confirm publish with unapproved routes 
     unapprovedRoutesHeader: "The following routes are not approved"

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -88,7 +88,7 @@ components:
       publishNewVersion:
         label: Publish snapshot as new feed version
       publishProprietaryFiles: 
-        helpText: Proprietary files allow you to maintain Datatools certain proprietary features across feed version, e.g. Pattern names.
+        helpText: Proprietary files allow you to maintain certain proprietary Datatools features across feed version, e.g. Pattern names.
         label: Publish new feed version with proprietary (extra) datatools files.
       confirmPublishWithUnapproved:
         label: Confirm publish with unapproved routes 
@@ -291,6 +291,7 @@ components:
     load: Load for Editing
     loadLatest: Load latest for editing
     name: Name
+    noOtherSnapshots: No other snapshots
     noSnapshotsExist: No snapshots currently exist for this feed. Snapshots can be created within the Editor. Click "Edit Feed" to enter editing mode.
     noVersions: (No Versions)
     noVersionsExist: No versions exist for this feed source.
@@ -337,6 +338,11 @@ components:
     deleteRange: Delete range
   ExceptionValidationErrorsList: 
     andOtherErrors: ...and %errors% other errors
+  ExportPatternsModal: 
+    exportPatterns: Publish version with proprietary patterns?
+    exportPatternsBody: A lot of text
+    yes: Yes
+    no: No
   FeedFetchFrequency:
     DAYS: days
     fetchFeedEvery: Fetch feed every

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -341,8 +341,8 @@ components:
   ExportPatternsModal: 
     exportPatterns: Publish version with proprietary patterns?
     exportPatternsBody: A lot of text
-    yes: Yes
     no: No
+    yes: Yes
   FeedFetchFrequency:
     DAYS: days
     fetchFeedEvery: Fetch feed every

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -81,7 +81,7 @@ components:
       publishNewVersion:
         label: Veröffentliche Schnappschuss als neue Feed-Version
       publishProprietaryFiles: 
-        helpText: Proprietary files allow you to maintain Datatools certain proprietary features across feed version, e.g. Pattern names.
+        helpText: Proprietary files allow you to maintain certain proprietary Datatools features across feed version, e.g. Pattern names.
         label: Publish new feed version with proprietary (extra) datatools files.
     missingNameAlert: Gültiger Schnappschuss-Name erforderlich!
     ok: OK

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -81,7 +81,7 @@ components:
       publishNewVersion:
         label: Veröffentliche Schnappschuss als neue Feed-Version
       publishProprietaryFiles: 
-        helpText: Proprietary files allow you to maintain certain Datatools features when re-importing, such as pattern names.
+        helpText: Proprietary files allow you to maintain certain Datatools features, such as pattern names, when re-importing a feed.
         label: Publish new feed version with proprietary (extra) Datatools files.
     missingNameAlert: Gültiger Schnappschuss-Name erforderlich!
     ok: OK

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -81,8 +81,8 @@ components:
       publishNewVersion:
         label: Veröffentliche Schnappschuss als neue Feed-Version
       publishProprietaryFiles: 
-        helpText: Proprietary files allow you to maintain certain proprietary Datatools features across feed version, e.g. Pattern names.
-        label: Publish new feed version with proprietary (extra) datatools files.
+        helpText: Proprietary files allow you to maintain certain Datatools features when re-importing, such as pattern names.
+        label: Publish new feed version with proprietary (extra) Datatools files.
     missingNameAlert: Gültiger Schnappschuss-Name erforderlich!
     ok: OK
     title: Neuen Schnappschuss erstellen

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -80,6 +80,8 @@ components:
         placeholder: Name des Schnappschusses (erforderlich)
       publishNewVersion:
         label: Veröffentliche Schnappschuss als neue Feed-Version
+      publishProprietaryFiles: 
+        label: Publish new feed version with proprietary (extra) datatools files.
     missingNameAlert: Gültiger Schnappschuss-Name erforderlich!
     ok: OK
     title: Neuen Schnappschuss erstellen

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -298,6 +298,7 @@ components:
     load: Zur Bearbeitung laden
     loadLatest: Aktuellsten zur Bearbeitung herunterladen
     name: Name
+    noOtherSnapshots: No other snapshots
     noSnapshotsExist: Für diese Feed-Quelle existieren noch keine Schnappschüsse.
       Schnappschüsse können im Editor erstellt werden. Wählen Sie "Feed bearbeiten"
       um den Bearbeitungsmodus zu starten.
@@ -349,6 +350,11 @@ components:
     deleteRange: Delete range
   ExceptionValidationErrorsList: 
     andOtherErrors: ...and %errors% other errors
+  ExportPatternsModal:
+    exportPatterns: Publish version with proprietary patterns?
+    exportPatternsBody: A lot of text
+    no: No
+    yes: Yes
   FeedActionsDropdown:
     delete: Löschen
     deleteFeedSource: Feed-Quelle löschen?

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -352,7 +352,6 @@ components:
     andOtherErrors: ...and %errors% other errors
   ExportPatternsModal:
     exportPatterns: Publish version with proprietary patterns?
-    exportPatternsBody: A lot of text
     no: No
     yes: Yes
   FeedActionsDropdown:

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -81,6 +81,7 @@ components:
       publishNewVersion:
         label: Veröffentliche Schnappschuss als neue Feed-Version
       publishProprietaryFiles: 
+        helpText: Proprietary files allow you to maintain Datatools certain proprietary features across feed version, e.g. Pattern names.
         label: Publish new feed version with proprietary (extra) datatools files.
     missingNameAlert: Gültiger Schnappschuss-Name erforderlich!
     ok: OK

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -80,7 +80,7 @@ components:
       publishNewVersion:
         label: Publikuj migawkę jako nowa wersja pliku
       publishProprietaryFiles: 
-        helpText: Proprietary files allow you to maintain Datatools certain proprietary features across feed version, e.g. Pattern names.
+        helpText: Proprietary files allow you to maintain certain proprietary Datatools features across feed version, e.g. Pattern names.
         label: Publish new feed version with proprietary (extra) datatools files.
     missingNameAlert: Migawce należy nadać prawidłową nazwę!
     ok: OK

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -80,6 +80,7 @@ components:
       publishNewVersion:
         label: Publikuj migawkę jako nowa wersja pliku
       publishProprietaryFiles: 
+        helpText: Proprietary files allow you to maintain Datatools certain proprietary features across feed version, e.g. Pattern names.
         label: Publish new feed version with proprietary (extra) datatools files.
     missingNameAlert: Migawce należy nadać prawidłową nazwę!
     ok: OK

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -347,7 +347,6 @@ components:
     andOtherErrors: ...and %errors% other errors
   ExportPatternsModal: 
     exportPatterns: Publish version with proprietary patterns?
-    exportPatternsBody: A lot of text
     no: No
     yes: Yes
   FeedActionsDropdown:

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -296,6 +296,7 @@ components:
     load: Wczytaj do edycji
     loadLatest: Załaduj najnowszy do edycji
     name: Nazwa
+    noOtherSnapshots: No other snapshots
     noSnapshotsExist: Obecnie nie istnieją żadne zrzuty tego kanału. Migawki można
       tworzyć w Edytorze. Kliknij „Edytuj kanał”, aby przejść do trybu edycji.
     noVersions: (Brak wersji)
@@ -344,6 +345,11 @@ components:
     deleteRange: Delete range
   ExceptionValidationErrorsList: 
     andOtherErrors: ...and %errors% other errors
+  ExportPatternsModal: 
+    exportPatterns: Publish version with proprietary patterns?
+    exportPatternsBody: A lot of text
+    no: No
+    yes: Yes
   FeedActionsDropdown:
     delete: Delete
     deleteFeedSource: Delete Feed Source?

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -79,6 +79,8 @@ components:
         placeholder: Nazwa migawki (wymagana)
       publishNewVersion:
         label: Publikuj migawkę jako nowa wersja pliku
+      publishProprietaryFiles: 
+        label: Publish new feed version with proprietary (extra) datatools files.
     missingNameAlert: Migawce należy nadać prawidłową nazwę!
     ok: OK
     title: Utwórz nową migawkę

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -80,8 +80,8 @@ components:
       publishNewVersion:
         label: Publikuj migawkę jako nowa wersja pliku
       publishProprietaryFiles: 
-        helpText: Proprietary files allow you to maintain certain proprietary Datatools features across feed version, e.g. Pattern names.
-        label: Publish new feed version with proprietary (extra) datatools files.
+        helpText: Proprietary files allow you to maintain certain Datatools features when re-importing, such as pattern names.
+        label: Publish new feed version with proprietary (extra) Datatools files.
     missingNameAlert: Migawce należy nadać prawidłową nazwę!
     ok: OK
     title: Utwórz nową migawkę

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -80,7 +80,7 @@ components:
       publishNewVersion:
         label: Publikuj migawkę jako nowa wersja pliku
       publishProprietaryFiles: 
-        helpText: Proprietary files allow you to maintain certain Datatools features when re-importing, such as pattern names.
+        helpText: Proprietary files allow you to maintain certain Datatools features, such as pattern names, when re-importing a feed.
         label: Publish new feed version with proprietary (extra) Datatools files.
     missingNameAlert: Migawce należy nadać prawidłową nazwę!
     ok: OK

--- a/lib/common/components/ExportPatternsModal.js
+++ b/lib/common/components/ExportPatternsModal.js
@@ -1,0 +1,62 @@
+// @flow
+
+import React from 'react'
+import { Modal, Button } from 'react-bootstrap'
+
+import {getComponentMessages} from '../../common/util/config'
+import * as versionActions from '../../manager/actions/versions'
+import type { Feed, Snapshot } from '../../types'
+import type { ItemProps } from '../../editor/components/EditorFeedSourcePanel'
+
+type Props = {
+  createFeedVersionFromSnapshot: typeof versionActions.createFeedVersionFromSnapshot,
+  feedSource: Feed,
+}
+
+type State = {
+  showModal: boolean,
+  snapshot: ?Snapshot
+}
+
+export default class ExportPatternsModal extends React.Component<Props, State> {
+  messages = getComponentMessages('ExportPatternsModal')
+
+  state = {
+    showModal: false,
+    snapshot: null
+  }
+
+  publish (publishProprietaryFiles: boolean) {
+    const { createFeedVersionFromSnapshot, feedSource } = this.props
+    this.state.snapshot && createFeedVersionFromSnapshot(feedSource, this.state.snapshot.id, publishProprietaryFiles)
+    this.close()
+  }
+
+  close () {
+    this.setState({showModal: false})
+  }
+
+  // Open is called by the SnapshotItem class
+  open (props: ItemProps) {
+    this.setState({showModal: true, snapshot: props.snapshot})
+  }
+
+  render () {
+    const {Body, Title} = Modal
+    const buttonStyle = {marginLeft: '10px', width: '50px'}
+
+    return (
+      <Modal show={this.state.showModal} onHide={this.close}>
+        <Body style={{display: 'flex'}}>
+          <Title>{this.messages('exportPatterns')}</Title>
+          <Button onClick={() => this.publish(true)} style={buttonStyle}>
+            {this.messages('yes')}
+          </Button>
+          <Button onClick={() => this.publish(false)} style={buttonStyle}>
+            {this.messages('no')}
+          </Button>
+        </Body>
+      </Modal>
+    )
+  }
+}

--- a/lib/common/components/ExportPatternsModal.js
+++ b/lib/common/components/ExportPatternsModal.js
@@ -49,10 +49,17 @@ export default class ExportPatternsModal extends React.Component<Props, State> {
       <Modal show={this.state.showModal} onHide={this.close}>
         <Body style={{display: 'flex'}}>
           <Title>{this.messages('exportPatterns')}</Title>
-          <Button onClick={() => this.publish(true)} style={buttonStyle}>
+          <Button
+            onClick={() => this.publish(true)}
+            style={buttonStyle}
+          >
             {this.messages('yes')}
           </Button>
-          <Button onClick={() => this.publish(false)} style={buttonStyle}>
+          <Button
+            data-test-id='export-patterns-modal-no'
+            onClick={() => this.publish(false)}
+            style={buttonStyle}
+          >
             {this.messages('no')}
           </Button>
         </Body>

--- a/lib/editor/actions/snapshots.js
+++ b/lib/editor/actions/snapshots.js
@@ -5,7 +5,6 @@ import {createAction, type ActionType} from 'redux-actions'
 import {secureFetch} from '../../common/actions'
 import {getConfigProperty} from '../../common/util/config'
 import {handleJobResponse} from '../../manager/actions/status'
-
 import type {Feed, Snapshot} from '../../types'
 import type {dispatchFn, getStateFn} from '../../types/reducers'
 
@@ -87,9 +86,9 @@ export function downloadSnapshotViaCredentials (snapshot: Snapshot, isPublic: bo
 /**
  * Create a new snapshot from the data currently present in the editor buffer.
  */
-export function createSnapshot (feedSource: Feed, name: string, comment?: ?string, publishNewVersion?: boolean) {
+export function createSnapshot (feedSource: Feed, name: string, comment?: ?string, publishNewVersion?: boolean, publishProprietaryFiles?: boolean) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    const url = `/api/editor/secure/snapshot?feedId=${feedSource.id}${publishNewVersion ? '&publishNewVersion=true' : ''}`
+    const url = `/api/editor/secure/snapshot?feedId=${feedSource.id}${publishNewVersion ? '&publishNewVersion=true' : ''}${publishProprietaryFiles ? '&publishProprietaryFiles=true' : ''}`
     const snapshot = {
       feedId: feedSource.id,
       name,

--- a/lib/editor/components/CreateSnapshotModal.js
+++ b/lib/editor/components/CreateSnapshotModal.js
@@ -34,6 +34,7 @@ type State = {
   loading: boolean,
   name: ?string,
   publishNewVersion: boolean,
+  publishProprietaryFiles: boolean,
   showModal: boolean,
 }
 
@@ -42,6 +43,7 @@ function getDefaultState () {
     comment: null,
     name: formatTimestamp(),
     publishNewVersion: false,
+    publishProprietaryFiles: false,
     confirmPublishWithUnapproved: false,
     showModal: false,
     loading: false
@@ -54,6 +56,12 @@ class CreateSnapshotModal extends Component<Props, State> {
   messages = getComponentMessages('CreateSnapshotModal')
 
   _onTogglePublish = (e: SyntheticInputEvent<HTMLInputElement>) => {
+    // If unchecking publishNewVersion, we need to also uncheck publishProprietaryFiles
+    if (!e.target.checked) this.setState({publishProprietaryFiles: false})
+    this.setState({[e.target.name]: e.target.checked})
+  }
+
+  _onTogglePublishProprietaryFiles = (e: SyntheticInputEvent<HTMLInputElement>) => {
     this.setState({[e.target.name]: e.target.checked})
   }
 
@@ -91,9 +99,9 @@ class CreateSnapshotModal extends Component<Props, State> {
 
   ok = () => {
     const {createSnapshot, feedSource} = this.props
-    const {comment, name, publishNewVersion} = this.state
+    const {comment, name, publishNewVersion, publishProprietaryFiles} = this.state
     if (!name) return window.alert(this.messages('missingNameAlert'))
-    createSnapshot(feedSource, name, comment, publishNewVersion)
+    createSnapshot(feedSource, name, comment, publishNewVersion, publishProprietaryFiles)
     this.close()
   }
 
@@ -105,6 +113,7 @@ class CreateSnapshotModal extends Component<Props, State> {
       loading,
       name,
       publishNewVersion,
+      publishProprietaryFiles,
       showModal
     } = this.state
     const {routes} = this.props
@@ -149,6 +158,16 @@ class CreateSnapshotModal extends Component<Props, State> {
               onChange={this._onTogglePublish}>
               {this.messages('fields.publishNewVersion.label')}
             </Checkbox>
+            {publishNewVersion &&
+              <Checkbox
+                name='publishProprietaryFiles'
+                checked={publishProprietaryFiles}
+                onChange={this._onTogglePublishProprietaryFiles}
+                style={{marginLeft: 10}}
+              >
+                {this.messages('fields.publishProprietaryFiles.label')}
+              </Checkbox>
+            }
           </FormGroup>
           {loading && <Icon type='spinner' className='fa-pulse' />}
           {unapprovedRoutes.length > 0 &&

--- a/lib/editor/components/CreateSnapshotModal.js
+++ b/lib/editor/components/CreateSnapshotModal.js
@@ -8,7 +8,9 @@ import {
   ControlLabel,
   FormGroup,
   FormControl,
-  Modal
+  Modal,
+  OverlayTrigger,
+  Tooltip
 } from 'react-bootstrap'
 import {connect} from 'react-redux'
 
@@ -151,7 +153,7 @@ class CreateSnapshotModal extends Component<Props, State> {
               placeholder={this.messages('fields.comment.placeholder')}
             />
           </FormGroup>
-          <FormGroup>
+          <FormGroup style={{width: 'fit-content'}}>
             <Checkbox
               name='publishNewVersion'
               checked={publishNewVersion}
@@ -159,14 +161,18 @@ class CreateSnapshotModal extends Component<Props, State> {
               {this.messages('fields.publishNewVersion.label')}
             </Checkbox>
             {publishNewVersion &&
-              <Checkbox
-                name='publishProprietaryFiles'
-                checked={publishProprietaryFiles}
-                onChange={this._onTogglePublishProprietaryFiles}
-                style={{marginLeft: 10}}
-              >
-                {this.messages('fields.publishProprietaryFiles.label')}
-              </Checkbox>
+              <OverlayTrigger overlay={<Tooltip>{this.messages('fields.publishProprietaryFiles.helpText')}</Tooltip>}>
+                <span>
+                  <Checkbox
+                    name='publishProprietaryFiles'
+                    checked={publishProprietaryFiles}
+                    onChange={this._onTogglePublishProprietaryFiles}
+                    style={{marginLeft: 10}}
+                  >
+                    {this.messages('fields.publishProprietaryFiles.label')}
+                  </Checkbox>
+                </span>
+              </OverlayTrigger>
             }
           </FormGroup>
           {loading && <Icon type='spinner' className='fa-pulse' />}

--- a/lib/editor/components/EditorFeedSourcePanel.js
+++ b/lib/editor/components/EditorFeedSourcePanel.js
@@ -148,10 +148,7 @@ class SnapshotItem extends Component<ItemProps> {
   }
 
   _onClickExport = () => {
-    this.props.modal.open({
-      body: this.messages('exportPatternsBody'),
-      snapshot: this.props.snapshot
-    })
+    this.props.modal.open({snapshot: this.props.snapshot})
   }
 
   _onDeleteSnapshot = () => {

--- a/lib/editor/components/EditorFeedSourcePanel.js
+++ b/lib/editor/components/EditorFeedSourcePanel.js
@@ -8,6 +8,7 @@ import moment from 'moment'
 
 import * as snapshotActions from '../actions/snapshots.js'
 import ConfirmModal from '../../common/components/ConfirmModal'
+import ExportPatternsModal from '../../common/components/ExportPatternsModal.js'
 import {getComponentMessages, getConfigProperty} from '../../common/util/config'
 import CreateSnapshotModal from '../../editor/components/CreateSnapshotModal'
 import * as versionActions from '../../manager/actions/versions'
@@ -63,6 +64,11 @@ export default class EditorFeedSourcePanel extends Component<Props> {
           ref='snapshotModal'
         />
         <ConfirmModal ref='confirmModal' />
+        <ExportPatternsModal
+          createFeedVersionFromSnapshot={this.props.createFeedVersionFromSnapshot}
+          feedSource={feedSource}
+          ref='exportPatternsModal'
+        />
         <Col xs={9}>
           {feedSource.editorSnapshots && feedSource.editorSnapshots.length
             ? <div>
@@ -73,13 +79,13 @@ export default class EditorFeedSourcePanel extends Component<Props> {
                 </Panel.Title></Panel.Heading>
                 <ListGroup>
                   {snapshots.length === 0
-                    ? <ListGroupItem>No other snapshots</ListGroupItem>
+                    ? <ListGroupItem>{this.messages('noOtherSnapshots')}</ListGroupItem>
                     : snapshots.map(s => {
                       return (
                         <SnapshotItem
                           disabled={disabled}
                           key={s.id}
-                          modal={this.refs.confirmModal}
+                          modal={this.refs.exportPatternsModal}
                           snapshot={s}
                           {...this.props} />
                       )
@@ -122,7 +128,7 @@ export default class EditorFeedSourcePanel extends Component<Props> {
   }
 }
 
-type ItemProps = {
+export type ItemProps = {
   createFeedVersionFromSnapshot: typeof versionActions.createFeedVersionFromSnapshot,
   deleteSnapshot: typeof snapshotActions.deleteSnapshot,
   disabled: boolean,
@@ -142,8 +148,10 @@ class SnapshotItem extends Component<ItemProps> {
   }
 
   _onClickExport = () => {
-    const {createFeedVersionFromSnapshot, feedSource, snapshot} = this.props
-    createFeedVersionFromSnapshot(feedSource, snapshot.id)
+    this.props.modal.open({
+      body: this.messages('exportPatternsBody'),
+      snapshot: this.props.snapshot
+    })
   }
 
   _onDeleteSnapshot = () => {

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -543,10 +543,11 @@ export function downloadFeedViaToken (
  */
 export function createFeedVersionFromSnapshot (
   feedSource: Feed,
-  snapshotId: string
+  snapshotId: string,
+  publishProprietaryFiles: boolean
 ) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
-    const url = `${SECURE_API_PREFIX}feedversion/fromsnapshot?feedSourceId=${feedSource.id}&snapshotId=${snapshotId}`
+    const url = `${SECURE_API_PREFIX}feedversion/fromsnapshot?feedSourceId=${feedSource.id}&snapshotId=${snapshotId}&publishProprietaryFiles=${publishProprietaryFiles.toString()}`
     return dispatch(secureFetch(url, 'post'))
       .then(res => dispatch(handleJobResponse(res, 'Error downloading snapshot')))
   }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR provides the user an option to export a feed with the proprietary `datatools_patterns.txt` file, introduced in https://github.com/conveyal/gtfs-lib/pulls, which allows the preservation of custom pattern names in the editor. 

For testing:
Server PR: https://github.com/ibi-group/datatools-server/pull/567
GTFS-Lib PR: https://github.com/conveyal/gtfs-lib/pull/394
