### PR TITLE
Fix bug with export pattern modal

### DIFF
--- a/lib/editor/components/EditorFeedSourcePanel.js
+++ b/lib/editor/components/EditorFeedSourcePanel.js
@@ -84,8 +84,9 @@ export default class EditorFeedSourcePanel extends Component<Props> {
                       return (
                         <SnapshotItem
                           disabled={disabled}
+                          exportPatternsModal={this.refs.exportPatternsModal}
                           key={s.id}
-                          modal={this.refs.exportPatternsModal}
+                          modal={this.refs.confirmModal}
                           snapshot={s}
                           {...this.props} />
                       )
@@ -133,6 +134,7 @@ export type ItemProps = {
   deleteSnapshot: typeof snapshotActions.deleteSnapshot,
   disabled: boolean,
   downloadSnapshot: typeof snapshotActions.downloadSnapshot,
+  exportPatternsModal: any,
   feedSource: Feed,
   modal: any,
   restoreSnapshot: typeof snapshotActions.restoreSnapshot,
@@ -148,7 +150,7 @@ class SnapshotItem extends Component<ItemProps> {
   }
 
   _onClickExport = () => {
-    this.props.modal.open({snapshot: this.props.snapshot})
+    this.props.exportPatternsModal.open({snapshot: this.props.snapshot})
   }
 
   _onDeleteSnapshot = () => {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

The old modal was replaced rather than just supplemented by the new pattern export modal. This PR makes the pattern export modal a separate ref and only opens it on the export button being clicked. 
