### PR TITLE
Fix Timetable Pasting

### DIFF
--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -304,7 +304,6 @@ export default class EditableCell extends Component<Props, State> {
         onPaste={this.handlePaste}
         placeholder={placeholder || ''}
         readOnly={!isEditing}
-        ref='inputCell'
         type='text' />
       : <div
         className='cell-div noselect'

--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -192,6 +192,7 @@ export default class EditableCell extends Component<Props, State> {
   }
 
   save () {
+    this.cancel()
     const {column} = this.props
     const {data} = this.state
     // for non-time rendering

--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -5,7 +5,7 @@ import moment from 'moment'
 
 import * as tripActions from '../../actions/trip'
 import {secondsAfterMidnightToHHMM} from '../../../common/util/gtfs'
-import { isTimeFormat } from '../../util/timetable'
+import { isTimeFormat, parseCellValue } from '../../util/timetable'
 import type {TimetableColumn} from '../../../types'
 import type {EditorValidationIssue} from '../../util/validation'
 
@@ -65,8 +65,6 @@ export default class EditableCell extends Component<Props, State> {
       originalData: this.props.data
     })
   }
-
-  cellInput = null
 
   /**
    * The component may receive data from a save event or
@@ -157,8 +155,6 @@ export default class EditableCell extends Component<Props, State> {
         offsetScrollCol(-1)
         return
       case 38: // up
-        this.save()
-        break
       case 40: // down
         this.save()
         break
@@ -206,6 +202,14 @@ export default class EditableCell extends Component<Props, State> {
       // Ensure that only a positive integer value can be set.
       const value = +data
       this._handleSave(value)
+    } else if (isTimeFormat(column.type)) {
+      if (typeof data !== 'string') return this.cancel()
+      const parsedValue = parseCellValue(data, column)
+      if (parsedValue !== null) {
+        this._handleSave(parsedValue)
+      } else {
+        this.cancel()
+      }
     } else {
       if (typeof data !== 'string') return this.cancel()
       const duration = moment.duration(data)
@@ -238,11 +242,8 @@ export default class EditableCell extends Component<Props, State> {
         ? String.fromCharCode(13)
         : undefined
     const rows = text.split(rowDelimiter)
-    const rowsAndColumns = []
-    // Split each row into columns
-    for (let i = 0; i < rows.length; i++) {
-      rowsAndColumns.push(rows[i].split(String.fromCharCode(9)))
-    }
+    // Remove carriage return characters (/r) from rows to handle pasted data from Excel
+    const rowsAndColumns = rows.map(row => row.split(String.fromCharCode(9)).map(cellValue => cellValue.replace(/\r/g, '')))
 
     if (rowsAndColumns.length > 1 || rowsAndColumns[0].length > 1) {
       this.cancel()
@@ -303,6 +304,7 @@ export default class EditableCell extends Component<Props, State> {
         onPaste={this.handlePaste}
         placeholder={placeholder || ''}
         readOnly={!isEditing}
+        ref='inputCell'
         type='text' />
       : <div
         className='cell-div noselect'

--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -371,7 +371,6 @@ export default class TimetableGrid extends Component<Props> {
       addNewRow,
       columns,
       data,
-      // setActiveCell,
       hideDepartureTimes,
       updateCellValue,
       updateScroll
@@ -410,10 +409,6 @@ export default class TimetableGrid extends Component<Props> {
         }
       }
     }
-    // Prevent the active cell from being set to the last cell in the pasted selection
-    // if (activeRow !== rowIndex + pastedRows.length - 1) {
-    //   setActiveCell(`${activeRow}-${activeCol}`)
-    // }
     updateScroll(activeRow, activeCol)
   }
 

--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -377,6 +377,7 @@ export default class TimetableGrid extends Component<Props> {
     } = this.props
     let activeRow = rowIndex
     let activeCol = colIndex
+    let errorShown = false
     // Iterate over rows in pasted selection
     for (var i = 0; i < pastedRows.length; i++) {
       activeRow = rowIndex + i
@@ -390,7 +391,7 @@ export default class TimetableGrid extends Component<Props> {
         const col = columns[activeCol]
         const path = `${activeRow}.${col.key}`
         const originalValue = objectPath.get(data[activeRow], col.key)
-        const value = parseCellValue(pastedRows[i][j], col)
+        const value = parseCellValue(pastedRows[i][j], col, errorShown)
         if (value !== null) {
           const finalValue = value
           updateCellValue({ value: finalValue, rowIndex: activeRow, key: path })
@@ -406,6 +407,7 @@ export default class TimetableGrid extends Component<Props> {
         } else {
           // If the value is rejected, keep the original value
           updateCellValue({ value: originalValue, rowIndex: activeRow, key: path })
+          errorShown = true
         }
       }
     }

--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -10,8 +10,6 @@ import objectPath from 'object-path'
 
 import * as tripActions from '../../actions/trip'
 import {ENTITY} from '../../constants'
-import HeaderCell from './HeaderCell'
-import EditableCell from './EditableCell'
 import {
   getHeaderColumns,
   HEADER_GRID_STYLE,
@@ -23,16 +21,18 @@ import {
   MAIN_GRID_WRAPPER_STYLE,
   OVERSCAN_COLUMN_COUNT,
   OVERSCAN_ROW_COUNT,
-  parseTime,
+  parseCellValue,
   ROW_HEIGHT,
   SCROLL_SIZE,
   TOP_LEFT_STYLE,
   WRAPPER_STYLE
 } from '../../util/timetable'
-
 import type {Pattern, TimetableColumn} from '../../../types'
 import type {TimetableState} from '../../../types/reducers'
 import type {TripValidationIssues} from '../../selectors/timetable'
+
+import EditableCell from './EditableCell'
+import HeaderCell from './HeaderCell'
 
 type Style = {[string]: number | string}
 
@@ -371,38 +371,49 @@ export default class TimetableGrid extends Component<Props> {
       addNewRow,
       columns,
       data,
-      setActiveCell,
+      // setActiveCell,
       hideDepartureTimes,
       updateCellValue,
       updateScroll
     } = this.props
     let activeRow = rowIndex
     let activeCol = colIndex
-    // iterate over rows in pasted selection
+    // Iterate over rows in pasted selection
     for (var i = 0; i < pastedRows.length; i++) {
       activeRow = rowIndex + i
-      // construct new row if it doesn't exist
-      if (typeof data[i + rowIndex] === 'undefined') {
+      // Construct new row if it doesn't exist
+      if (typeof data[activeRow] === 'undefined') {
         addNewRow()
       }
-      // iterate over number of columns in pasted selection
+      // Iterate over number of columns in pasted selection
       for (var j = 0; j < pastedRows[0].length; j++) {
         activeCol = colIndex + j
-        const path = `${rowIndex + i}.${columns[colIndex + j].key}`
-        const value = parseTime(pastedRows[i][j])
-        updateCellValue({value, rowIndex: rowIndex + i, key: path})
-        // if departure times are hidden, paste into adjacent time column
-        const adjacentPath = `${rowIndex + i}.${columns[colIndex + j + 2].key}`
-        if (
-          hideDepartureTimes &&
-          isTimeFormat(columns[colIndex + j].type) &&
-          typeof objectPath.get(data, adjacentPath) !== 'undefined'
-        ) {
-          updateCellValue({value, rowIndex: rowIndex + i, key: adjacentPath})
+        const col = columns[activeCol]
+        const path = `${activeRow}.${col.key}`
+        const originalValue = objectPath.get(data[activeRow], col.key)
+        const value = parseCellValue(pastedRows[i][j], col)
+        if (value !== null) {
+          const finalValue = value
+          updateCellValue({ value: finalValue, rowIndex: activeRow, key: path })
+          // If departure times are hidden, paste into adjacent time column
+          const adjacentPath = `${activeRow}.${columns[activeCol + 2].key}`
+          if (
+            hideDepartureTimes &&
+            isTimeFormat(col.type) &&
+            typeof objectPath.get(data, adjacentPath) !== 'undefined'
+          ) {
+            updateCellValue({ value: finalValue, rowIndex: activeRow, key: adjacentPath })
+          }
+        } else {
+          // If the value is rejected, keep the original value
+          updateCellValue({ value: originalValue, rowIndex: activeRow, key: path })
         }
       }
     }
-    setActiveCell(`${activeRow}-${activeCol}`)
+    // Prevent the active cell from being set to the last cell in the pasted selection
+    // if (activeRow !== rowIndex + pastedRows.length - 1) {
+    //   setActiveCell(`${activeRow}-${activeCol}`)
+    // }
     updateScroll(activeRow, activeCol)
   }
 

--- a/lib/editor/util/timetable.js
+++ b/lib/editor/util/timetable.js
@@ -40,12 +40,17 @@ export function getHeaderColumns (
   return columns.filter(c => c.type !== 'DEPARTURE_TIME')
 }
 
-export function parseTime (timeString: string) {
+export function parseCellValue (timeString: string, col: TimetableColumn) {
   const date = moment().startOf('day').format('YYYY-MM-DD')
-  return moment(date + 'T' + timeString, TIMETABLE_FORMATS).diff(
-    date,
-    'seconds'
-  )
+  const parsedDate = moment(date + 'T' + timeString, TIMETABLE_FORMATS, true)
+  if (isTimeFormat(col.type)) {
+    if (!parsedDate.isValid()) {
+      alert(`Please enter a valid time format`)
+      return null
+    }
+    return moment(date + 'T' + timeString, TIMETABLE_FORMATS).diff(date, 'seconds')
+  }
+  return timeString
 }
 
 export const LEFT_COLUMN_WIDTH = 30

--- a/lib/editor/util/timetable.js
+++ b/lib/editor/util/timetable.js
@@ -40,12 +40,12 @@ export function getHeaderColumns (
   return columns.filter(c => c.type !== 'DEPARTURE_TIME')
 }
 
-export function parseCellValue (timeString: string, col: TimetableColumn) {
+export function parseCellValue (timeString: string, col: TimetableColumn, errorShown?: boolean) {
   const date = moment().startOf('day').format('YYYY-MM-DD')
   const parsedDate = moment(date + 'T' + timeString, TIMETABLE_FORMATS, true)
   if (isTimeFormat(col.type)) {
     if (!parsedDate.isValid()) {
-      alert(`Please enter a valid time format`)
+      if (errorShown !== true) alert(`Please enter a valid time format`)
       return null
     }
     return moment(date + 'T' + timeString, TIMETABLE_FORMATS).diff(date, 'seconds')


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

- Enhances data handling when pasting content from the clipboard, such as CSV data, into TEXT type timetable cells (e.g., Trip ID, Trip Headsign). Previously, the data was returned as seconds, which an issue
![image](https://github.com/ibi-group/datatools-ui/assets/62163307/2ff33f3e-826a-4f01-9fd1-2f395962b7e7)
- Improves the handling of carriage return characters that may appear when pasting data from Excel so `parseCellValue` can parse the correct string in`TIMETABLE_FORMATS`
- Checks if the parsed value is valid and keeps the original value of the timetable cell instead of returning 00:00:00 for:
     - pasted CSV
     - inputted data in individual cells
