### PR TITLE
fix: define and document MAP_BASE_URL to prevent gray maps

### DIFF
--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -6,7 +6,7 @@ MAP_BASE_URL: optional-map-tile-url
 MAPBOX_ACCESS_TOKEN: your-mapbox-access-token
 MAPBOX_MAP_ID: mapbox/outdoors-v11
 MAPBOX_ATTRIBUTION: <a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox &copy; OpenStreetMap</a> <a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>
-MAP_BASE_URL: http://tile.openstreetmap.org/{z}/{x}/{y}.png # Keep it until a fix or maps are gray
+# MAP_BASE_URL: http://tile.openstreetmap.org/{z}/{x}/{y}.png # Uncomment it if maps are gray
 SLACK_CHANNEL: optional-slack-channel
 SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -6,6 +6,7 @@ MAP_BASE_URL: optional-map-tile-url
 MAPBOX_ACCESS_TOKEN: your-mapbox-access-token
 MAPBOX_MAP_ID: mapbox/outdoors-v11
 MAPBOX_ATTRIBUTION: <a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox &copy; OpenStreetMap</a> <a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>
+MAP_BASE_URL: http://tile.openstreetmap.org/{z}/{x}/{y}.png # Keep it until a fix or maps are gray
 SLACK_CHANNEL: optional-slack-channel
 SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key

--- a/docs/dev/deployment.md
+++ b/docs/dev/deployment.md
@@ -244,6 +244,8 @@ Enables the GTFS Editor module.
 - `MAPBOX_ACCESS_TOKEN`
 - `R5_URL` (optional parameter for r5 routing in editor pattern drawing)
 
+**Note:** If maps are gray, add the property `MAP_BASE_URL: http://tile.openstreetmap.org/{z}/{x}/{y}.png` into `env.yml`.
+
 ### R5 network validation
 
 While the application handles basic validation even without the `r5_network`


### PR DESCRIPTION
### Checklist

- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

The maps are gray when we start the application with this commit id ae16265b8041d32a45964bb0d208d8eb6cf5a347. 
A functional fix was suggested by a maintainer. My suggestion is to add it to the default environment variables template.

Fix suggestion: https://github.com/ibi-group/datatools-ui/issues/983#issuecomment-1922182079
Related issue: https://github.com/ibi-group/datatools-ui/issues/983