### PR TITLE
Add warning to RouteLayout component about page size

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1152,6 +1152,8 @@ components:
     line: Line
     priority: Priority
     problemType: Problem Type
+  RouteLayout: 
+    pageSizeNotice: ⚠️ Summary below shows a maximum of %pageSize% routes.
   SelectFileModal:
     ok: OK
     cancel: Cancel

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1156,6 +1156,8 @@ components:
       und eine detailierte Beschreibung der Schritte, die Sie zuvor ausgeführt haben
       an <a href='mailto:%supportEmail%'>%supportEmail%</a>.
     view: Ansehen
+  RouteLayout: 
+    pageSizeNotice: ⚠️ Summary below shows a maximum of %pageSize% routes.
   SelectFileModal:
     cancel: Abbrechen
     ok: OK

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1140,6 +1140,8 @@ components:
       the following text (current URL and error details), and a detailed description
       of the steps you followed to <a href='mailto:%supportEmail%'>%supportEmail%</a>.
     view: View
+  RouteLayout: 
+    pageSizeNotice: ⚠️ Summary below shows a maximum of %pageSize% routes.
   SelectFileModal:
     cancel: Cancel
     ok: OK

--- a/lib/manager/components/reporter/components/RouteLayout.js
+++ b/lib/manager/components/reporter/components/RouteLayout.js
@@ -6,6 +6,7 @@ import {
   Alert,
   Button,
   Col,
+  ControlLabel,
   ListGroup,
   ListGroupItem,
   Pagination,
@@ -17,12 +18,13 @@ import Loading from '../../../../common/components/Loading'
 import ActiveDateTimeFilter from '../containers/ActiveDateTimeFilter'
 import * as routesActions from '../../../../gtfs/actions/routes'
 import * as patternsActions from '../../../../gtfs/actions/patterns'
-import TripsPerHourChart from './TripsPerHourChart'
-
+import { getComponentMessages } from '../../../../common/util/config'
 import type {Props as ContainerProps} from '../containers/Routes'
 import type {RouteRowData} from '../../../selectors'
 import type {FetchStatus} from '../../../../types'
 import type {AllRoutesSubState, RouteListItem} from '../../../../types/reducers'
+
+import TripsPerHourChart from './TripsPerHourChart'
 
 type Props = ContainerProps & {
   allRoutes: AllRoutesSubState,
@@ -40,6 +42,8 @@ type Props = ContainerProps & {
 const PAGE_SIZE = 10
 
 export default class RouteLayout extends Component<Props> {
+  messages = getComponentMessages('RouteLayout')
+
   componentWillMount () {
     const {fetchRouteDetails, fetchRoutes, fetchStatus, version} = this.props
     const {namespace} = version
@@ -118,7 +122,10 @@ export default class RouteLayout extends Component<Props> {
           hideDateTimeField
           onChange={this._onDateTimeFilterChange}
           version={version} />
-
+        {/* TODO: Fix Pagination in this component and remove this warning */}
+        <ControlLabel style={{paddingTop: '10px'}}>
+          {this.messages('pageSizeNotice').replace('%pageSize%', PAGE_SIZE)}
+        </ControlLabel>
         {fetching &&
           <Loading />
         }

--- a/lib/manager/components/reporter/components/RouteLayout.js
+++ b/lib/manager/components/reporter/components/RouteLayout.js
@@ -124,7 +124,7 @@ export default class RouteLayout extends Component<Props> {
           version={version} />
         {/* TODO: Fix Pagination in this component and remove this warning */}
         <ControlLabel style={{paddingTop: '10px'}}>
-          {this.messages('pageSizeNotice').replace('%pageSize%', PAGE_SIZE)}
+          {this.messages('pageSizeNotice').replace('%pageSize%', PAGE_SIZE.toString())}
         </ControlLabel>
         {fetching &&
           <Loading />


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Intermediate fix for a bug with the RouteLayout page where Pagination is not working and only 10 routes are currently displayed, without indication that this is not the entire list. This warning should be removed once pagination is completely fixed.
