### PR TITLE
Add Stop Time Interpolation

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -818,6 +818,25 @@ components:
       fieldUndefined: Field to normalize must be defined.
       substitutionUndefined: Substitution patterns must be defined.
       substitutionInvalid: Some substitution patterns are invalid.
+  NormalizeStopTimesModal:
+    close: Close
+    interpolateStopTimes: Interpolate stop times between timepoints?
+    normalizeStopTimes: Normalize stop times
+    normalizeStopTimesQuestion: Normalize stop times?
+    selectBeginningPatternStop: "Select beginning pattern stop:"
+    usageExplanationOne: This feature is useful when the travel times for one or more
+      pattern stops change. Take for example a pattern
+      that has been re-routed along to travel a longer distance, has had a
+      stop added (or removed), or has had a layover introduced mid-trip.
+      Once you have adjusted the travel times to account for these changes,
+      you can normalize the stop times to bring them into alignment with the
+      updated travel times reflected in the pattern stops.
+    usageExplanationTwo: Interpolating stop times calculates the implicit speed between timepoints
+      based on the shape distance and the default travel times. This speed is
+      then applied to the shape distance traveled for each intermediate non-timepoint
+      stop to provide interpolated travel times. The default travel time for non-timepoint
+      stops will not be modified.
+    usageNotes: " Usage notes"
   NormalizeStopTimesTip:
     info: "Tip: when changing travel times, consider
     using the 'Normalize stop times' button above to automatically update

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -824,6 +824,7 @@ components:
     normalizeStopTimes: Normalize stop times
     normalizeStopTimesQuestion: Normalize stop times?
     selectBeginningPatternStop: "Select beginning pattern stop:"
+    tooFewTimepoints: "You must have more than 1 timepoint to interpolate times"
     usageExplanationOne: This feature is useful when the travel times for one or more
       pattern stops change. Take for example a pattern
       that has been re-routed along to travel a longer distance, has had a

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -836,6 +836,7 @@ components:
     normalizeStopTimes: Normalize stop times
     normalizeStopTimesQuestion: Normalize stop times?
     selectBeginningPatternStop: "Select beginning pattern stop:"
+    tooFewTimepoints: "You must have more than 1 timepoint to interpolate times"
     usageExplanationOne: This feature is useful when the travel times for one or more
       pattern stops change. Take for example a pattern
       that has been re-routed along to travel a longer distance, has had a

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -830,6 +830,25 @@ components:
       fieldUndefined: Zu normalisierendes Feld muss angegeben werden.
       substitutionInvalid: Substitutions-Muster ungültig.
       substitutionUndefined: Substitution-Muster müssen angegeben werden.
+  NormalizeStopTimesModal:
+    close: Close
+    interpolateStopTimes: Interpolate stop times between timepoints?
+    normalizeStopTimes: Normalize stop times
+    normalizeStopTimesQuestion: Normalize stop times?
+    selectBeginningPatternStop: "Select beginning pattern stop:"
+    usageExplanationOne: This feature is useful when the travel times for one or more
+      pattern stops change. Take for example a pattern
+      that has been re-routed along to travel a longer distance, has had a
+      stop added (or removed), or has had a layover introduced mid-trip.
+      Once you have adjusted the travel times to account for these changes,
+      you can normalize the stop times to bring them into alignment with the
+      updated travel times reflected in the pattern stops.
+    usageExplanationTwo: Interpolating stop times calculates the implicit speed between timepoints
+      based on the shape distance and the default travel times. This speed is
+      then applied to the shape distance traveled for each intermediate non-timepoint
+      stop to provide interpolated travel times. The default travel time for non-timepoint
+      stops will not be modified.
+    usageNotes: " Usage notes"
   NormalizeStopTimesTip:
     info: 'Tipp: Wenn Sie Reisezeiten ändern, erwägen Sie die Benutzung des "Stop
       times normalisieren"-Buttons oberhalb, um automatisch alle Stop Times auf die

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -827,6 +827,7 @@ components:
     normalizeStopTimes: Normalize stop times
     normalizeStopTimesQuestion: Normalize stop times?
     selectBeginningPatternStop: "Select beginning pattern stop:"
