### PR TITLE
Flex: Timetable Editor: Support Flex stop times allowing multiple stop times to have the same times

### DIFF
--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -77,7 +77,7 @@ function getCloneProps (entityId: number, component: string, state: AppState) {
         patternId: newPatternId,
         shapeId: newShapeId,
         shapePoints: pattern.shapePoints.map(sp => ({...sp, shapeId: newShapeId})),
-        patternStopAreas: pattern.stopAreas.map(area => ({...area, patternId: newPatternId})),
+        patternStopAreas: pattern.stopAreas && pattern.stopAreas.map(area => ({...area, patternId: newPatternId})),
         patternLocations: pattern.patternLocations.map(pl => ({...pl, patternId: newPatternId})),
         patternStops: pattern.patternStops.map(ps => ({...ps, patternId: newPatternId}))
       }

--- a/lib/editor/selectors/timetable.js
+++ b/lib/editor/selectors/timetable.js
@@ -157,6 +157,7 @@ const isCellValueInvalid = (
   tripIds: Array<string>
 ): ?EditorValidationIssue => {
   const col = columns[colIndex]
+  const isFlexInvolved = columns.some(isFlexStopTime)
 
   if (isTimeFormat(col.type)) {
     // FIXME: This does not yet support validating frequency start/end times.
@@ -176,7 +177,7 @@ const isCellValueInvalid = (
       // Ensure value is increasing over previous value
       // Flexible stop times (because intra zonal trips are represented by a duplicate stop time) can
       // include the same start and end pickup times back to back and so must avoid this check.
-      const isInvalid = !isFlexStopTime(col) && val < previousValue
+      const isInvalid = !isFlexInvolved && val < previousValue
       return isInvalid
         ? {
           field: col.key,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

It seems the new flex spec allows you to have multiple stops and locations on the same row at the same time. This PR allows this for stops instead of just locations