### PR TITLE
Update Placeholder For Custom Raw Input

### DIFF
--- a/lib/manager/components/deployment/CustomConfig.js
+++ b/lib/manager/components/deployment/CustomConfig.js
@@ -152,7 +152,7 @@ export default class CustomConfig extends Component<{
             <FormControl
               componentClass='textarea'
               style={{height: '125px'}}
-              placeholder='{"blah": true}'
+              placeholder='{"property": true}'
               onChange={e => this._onChangeConfig(e, CONFIG_OPTIONS.custom)}
               value={value} />
             {!validJSON && <HelpBlock>Must provide valid JSON string.</HelpBlock>}

--- a/lib/manager/components/deployment/CustomFileEditor.js
+++ b/lib/manager/components/deployment/CustomFileEditor.js
@@ -282,7 +282,7 @@ export default class CustomFileEditor extends Component<Props, {
               componentClass='textarea'
               disabled={!isEditing}
               style={{height: '125px'}}
-              placeholder='{"blah": true}'
+              placeholder='{"property": true}'
               onChange={this._onChangeContents}
               value={customFile.contents}
             />


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Using "blah" was perhaps not the most demonstrative or user-friendly. This PR updates that placeholder to just use "property"