+    tooFewTimepoints: "You must have more than 1 timepoint to interpolate times"
     usageExplanationOne: This feature is useful when the travel times for one or more
       pattern stops change. Take for example a pattern
       that has been re-routed along to travel a longer distance, has had a

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -821,6 +821,25 @@ components:
       fieldUndefined: Field to normalize must be defined.
       substitutionInvalid: Some substitution patterns are invalid.
       substitutionUndefined: Substitution patterns must be defined.
+  NormalizeStopTimesModal:
+    close: Close
+    interpolateStopTimes: Interpolate stop times between timepoints?
+    normalizeStopTimes: Normalize stop times
+    normalizeStopTimesQuestion: Normalize stop times?
+    selectBeginningPatternStop: "Select beginning pattern stop:"
+    usageExplanationOne: This feature is useful when the travel times for one or more
+      pattern stops change. Take for example a pattern
+      that has been re-routed along to travel a longer distance, has had a
+      stop added (or removed), or has had a layover introduced mid-trip.
+      Once you have adjusted the travel times to account for these changes,
+      you can normalize the stop times to bring them into alignment with the
+      updated travel times reflected in the pattern stops.
+    usageExplanationTwo: Interpolating stop times calculates the implicit speed between timepoints
+      based on the shape distance and the default travel times. This speed is
+      then applied to the shape distance traveled for each intermediate non-timepoint
+      stop to provide interpolated travel times. The default travel time for non-timepoint
+      stops will not be modified.
+    usageNotes: " Usage notes"
   NormalizeStopTimesTip:
     info: 'Tip: when changing travel times, consider using the "Normalize stop times"
       button above to automatically update all stop times to the updated travel time.'

--- a/lib/editor/actions/tripPattern.js
+++ b/lib/editor/actions/tripPattern.js
@@ -4,20 +4,20 @@ import {createAction, type ActionType} from 'redux-actions'
 import {ActionCreators} from 'redux-undo'
 import {toast} from 'react-toastify'
 
-import {resetActiveGtfsEntity, savedGtfsEntity, updateActiveGtfsEntity, updateEditSetting} from './active'
 import {createVoidPayloadAction, fetchGraphQL, secureFetch} from '../../common/actions'
 import {snakeCaseKeys} from '../../common/util/map-keys'
 import {generateUID} from '../../common/util/util'
-import {showEditorModal} from './editor'
 import {shapes} from '../../gtfs/util/graphql'
 import {fetchGTFSEntities, receiveGTFSEntities} from '../../manager/actions/versions'
-import {fetchTripCounts} from './trip'
 import {getEditorNamespace} from '../util/gtfs'
 import {resequenceStops, resequenceShapePoints} from '../util/map'
 import {entityIsNew} from '../util/objects'
-
 import type {ControlPoint, Pattern, PatternStop} from '../../types'
 import type {dispatchFn, getStateFn} from '../../types/reducers'
+
+import {fetchTripCounts} from './trip'
+import {showEditorModal} from './editor'
+import {resetActiveGtfsEntity, savedGtfsEntity, updateActiveGtfsEntity, updateEditSetting} from './active'
 
 const fetchingTripPatterns = createVoidPayloadAction('FETCHING_TRIP_PATTERNS')
 const savedTripPattern = createVoidPayloadAction('SAVED_TRIP_PATTERN')
@@ -51,12 +51,12 @@ export type EditorTripPatternActions = ActionType<typeof normalizeStopTimes> |
  * provides a way to bulk update existing trips when pattern stops are modified
  * (e.g., a pattern stop is inserted, removed, or its travel times modified).
  */
