### PR TITLE
Do not require stop_code to be unique

### DIFF
--- a/gtfs.yml
+++ b/gtfs.yml
@@ -147,12 +147,12 @@
     required: true
     inputType: GTFS_ID
     columnWidth: 6
-    helpContent: "The stop_id field contains an ID that identifies a stop or station. Multiple routes may use the same stop. The stop_id is dataset unique."
+    helpContent: "The stop_id field contains an ID that uniquely identifies a stop or station. Multiple routes may use the same stop. The stop_id is dataset unique."
   - name: "stop_code"
     required: false
     inputType: TEXT
     columnWidth: 6
-    helpContent: "The stop_code field contains short text or a number that uniquely identifies the stop for passengers. Stop codes are often used in phone-based transit information systems or printed on stop signage to make it easier for riders to get a stop schedule or real-time arrival information for a particular stop."
+    helpContent: "The stop_code field contains short text or a number that identifies the stop for passengers. Stop codes are often used in phone-based transit information systems or printed on stop signage to make it easier for riders to get a stop schedule or real-time arrival information for a particular stop."
   - name: "stop_name"
     required: false
     inputType: TEXT

--- a/gtfs.yml
+++ b/gtfs.yml
@@ -147,10 +147,10 @@
     required: true
     inputType: GTFS_ID
     columnWidth: 6
-    helpContent: "The stop_id field contains an ID that uniquely identifies a stop or station. Multiple routes may use the same stop. The stop_id is dataset unique."
+    helpContent: "The stop_id field contains an ID that identifies a stop or station. Multiple routes may use the same stop. The stop_id is dataset unique."
   - name: "stop_code"
     required: false
-    inputType: GTFS_ID
+    inputType: TEXT
     columnWidth: 6
     helpContent: "The stop_code field contains short text or a number that uniquely identifies the stop for passengers. Stop codes are often used in phone-based transit information systems or printed on stop signage to make it easier for riders to get a stop schedule or real-time arrival information for a particular stop."
   - name: "stop_name"


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Fix #987 . Stop_code should not be required to be unique. This PR also slightly amends the help text associated with stop_code.  