### PR TITLE
Add auto block IDs

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1370,6 +1370,7 @@ components:
     incrementStartPlaceholder: Increment start (default 0)
     prefixPlaceholder: Trip ID prefix (optional)
     startTime: "Start Time:"
+    trips: trip(s)
   UserAccount:
     account:
       title: Account

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1352,12 +1352,17 @@ components:
     tableDeleted: Table Deleted
     transformationsTitle: Transformations
   TripSeriesModal:
+    alternateEvery: "Alternate every: "
+    automaticallyUpdateBlockIds: Automatically assign Block IDs for trips created in series?
     automaticallyUpdateTripIds: Automatically update Trip IDs for trips created in series?
+    blockIdPrefixPlaceholder: Auto block ID prefix
+    blockIncrementPlaceholder: inc. by
     close: Close
     createTripSeriesBody: Enter the start and end time for the trip series (24 hour time) and headway between trips. Click generate to create the series of trips. 
     createTripSeriesQuestion: Create a series of trips
     disabledTooltip: There is an issue with the input data
     endTime: "End Time:"
+    formatExplanation: "* Block IDs will be formatted as {prefix}-{alternating number}, e.g. 'WEEKDAY-1' then 'WEEKDAY-2', etc.'"
     generateTrips: Generate Trips
     headway: "Headway:"
     incrementAmountPlaceholder: Increment amount

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -1355,7 +1355,7 @@ components:
     alternateEvery: "Alternate every: "
     automaticallyUpdateBlockIds: Automatically assign Block IDs for trips created in series?
     automaticallyUpdateTripIds: Automatically update Trip IDs for trips created in series?
-    blockIdPrefixPlaceholder: Auto block ID prefix
+    blockIdPrefixPlaceholder: Block ID prefix
     blockIncrementPlaceholder: inc. by
     close: Close
     createTripSeriesBody: Enter the start and end time for the trip series (24 hour time) and headway between trips. Click generate to create the series of trips. 
@@ -1370,7 +1370,7 @@ components:
     incrementStartPlaceholder: Increment start (default 0)
     prefixPlaceholder: Trip ID prefix (optional)
     startTime: "Start Time:"
-    trips: trip(s)
+    tripsStartingWith: "trip(s), starting with:"
   UserAccount:
     account:
       title: Account

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1569,3 +1569,5 @@ components:
     incrementStartPlaceholder: Increment start (default 0)
     prefixPlaceholder: Trip ID prefix (optional)
     startTime: "Start Time:"
+    trips: trip(s)
+

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1554,7 +1554,7 @@ components:
     alternateEvery: "Alternate every: "
     automaticallyUpdateBlockIds: Automatically assign Block IDs for trips created in series?
     automaticallyUpdateTripIds: Automatically update Trip IDs for trips created in series?
-    blockIdPrefixPlaceholder: Auto block ID prefix
+    blockIdPrefixPlaceholder: Block ID prefix
     blockIncrementPlaceholder: inc. by
     close: Close
     createTripSeriesBody: Enter the start and end time for the trip series (24 hour time) and headway between trips. Click generate to create the series of trips. 
@@ -1569,5 +1569,5 @@ components:
     incrementStartPlaceholder: Increment start (default 0)
     prefixPlaceholder: Trip ID prefix (optional)
     startTime: "Start Time:"
-    trips: trip(s)
+    tripsStartingWith: "trip(s), starting with:"
 

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -1551,13 +1551,17 @@ components:
       pickupDropOffDefault: (Default - Available)
       pickupTitle: Define the pickup method/availability at this stop.
   TripSeriesModal:
+    alternateEvery: "Alternate every: "
+    automaticallyUpdateBlockIds: Automatically assign Block IDs for trips created in series?
     automaticallyUpdateTripIds: Automatically update Trip IDs for trips created in series?
+    blockIdPrefixPlaceholder: Auto block ID prefix
+    blockIncrementPlaceholder: inc. by
     close: Close