-export function normalizeStopTimes (patternId: number, beginStopSequence: number) {
+export function normalizeStopTimes (patternId: number, beginStopSequence: number, interpolateStopTimes: boolean) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     const {data} = getState().editor
     const {feedSourceId} = data.active
     const sessionId = data.lock.sessionId || ''
-    const url = `/api/editor/secure/pattern/${patternId}/stop_times?feedId=${feedSourceId || ''}&sessionId=${sessionId}&stopSequence=${beginStopSequence}`
+    const url = `/api/editor/secure/pattern/${patternId}/stop_times?feedId=${feedSourceId || ''}&sessionId=${sessionId}&stopSequence=${beginStopSequence}&interpolateStopTimes=${interpolateStopTimes.toString()}`
     return dispatch(secureFetch(url, 'put'))
       .then(res => res.json())
       .then(json => toast.info(`ⓘ ${json.updateResult}`, {

--- a/lib/editor/components/pattern/NormalizeStopTimesModal.js
+++ b/lib/editor/components/pattern/NormalizeStopTimesModal.js
@@ -83,6 +83,8 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
             <OverlayTrigger
               overlay={<Tooltip>{this.messages('tooFewTimepoints')}</Tooltip>}
               placement='bottom'
+              // Semi-hack: Use the trigger prop to conditionally render the tooltip text only when checkbox is disabled.
+              trigger={interpolationDisabled ? ['hover'] : []}
             >
               <Checkbox
                 disabled={interpolationDisabled}

--- a/lib/editor/components/pattern/NormalizeStopTimesModal.js
+++ b/lib/editor/components/pattern/NormalizeStopTimesModal.js
@@ -2,7 +2,7 @@
 
 import Icon from '@conveyal/woonerf/components/icon'
 import React, { Component } from 'react'
-import { Alert, Button, ControlLabel, FormControl, Modal } from 'react-bootstrap'
+import { Alert, Button, Checkbox, ControlLabel, FormControl, Modal } from 'react-bootstrap'
 
 import * as tripPatternActions from '../../actions/tripPattern'
 import type { GtfsStop, Pattern } from '../../../types'
@@ -15,17 +15,18 @@ type Props = {
   stops: Array<GtfsStop>
 }
 
-type State = { patternStopIndex: number, show: boolean }
+  type State = { interpolateStopTimes: boolean, patternStopIndex: number, show: boolean }
 
 export default class NormalizeStopTimesModal extends Component<Props, State> {
   state = {
+    interpolateStopTimes: false,
     patternStopIndex: 0, // default to zeroth pattern stop
     show: false
   }
 
   _onClickNormalize = () => {
     const { activePattern, normalizeStopTimes } = this.props
-    normalizeStopTimes(activePattern.id, this.state.patternStopIndex)
+    normalizeStopTimes(activePattern.id, this.state.patternStopIndex, this.state.interpolateStopTimes)
   }
 
   _onChangeStop = (evt: SyntheticInputEvent<HTMLInputElement>) => {
@@ -35,6 +36,10 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
   _onClose = () => {
     this.setState({ show: false })
     this.props.onClose()
+  }
+
+  _onChangeInterpolation = () => {
+    this.setState({interpolateStopTimes: !this.state.interpolateStopTimes})
   }
 
   render () {
@@ -69,6 +74,12 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
             }
             )}
           </FormControl>
+          <Checkbox
+            onChange={this._onChangeInterpolation}
+            value={this.state.interpolateStopTimes}
+          >
+            Interpolate stop times between timepoints?
+          </Checkbox>
           <br />
           <Alert bsStyle='warning'>
             {this.state.patternStopIndex === 0
@@ -95,6 +106,12 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
               Once you have adjusted the travel times to account for these changes,
               you can normalize the stop times to bring them into alignment with the
               updated travel times reflected in the pattern stops.
+              <hr />
+              Interpolating stop times calculates the implicit speed between timepoints
+              based on the shape distance and the default travel times. This speed is
+              then applied to the shape distance traveled for each intermediate non-timepoint
+              stop to provide interpolated travel times. The default travel time for non-timepoint
+              stops will not be modified.
               <hr />
               <strong>Note:</strong> this does not account for any variation
               in travel time between stops for trips throughout the day (e.g.,

--- a/lib/editor/components/pattern/NormalizeStopTimesModal.js
+++ b/lib/editor/components/pattern/NormalizeStopTimesModal.js
@@ -30,6 +30,7 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
   _onClickNormalize = () => {
     const { activePattern, normalizeStopTimes } = this.props
     normalizeStopTimes(activePattern.id, this.state.patternStopIndex, this.state.interpolateStopTimes)
+    this.setState({interpolateStopTimes: false})
   }
 
   _onChangeStop = (evt: SyntheticInputEvent<HTMLInputElement>) => {
@@ -37,7 +38,7 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
   }
 
   _onClose = () => {
-    this.setState({ show: false })
+    this.setState({ show: false, interpolateStopTimes: false })
     this.props.onClose()
   }
 

--- a/lib/editor/components/pattern/NormalizeStopTimesModal.js
+++ b/lib/editor/components/pattern/NormalizeStopTimesModal.js
@@ -2,7 +2,7 @@
 
 import Icon from '@conveyal/woonerf/components/icon'
 import React, { Component } from 'react'
-import { Alert, Button, Checkbox, ControlLabel, FormControl, Modal } from 'react-bootstrap'
+import { Alert, Button, Checkbox, ControlLabel, FormControl, Modal, OverlayTrigger, Tooltip } from 'react-bootstrap'
 
 import * as tripPatternActions from '../../actions/tripPattern'
 import type { GtfsStop, Pattern } from '../../../types'
@@ -48,6 +48,8 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
   render () {
     const { Body, Footer, Header, Title } = Modal
     const { activePattern, stops } = this.props
+    const timepoints = activePattern.patternStops.filter(ps => ps.timepoint === 1)
+    const interpolationDisabled = timepoints.length < 2
     return (
       <Modal show={this.props.show || this.state.show} onHide={this._onClose}>
         <Header>
@@ -77,12 +79,20 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
             }
             )}
           </FormControl>
-          <Checkbox
-            onChange={this._onChangeInterpolation}
-            value={this.state.interpolateStopTimes}
-          >
-            {this.messages('interpolateStopTimes')}
-          </Checkbox>
+          <div style={{alignContent: 'center', alignItems: 'center', display: 'flex'}}>
+            <OverlayTrigger
+              overlay={<Tooltip>{this.messages('tooFewTimepoints')}</Tooltip>}
+              placement='bottom'
+            >
+              <Checkbox
+                disabled={interpolationDisabled}
+                onChange={this._onChangeInterpolation}
+                value={this.state.interpolateStopTimes}
+              />
+            </OverlayTrigger>
+            {/* Separate label so that tooltip appears over checkbox. Hack: Padding to align center with checkbox */}
+            <span style={{paddingBottom: '2px'}}>{this.messages('interpolateStopTimes')}</span>
+          </div>
           <br />
           <Alert bsStyle='warning'>
             {this.state.patternStopIndex === 0

--- a/lib/editor/components/pattern/NormalizeStopTimesModal.js
+++ b/lib/editor/components/pattern/NormalizeStopTimesModal.js
@@ -6,6 +6,7 @@ import { Alert, Button, Checkbox, ControlLabel, FormControl, Modal } from 'react
 
 import * as tripPatternActions from '../../actions/tripPattern'
 import type { GtfsStop, Pattern } from '../../../types'
+import { getComponentMessages } from '../../../common/util/config'
 
 type Props = {
   activePattern: Pattern,
@@ -18,6 +19,8 @@ type Props = {
   type State = { interpolateStopTimes: boolean, patternStopIndex: number, show: boolean }
 
 export default class NormalizeStopTimesModal extends Component<Props, State> {
+  messages = getComponentMessages('NormalizeStopTimesModal')
+
   state = {
     interpolateStopTimes: false,
     patternStopIndex: 0, // default to zeroth pattern stop
@@ -48,7 +51,7 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
     return (
       <Modal show={this.props.show || this.state.show} onHide={this._onClose}>
         <Header>
-          <Title>Normalize stop times?</Title>
+          <Title>{this.messages('normalizeStopTimesQuestion')}</Title>
         </Header>
         <Body>
           <p>
@@ -56,7 +59,7 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
             times for <strong>all trips</strong> on this pattern to conform
             to the default travel and dwell times defined for the pattern stops.
           </p>
-          <ControlLabel>Select beginning pattern stop:</ControlLabel>
+          <ControlLabel>{this.messages('selectBeginningPatternStop')}</ControlLabel>
           <FormControl
             value={this.state.patternStopIndex}
             componentClass='select'
@@ -78,7 +81,7 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
             onChange={this._onChangeInterpolation}
             value={this.state.interpolateStopTimes}
           >
-            Interpolate stop times between timepoints?
+            {this.messages('interpolateStopTimes')}
           </Checkbox>
           <br />
           <Alert bsStyle='warning'>
@@ -97,21 +100,11 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
             }
           </Alert>
           <Alert bsStyle='info'>
-            <h5><Icon type='info-circle' /> Usage notes</h5>
+            <h5><Icon type='info-circle' />{this.messages('usageNotes')}</h5>
             <small>
-              This feature is useful when the travel times for one or more
-              pattern stops change. Take for example a pattern
-              that has been re-routed along to travel a longer distance, has had a
-              stop added (or removed), or has had a layover introduced mid-trip.
-              Once you have adjusted the travel times to account for these changes,
-              you can normalize the stop times to bring them into alignment with the
-              updated travel times reflected in the pattern stops.
+              {this.messages('usageExplanationOne')}
               <hr />
-              Interpolating stop times calculates the implicit speed between timepoints
-              based on the shape distance and the default travel times. This speed is
-              then applied to the shape distance traveled for each intermediate non-timepoint
-              stop to provide interpolated travel times. The default travel time for non-timepoint
-              stops will not be modified.
+              {this.messages('usageExplanationTwo')}
               <hr />
               <strong>Note:</strong> this does not account for any variation
               in travel time between stops for trips throughout the day (e.g.,
@@ -125,11 +118,11 @@ export default class NormalizeStopTimesModal extends Component<Props, State> {
             bsStyle='primary'
             onClick={this._onClickNormalize}
           >
-            Normalize stop times
+            {this.messages('normalizeStopTimes')}
           </Button>
           <Button
             onClick={this._onClose}>
-            Close
+            {this.messages('close')}
           </Button>
         </Footer>
       </Modal>

--- a/lib/editor/components/pattern/PatternStopsPanel.js
+++ b/lib/editor/components/pattern/PatternStopsPanel.js
@@ -122,11 +122,14 @@ export default class PatternStopsPanel extends Component<Props, State> {
         </h4>
         <div style={{width: '100%'}}>
           <Button
+            disabled={!patternHasStops}
             onClick={this._clickNormalizeStopTimes}
             style={{marginBottom: '5px'}}
             className='pull-right'
             block
-            bsSize='small'>
+            bsSize='small'
+            title={!patternHasStops ? 'Must add stops to pattern before normalizing' : ''}
+          >
             <Icon type='clock-o' />{' '}
             Normalize stop times
           </Button>


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Front end PR to add support for stop time interpolation in the NormalizeStopTimes modal. 
Backend PR: https://github.com/ibi-group/datatools-server/pull/572
GTFS-lib PR: https://github.com/conveyal/gtfs-lib/pull/399