-    createTripSeriesBody: Enter the start and end time for the trip series (24 hour
-      time) and headway between trips. Click generate to create the series of trips.
+    createTripSeriesBody: Enter the start and end time for the trip series (24 hour time) and headway between trips. Click generate to create the series of trips. 
     createTripSeriesQuestion: Create a series of trips
     disabledTooltip: There is an issue with the input data
     endTime: "End Time:"
+    formatExplanation: "* Block IDs will be formatted as {prefix}-{alternating number}, e.g. 'WEEKDAY-1' then 'WEEKDAY-2', etc.'"
     generateTrips: Generate Trips
     headway: "Headway:"
     incrementAmountPlaceholder: Increment amount

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1522,13 +1522,17 @@ components:
       pickupDropOffDefault: (Default - Available)
       pickupTitle: Define the pickup method/availability at this stop.
   TripSeriesModal:
+    alternateEvery: "Alternate every: "
+    automaticallyUpdateBlockIds: Automatically assign Block IDs for trips created in series?
     automaticallyUpdateTripIds: Automatically update Trip IDs for trips created in series?
+    blockIdPrefixPlaceholder: Auto block ID prefix
+    blockIncrementPlaceholder: inc. by
     close: Close
-    createTripSeriesBody: Enter the start and end time for the trip series (24 hour
-      time) and headway between trips. Click generate to create the series of trips.
+    createTripSeriesBody: Enter the start and end time for the trip series (24 hour time) and headway between trips. Click generate to create the series of trips. 
     createTripSeriesQuestion: Create a series of trips
     disabledTooltip: There is an issue with the input data
     endTime: "End Time:"
+    formatExplanation: "* Block IDs will be formatted as {prefix}-{alternating number}, e.g. 'WEEKDAY-1' then 'WEEKDAY-2', etc.'"
     generateTrips: Generate Trips
     headway: "Headway:"
     incrementAmountPlaceholder: Increment amount

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1540,3 +1540,4 @@ components:
     incrementStartPlaceholder: Increment start (default 0)
     prefixPlaceholder: Trip ID prefix (optional)
     startTime: "Start Time:"
+    trips: trip(s)

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -1525,7 +1525,7 @@ components:
     alternateEvery: "Alternate every: "
     automaticallyUpdateBlockIds: Automatically assign Block IDs for trips created in series?
     automaticallyUpdateTripIds: Automatically update Trip IDs for trips created in series?
-    blockIdPrefixPlaceholder: Auto block ID prefix
+    blockIdPrefixPlaceholder: Block ID prefix
     blockIncrementPlaceholder: inc. by
     close: Close
     createTripSeriesBody: Enter the start and end time for the trip series (24 hour time) and headway between trips. Click generate to create the series of trips. 
@@ -1540,4 +1540,5 @@ components:
     incrementStartPlaceholder: Increment start (default 0)
     prefixPlaceholder: Trip ID prefix (optional)
     startTime: "Start Time:"
-    trips: trip(s)
+    tripsStartingWith: "trip(s), starting with:"
+

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -152,7 +152,7 @@ export default class TimetableEditor extends Component<Props, State> {
 
   cloneSelectedTrips = () => this.duplicateRows(this._getSelectedRowIndexes())
 
-  constructNewRow = (toClone: ?Trip = null, tripSeriesStartTime: ?number, autoTripId: ?string): ?Trip => {
+  constructNewRow = (toClone: ?Trip = null, tripSeriesStartTime: ?number, autoTripId: ?string, autoBlockId: ?string): ?Trip => {
     const {activePatternId, route} = this.props
     const activePattern = route && route.tripPatterns
       ? route.tripPatterns.find(p => p.id === activePatternId)
@@ -230,6 +230,7 @@ export default class TimetableEditor extends Component<Props, State> {
       // IMPORTANT: set id to NEW_ID
       objectPath.set(newRow, 'id', ENTITY.NEW_ID)
       objectPath.set(newRow, 'tripId', autoTripId || null)
+      objectPath.set(newRow, 'blockId', autoBlockId || null)
       objectPath.set(newRow, 'useFrequency', activePattern.useFrequency)
       if (activePattern.useFrequency) {
         // If a frequency-based trip, never use exact times. NOTE: there is no

--- a/lib/editor/components/timetable/TripSeriesModal.js
+++ b/lib/editor/components/timetable/TripSeriesModal.js
@@ -10,7 +10,7 @@ import type {Trip} from '../../../types'
 
 type Props = {
   addNewTrip: typeof tripActions.addNewTrip,
-  constructNewRow: (trip: ?Trip, tripSeriesStartTime: ?number, autoTripId: ?string) => ?Trip,
+  constructNewRow: (trip: ?Trip, tripSeriesStartTime: ?number, autoTripId: ?string, autoBlockId: ?string) => ?Trip,
   onClose: () => void,
   show: boolean,
   useSecondsInOffset: boolean

--- a/lib/editor/components/timetable/TripSeriesModal.js
+++ b/lib/editor/components/timetable/TripSeriesModal.js
@@ -17,20 +17,32 @@ type Props = {
 }
 
 const TripSeriesModal = (props: Props) => {
+  // Trip series timing state variables
   const [startTime, setStartTime] = useState(null)
   const [headway, setHeadway] = useState(null)
   const [endTime, setEndTime] = useState(null)
+
+  // Automatic block and trip ID state variables
   const [useAutoTripIds, setUseAutoTripIds] = useState(false)
+  const [useAutoBlockIds, setUseAutoBlockIds] = useState(false)
+
   const [autoTripIdStart, setAutoTripIdStart] = useState(0)
+
   const [autoTripIdIncrement, setAutoTripIdIncrement] = useState(1)
+  const [autoBlockIdIncrement, setAutoBlockIdIncrement] = useState(1)
+
   const [autoTripIdPrefix, setAutoTripIdPrefix] = useState('')
+  const [autoBlockIdPrefix, setAutoBlockIdPrefix] = useState('')
 
   const messages = getComponentMessages('TripSeriesModal')
 
   const handleIncrementStartUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdStart(+evt.target.value)
   const handleTripPrefixUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdPrefix(evt.target.value)
+  const handleBlockPrefixUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoBlockIdPrefix(evt.target.value)
   const handleTripIncrementUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdIncrement(+evt.target.value)
-  const handleCheckBox = () => setUseAutoTripIds(!useAutoTripIds)
+  const handleBlockIncrementUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoBlockIdIncrement(+evt.target.value)
+  const handleAutoTripIDCheckBox = () => setUseAutoTripIds(!useAutoTripIds)
+  const handleAutoBlockIDCheckBox = () => setUseAutoBlockIds(!useAutoBlockIds)
 
   const onClickGenerate = useCallback(() => {
     const {addNewTrip, constructNewRow, onClose} = props
@@ -39,16 +51,25 @@ const TripSeriesModal = (props: Props) => {
     const adjustedEndTime = startTime < endTime ? endTime : endTime + 24 * 60 * 60
 
     let tripId = autoTripIdStart
+    let currentBlockIdSuffix = 1
     for (let time = startTime; time <= adjustedEndTime; time += headway) {
+      const autoTripId = useAutoTripIds ? `${autoTripIdPrefix}-${tripId}` : null
+      const autoBlockId = useAutoBlockIds ? `${autoBlockIdPrefix}-${currentBlockIdSuffix}` : null
+      addNewTrip(constructNewRow(null, time, autoTripId, autoBlockId))
       // If we're upating the trip IDs automatically, increment the trip ID:
-      addNewTrip(constructNewRow(null, time, useAutoTripIds ? `${autoTripIdPrefix}-${tripId}` : null))
       if (useAutoTripIds) tripId += autoTripIdIncrement
+      // If we're updating the Block IDs automatically, alternate according to input number
+      if (useAutoBlockIds) {
+        currentBlockIdSuffix += 1
+        // If we increase past the alternating number, use the modulus to reset
+        if (currentBlockIdSuffix > autoBlockIdIncrement) currentBlockIdSuffix = currentBlockIdSuffix % autoBlockIdIncrement
+      }
     }
     setStartTime(null)
     setEndTime(null)
     setHeadway(null)
     onClose()
-  }, [endTime, startTime, headway, autoTripIdStart, autoTripIdIncrement, autoTripIdPrefix])
+  }, [endTime, startTime, headway, autoTripIdStart, autoTripIdIncrement, autoTripIdPrefix, autoBlockIdPrefix, autoBlockIdIncrement])
 
   const {Body, Footer, Header, Title} = Modal
   const {onClose, show, useSecondsInOffset} = props
@@ -75,38 +96,64 @@ const TripSeriesModal = (props: Props) => {
             <HourMinuteInput onChange={setEndTime} seconds={endTime} showSeconds={useSecondsInOffset} standaloneInput />
           </div>
         </div>
+        <hr />
         <div>
-          <Checkbox checked={useAutoTripIds} onChange={handleCheckBox}>{messages('automaticallyUpdateTripIds')}</Checkbox>
-          <div style={{
-            alignItems: 'center',
-            display: 'flex'
-          }}>
-            {useAutoTripIds &&
-              <>
+          <Checkbox checked={useAutoTripIds} onChange={handleAutoTripIDCheckBox}>{messages('automaticallyUpdateTripIds')}</Checkbox>
+          {useAutoTripIds &&
+            <>
+              <div style={{alignItems: 'center', display: 'flex'}}>
+                <>
+                  <FormControl
+                    onChange={handleTripPrefixUpdate}
+                    placeholder={messages('prefixPlaceholder')}
+                    style={{width: '30%', marginRight: '5px'}}
+                    type='text'
+                  />
+                -
+                  <FormControl
+                    onChange={handleIncrementStartUpdate}
+                    placeholder={messages('incrementStartPlaceholder')}
+                    style={{width: '40%', marginLeft: '5px', marginRight: '5px'}}
+                    type='number'
+                  />
+                  {messages('incrementBy')}
+                  <FormControl
+                    onChange={handleTripIncrementUpdate}
+                    placeholder={messages('incrementAmountPlaceholder')}
+                    style={{width: '15%', marginLeft: '5px'}}
+                    type='number'
+                    value={autoTripIdIncrement}
+                  />
+                </>
+              </div>
+              <hr />
+            </>
+          }
+        </div>
+        <div>
+          <Checkbox checked={useAutoBlockIds} onChange={handleAutoBlockIDCheckBox}>{messages('automaticallyUpdateBlockIds')} </Checkbox>
+          {useAutoBlockIds &&
+            <>
+              <div style={{alignItems: 'center', display: 'flex'}}>
                 <FormControl
-                  onChange={handleTripPrefixUpdate}
-                  placeholder={messages('prefixPlaceholder')}
+                  onChange={handleBlockPrefixUpdate}
+                  placeholder={messages('blockIdPrefixPlaceholder')}
                   style={{width: '30%', marginRight: '5px'}}
                   type='text'
+                  value={autoBlockIdPrefix} // Remove me??
                 />
-                -
+                {messages('alternateEvery')}
                 <FormControl
-                  onChange={handleIncrementStartUpdate}
-                  placeholder={messages('incrementStartPlaceholder')}
-                  style={{width: '40%', marginLeft: '5px', marginRight: '5px'}}
-                  type='number'
-                />
-                {messages('incrementBy')}
-                <FormControl
-                  onChange={handleTripIncrementUpdate}
-                  placeholder={messages('incrementAmountPlaceholder')}
+                  onChange={handleBlockIncrementUpdate}
+                  placeholder={messages('blockIncrementPlaceholder')}
                   style={{width: '15%', marginLeft: '5px'}}
                   type='number'
-                  value={autoTripIdIncrement}
+                  value={autoBlockIdIncrement}
                 />
-              </>
-            }
-          </div>
+              </div>
+              <span style={{fontSize: 'smaller'}}>{messages('formatExplanation')}</span>
+            </>
+          }
         </div>
 
       </Body>

--- a/lib/editor/components/timetable/TripSeriesModal.js
+++ b/lib/editor/components/timetable/TripSeriesModal.js
@@ -140,16 +140,17 @@ const TripSeriesModal = (props: Props) => {
                   placeholder={messages('blockIdPrefixPlaceholder')}
                   style={{width: '30%', marginRight: '5px'}}
                   type='text'
-                  value={autoBlockIdPrefix} // Remove me??
+                  value={autoBlockIdPrefix}
                 />
                 {messages('alternateEvery')}
                 <FormControl
                   onChange={handleBlockIncrementUpdate}
                   placeholder={messages('blockIncrementPlaceholder')}
-                  style={{width: '15%', marginLeft: '5px'}}
+                  style={{width: '15%', marginLeft: '5px', marginRight: '5px'}}
                   type='number'
                   value={autoBlockIdIncrement}
                 />
+                {messages('trips')}
               </div>
               <span style={{fontSize: 'smaller'}}>{messages('formatExplanation')}</span>
             </>

--- a/lib/editor/components/timetable/TripSeriesModal.js
+++ b/lib/editor/components/timetable/TripSeriesModal.js
@@ -66,6 +66,14 @@ const TripSeriesModal = (props: Props) => {
     setAutoBlockIdStart(1)
     setAutoBlockIdIncrement(1)
     setAutoBlockIdPrefix('')
+    setUseAutoBlockIds(false)
+    setUseAutoTripIds(false)
+  }
+
+  const _onClose = () => {
+    const { onClose } = props
+    clearState()
+    onClose()
   }
 
   const onClickGenerate = useCallback(() => {
@@ -130,6 +138,7 @@ const TripSeriesModal = (props: Props) => {
                     placeholder={messages('prefixPlaceholder')}
                     style={{width: '30%', marginRight: '5px'}}
                     type='text'
+                    value={autoTripIdPrefix}
                   />
                 -
                   <FormControl
@@ -198,7 +207,7 @@ const TripSeriesModal = (props: Props) => {
           {messages('generateTrips')}
         </Button>
         <Button
-          onClick={onClose}>
+          onClick={_onClose}>
           {messages('close')}
         </Button>
       </Footer>

--- a/lib/editor/components/timetable/TripSeriesModal.js
+++ b/lib/editor/components/timetable/TripSeriesModal.js
@@ -27,6 +27,7 @@ const TripSeriesModal = (props: Props) => {
   const [useAutoBlockIds, setUseAutoBlockIds] = useState(false)
 
   const [autoTripIdStart, setAutoTripIdStart] = useState(0)
+  const [autoBlockIdStart, setAutoBlockIdStart] = useState(1)
 
   const [autoTripIdIncrement, setAutoTripIdIncrement] = useState(1)
   const [autoBlockIdIncrement, setAutoBlockIdIncrement] = useState(1)
@@ -37,12 +38,35 @@ const TripSeriesModal = (props: Props) => {
   const messages = getComponentMessages('TripSeriesModal')
 
   const handleIncrementStartUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdStart(+evt.target.value)
+  const handleBlockIdStartUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    // Check the input to make sure it's within the valid range.
+    let input = +evt.target.value
+    if (isNaN(input)) return null
+    if (input > autoBlockIdIncrement) input = autoBlockIdIncrement
+    else if (input < 1) input = 1
+    setAutoBlockIdStart(input)
+  }
+
   const handleTripPrefixUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdPrefix(evt.target.value)
   const handleBlockPrefixUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoBlockIdPrefix(evt.target.value)
+
   const handleTripIncrementUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoTripIdIncrement(+evt.target.value)
   const handleBlockIncrementUpdate = (evt: SyntheticInputEvent<HTMLInputElement>) => setAutoBlockIdIncrement(+evt.target.value)
+
   const handleAutoTripIDCheckBox = () => setUseAutoTripIds(!useAutoTripIds)
   const handleAutoBlockIDCheckBox = () => setUseAutoBlockIds(!useAutoBlockIds)
+
+  const clearState = () => {
+    setStartTime(null)
+    setEndTime(null)
+    setHeadway(null)
+    setAutoTripIdPrefix('')
+    setAutoTripIdStart(0)
+    setAutoTripIdIncrement(1)
+    setAutoBlockIdStart(1)
+    setAutoBlockIdIncrement(1)
+    setAutoBlockIdPrefix('')
+  }
 
   const onClickGenerate = useCallback(() => {
     const {addNewTrip, constructNewRow, onClose} = props
@@ -51,7 +75,7 @@ const TripSeriesModal = (props: Props) => {
     const adjustedEndTime = startTime < endTime ? endTime : endTime + 24 * 60 * 60
 
     let tripId = autoTripIdStart
-    let currentBlockIdSuffix = 1
+    let currentBlockIdSuffix = autoBlockIdStart
     for (let time = startTime; time <= adjustedEndTime; time += headway) {
       const autoTripId = useAutoTripIds ? `${autoTripIdPrefix}-${tripId}` : null
       const autoBlockId = useAutoBlockIds ? `${autoBlockIdPrefix}-${currentBlockIdSuffix}` : null
@@ -65,11 +89,9 @@ const TripSeriesModal = (props: Props) => {
         if (currentBlockIdSuffix > autoBlockIdIncrement) currentBlockIdSuffix = currentBlockIdSuffix % autoBlockIdIncrement
       }
     }
-    setStartTime(null)
-    setEndTime(null)
-    setHeadway(null)
+    clearState()
     onClose()
-  }, [endTime, startTime, headway, autoTripIdStart, autoTripIdIncrement, autoTripIdPrefix, autoBlockIdPrefix, autoBlockIdIncrement])
+  }, [endTime, startTime, headway, autoTripIdStart, autoTripIdIncrement, autoTripIdPrefix, autoBlockIdPrefix, autoBlockIdIncrement, autoBlockIdStart])
 
   const {Body, Footer, Header, Title} = Modal
   const {onClose, show, useSecondsInOffset} = props
@@ -138,7 +160,7 @@ const TripSeriesModal = (props: Props) => {
                 <FormControl
                   onChange={handleBlockPrefixUpdate}
                   placeholder={messages('blockIdPrefixPlaceholder')}
-                  style={{width: '30%', marginRight: '5px'}}
+                  style={{width: '20%', marginRight: '5px'}}
                   type='text'
                   value={autoBlockIdPrefix}
                 />
@@ -150,7 +172,15 @@ const TripSeriesModal = (props: Props) => {
                   type='number'
                   value={autoBlockIdIncrement}
                 />
-                {messages('trips')}
+                {messages('tripsStartingWith')}
+                <FormControl
+                  max={autoBlockIdIncrement}
+                  min={1}
+                  onChange={handleBlockIdStartUpdate}
+                  style={{width: '15%', marginLeft: '5px', marginRight: '5px'}}
+                  type='number'
+                  value={autoBlockIdStart}
+                />
               </div>
               <span style={{fontSize: 'smaller'}}>{messages('formatExplanation')}</span>
             </>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds an option to automatically alternate the block IDs according to a predetermined formula when using the Trip Series Modal. This is a common use case for smaller agencies but of course will only cover the case where block IDs are always alternated according to a sequence.
