### PR TITLE
Modification to use Valhalla routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ scripts/*client.json
 
 # Vs code settings
 .vscode/
+
+# My Entries
+notes.txt
+Temp/

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -2,11 +2,10 @@ AUTH0_CLIENT_ID: your-auth0-client-id
 AUTH0_CONNECTION_NAME: your-auth0-connection-name
 AUTH0_DOMAIN: your-auth0-domain
 BUGSNAG_KEY: optional-bugsnag-key
-MAP_BASE_URL: optional-map-tile-url
+MAP_BASE_URL: http://tile.openstreetmap.org/{z}/{x}/{y}.png # Uncomment it if maps are gray
 MAPBOX_ACCESS_TOKEN: your-mapbox-access-token
 MAPBOX_MAP_ID: mapbox/outdoors-v11
 MAPBOX_ATTRIBUTION: <a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox &copy; OpenStreetMap</a> <a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>
-# MAP_BASE_URL: http://tile.openstreetmap.org/{z}/{x}/{y}.png # Uncomment it if maps are gray
 SLACK_CHANNEL: optional-slack-channel
 SLACK_WEBHOOK: optional-slack-webhook
 GRAPH_HOPPER_KEY: your-graph-hopper-key

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -25,3 +25,6 @@ GRAPH_HOPPER_KEY: your-graph-hopper-key
 GOOGLE_ANALYTICS_TRACKING_ID: optional-ga-key
 # GRAPH_HOPPER_POINT_LIMIT: 10 # Defaults to 30
 DISABLE_AUTH: true
+
+MAPTYPE: OSM
+VALHALLA_URL: "https://valhalla1.openstreetmap.de/route"

--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -8,7 +8,7 @@ MAPBOX_MAP_ID: mapbox/outdoors-v11
 MAPBOX_ATTRIBUTION: <a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox &copy; OpenStreetMap</a> <a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>
 SLACK_CHANNEL: optional-slack-channel
 SLACK_WEBHOOK: optional-slack-webhook
-GRAPH_HOPPER_KEY: your-graph-hopper-key
+# GRAPH_HOPPER_KEY: your-graph-hopper-key
 # Optional override to use a custom service instead of the graphhopper.com hosted service.
 # GRAPH_HOPPER_URL: http://localhost:8989/
 # Optional overrides to use custom service or different api key for certain bounding boxes.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 x-common-variables: &common-variables
   - BUGSNAG_KEY=${BUGSNAG_KEY}
@@ -42,15 +41,17 @@ services:
         target: /config
     ports:
       - "4000:4000"
-  # datatools-ui:
-  #   build:
-  #     context: ../
-  #     dockerfile: ./docker/ui/Dockerfile
-  #     args: *common-variables
-  #   restart: always
-  #   environment: *common-variables
-  #   ports:
-  #     - "9966:9966"
+
+  datatools-ui:
+    build:
+      context: ../
+      dockerfile: ./docker/ui/Dockerfile
+      args: *common-variables
+    restart: always
+    environment: *common-variables
+    ports:
+      - "9966:9966"
+
   mongo:
     image: mongo
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,15 +42,15 @@ services:
         target: /config
     ports:
       - "4000:4000"
-  datatools-ui:
-    build:
-      context: ../
-      dockerfile: ./docker/ui/Dockerfile
-      args: *common-variables
-    restart: always
-    environment: *common-variables
-    ports:
-      - "9966:9966"
+  # datatools-ui:
+  #   build:
+  #     context: ../
+  #     dockerfile: ./docker/ui/Dockerfile
+  #     args: *common-variables
+  #   restart: always
+  #   environment: *common-variables
+  #   ports:
+  #     - "9966:9966"
   mongo:
     image: mongo
     restart: always

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -6,11 +6,12 @@ ARG BUGSNAG_KEY
 RUN cd /datatools-build
 COPY package.json yarn.lock patches /datatools-build/
 RUN yarn
-COPY . /datatools-build/ 
+COPY . /datatools-build/
+COPY ./lib/mastarm_css/css-transform.js /datatools-build/node_modules/mastarm/lib/css-transform.js
 COPY configurations/default /datatools-config/
 
 
 # Copy the tmp file to the env.yml if no env.yml is present
 RUN cp -R -u -p /datatools-config/env.yml.tmp /datatools-config/env.yml
 
-CMD yarn run mastarm build --env dev --serve --proxy http://datatools-server:4000/api # 
+CMD yarn run mastarm build --env dev --serve --proxy http://datatools-server:4000/api #

--- a/lib/mastarm_css/css-transform.js
+++ b/lib/mastarm_css/css-transform.js
@@ -1,0 +1,124 @@
+const fs = require('fs')
+const path = require('path')
+
+const cssnano = require('cssnano')
+const chokidar = require('chokidar')
+const mimeType = require('mime')
+const mkdirp = require('mkdirp')
+const postcss = require('postcss')
+const postcssImport = require('postcss-import')
+const postcssPresetEnv = require('postcss-preset-env')
+const postcssReporter = require('postcss-reporter')
+const postcssSafeParser = require('postcss-safe-parser')
+
+const browsers = require('./constants').BROWSER_SUPPORT
+const logger = require('./logger')
+
+module.exports = function ({ config, entry, minify, outfile, watch }) {
+  const configImport = config.stylePath
+    ? `@import url(${config.stylePath});`
+    : ''
+  let watcher
+  const plugins = [
+    postcssImport({
+      onImport: sources => {
+        if (watch) {
+          sources.forEach(source => watcher.add(source))
+        }
+      },
+      plugins: [
+        base64ify(process.cwd()) // inline all url files
+      ]
+    }),
+    base64ify(process.cwd()),
+    postcssPresetEnv({browsers})
+  ]
+
+  if (minify) {
+    plugins.push(cssnano({ preset: 'default' }))
+  }
+
+  plugins.push(postcssReporter({ clearMessages: true }))
+
+  const transform = () =>
+    postcss(plugins)
+      .process(`${configImport}${fs.readFileSync(entry, 'utf8')}`, {
+        from: undefined,
+        map: { inline: false },
+        parser: postcssSafeParser,
+        to: outfile
+      })
+      .then(function (results) {
+        if (outfile) {
+          mkdirp.sync(path.dirname(outfile))
+          fs.writeFileSync(outfile, results.css)
+          if ("results.map") {
+            fs.writeFileSync(`${outfile}.map`, results.map.toString())
+          }
+          if (watch) {
+            logger.log(`updated ${outfile}`)
+          }
+        }
+        return results
+      })
+
+  if (watch) {
+    watcher = chokidar.watch(entry)
+    watcher
+      .on('add', transform)
+      .on('change', transform)
+      .on('unlink', transform)
+  }
+
+  return transform()
+}
+
+const base64ify = postcss.plugin('postcss-base64ify', function () {
+  return function (css, result) {
+    css.replaceValues(/url\((\s*)(['"]?)(.+?)\2(\s*)\)/g, function (string) {
+      const filename = getUrl(string)
+        .split('?')[0]
+        .split('#')[0]
+      let file
+      if (
+        filename.indexOf('data') === 0 ||
+        filename.length === 0 ||
+        filename.indexOf('http') === 0
+      ) {
+        return string
+      } else if (filename[0] === '/') {
+        file = path.join(process.cwd(), filename)
+      } else {
+        const source = css.source.input.file
+        const dir = path.dirname(source)
+        file = path.resolve(dir, filename)
+      }
+      if (!fs.existsSync(file)) {
+        throw new Error(`File ${file} does not exist`)
+      }
+      const buffer = fs.readFileSync(file)
+      return (
+        'url("data:' +
+        mimeType.getType(filename) +
+        ';base64,' +
+        buffer.toString('base64') +
+        '")'
+      )
+    })
+  }
+})
+
+const URL_POSITION = 3
+
+/**
+ * Extract the contents of a css url
+ *
+ * @param  {string} value raw css
+ * @return {string}       the contents of the url
+ */
+function getUrl (value) {
+  const reg = /url\((\s*)(['"]?)(.+?)\2(\s*)\)/g
+  const match = reg.exec(value)
+  const url = match[URL_POSITION]
+  return url
+}

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -110,7 +110,11 @@ export async function getSegment (points, followRoad, defaultToStraightLine = tr
   let geometry
   if (followRoad) {
     // if snapping to streets, use routing service.
-    const coordinates = await polyline(points.map((p) => ({ lng: p[0], lat: p[1] })), false, avoidMotorways)
+    const coordinates = await polyline(
+      points.map((p) => ({ lng: p[0], lat: p[1] })),
+      false,
+      avoidMotorways
+    )
     if (!coordinates) {
       // If routing was unsuccessful, default to straight line (if desired by
       // caller).
@@ -318,7 +322,7 @@ const preparePoints = (points) => {
   return reversedPoints
 }
 
-//* 4. Decode Valhalla Polyline string
+//* 4. Decode Valhalla Polyline string: https://valhalla.github.io/valhalla/decoding/#javascript
 const decodeValhallaPolyline = (encoded, precision = 6) => {
   const factor = Math.pow(10, precision)
   let index = 0

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -93,8 +93,8 @@ export async function polyline (points, individualLegs = false, avoidMotorways =
       }
       count++
     }
-    console.info('geometryGraphhopper:', geometry) //! New content
-    console.info('valhallaGeometry:', valhallaGeometry) //! New content
+    // console.info("geometryGraphhopper:", geometry); //! New content
+    // console.info("valhallaGeometry:", valhallaGeometry); //! New content
     // return geometry; //! Changed content
     return valhallaGeometry //! New content
   } catch (e) {

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -1,83 +1,25 @@
-// @flow
-
-import {isEqual as coordinatesAreEqual} from '@conveyal/lonlat'
-import fetch from 'isomorphic-fetch'
+import { isEqual as coordinatesAreEqual } from '@conveyal/lonlat'
+import isomorphicFetch from 'isomorphic-fetch' //! Changed content
 import L from 'leaflet'
-import {decode as decodePolyline} from 'polyline'
+import { decode as decodePolyline } from 'polyline'
 import lineString from 'turf-linestring'
 import qs from 'qs'
 
-// This can be used for logging line strings to geojson.io URLs for easy
-// debugging.
-// import {logCoordsToGeojsonio} from '../../editor/util/debug'
-
 import { coordIsOutOfBounds } from '../../editor/util/map'
-import type {
-  Coordinates,
-  LatLng
-} from '../../types'
-
-type Instruction = {
-  distance: number,
-  heading: number,
-  interval: [number, number],
-  sign: number,
-  street_name: string,
-  text: string,
-  time: number
-}
-
-type Path = {
-  ascend: number,
-  bbox: [number, number, number, number],
-  descend: number,
-  details: {},
-  distance: number,
-  instructions: Array<Instruction>,
-  legs: [],
-  points: string,
-  points_encoded: boolean,
-  snapped_waypoints: string,
-  time: number,
-  transfers: number,
-  weight: number
-}
-
-type GraphHopperResponse = {
-  hints: {
-    'visited_nodes.average': string,
-    'visited_nodes.sum': string
-  },
-  info: {
-    copyrights: Array<string>,
-    took: number
-  },
-  paths: Array<Path>
-}
-
-type GraphHopperAlternateServer = {
-  BBOX: Array<number>,
-  KEY?: string,
-  URL?: string
-}
 
 /**
  * Convert GraphHopper routing JSON response to polyline.
  */
-function handleGraphHopperRouting (path: Path, individualLegs: boolean = false): any {
-  const {instructions, points} = path
+function handleGraphHopperRouting (path, individualLegs = false) {
+  // console.info({ path });
+  const { instructions, points } = path
   // Decode polyline and reverse coordinates.
-  const decodedPolyline = decodePolyline(points).map(c => ([c[1], c[0]]))
+  const decodedPolyline = decodePolyline(points).map((c) => [c[1], c[0]])
   if (individualLegs) {
     const segments = []
-    // Keep track of the segment point intervals to split the line segment at.
-    // This appears to be the most reliable way to split up the geometry
-    // (previously distance was used here, but that provided inconstent results).
+
     const segmentPointIndices = [0]
-    // Iterate over the instructions, accumulating segment point indices at each
-    // waypoint encountered. Indices are used to slice the line geometry when
-    // individual legs are needed. NOTE: Waypoint === routing point provided in
-    // the request.
+
     instructions.forEach((instruction, i) => {
       if (instruction.text.match(/Waypoint (\d+)/) || i === instructions.length - 1) {
         segmentPointIndices.push(instruction.interval[0])
@@ -87,13 +29,11 @@ function handleGraphHopperRouting (path: Path, individualLegs: boolean = false):
     // at the provided indices.
     if (segmentPointIndices.length > 2) {
       for (var i = 1; i < segmentPointIndices.length; i++) {
-        // Get the indices of the points that the entire path should be sliced at
-        // Note: 'to' index is incremented by one because it is not inclusive.
         const [from, to] = [segmentPointIndices[i - 1], segmentPointIndices[i] + 1]
         const segment = decodedPolyline.slice(from, to)
         segments.push(segment)
       }
-      // console.log('individual legs', segments)
+      // console.log("individual legs", segments);
       return segments
     } else {
       // FIXME does this work for two input points?
@@ -111,13 +51,11 @@ function handleGraphHopperRouting (path: Path, individualLegs: boolean = false):
  *                                 distinct segments for each pair of points
  * @return {[type]}                Array of coordinates or Array of arrays of coordinates.
  */
-export async function polyline (
-  points: Array<LatLng>,
-  individualLegs?: boolean = false,
-  avoidMotorways?: boolean = false
-): Promise<any> {
+export async function polyline (points, individualLegs = false, avoidMotorways = false) {
+  // console.info({ individualLegs });
   let json
   const geometry = []
+  const valhallaGeometry = [] //! New content
   try {
     // Chunk points into sets no larger than the max # of points allowed by
     // GraphHopper plan.
@@ -134,44 +72,44 @@ export async function polyline (
       const beginIndex = i + offset
       const endIndex = i + chunk + offset
       const chunkedPoints = points.slice(beginIndex, endIndex)
-      json = await routeWithGraphHopper(chunkedPoints, avoidMotorways)
-      const path = json && json.paths && json.paths[0]
-      // Route between chunked list of points
-      if (path) {
-        const result = handleGraphHopperRouting(path, individualLegs)
-        geometry.push(...result)
-      } else {
-        // If any of the routed legs fails, default to straight line (return null).
-        console.warn(`Error routing from point ${beginIndex} to ${endIndex}`, chunkedPoints)
-        return null
+
+      const valhallaData = await getValhallaData(points, individualLegs, avoidMotorways) //! New content
+      valhallaGeometry.push(...valhallaData) //! New content
+
+      //! Changed content
+      if (process.env.GRAPH_HOPPER_KEY) {
+        json = await routeWithGraphHopper(chunkedPoints, avoidMotorways)
+
+        const path = json && json.paths && json.paths[0]
+
+        if (path) {
+          const result = handleGraphHopperRouting(path, individualLegs)
+          geometry.push(...result)
+        } else {
+          // If any of the routed legs fails, default to straight line (return null).
+          console.warn(`Error routing from point ${beginIndex} to ${endIndex}`, chunkedPoints)
+          // return null;  //! Changed content
+        }
       }
       count++
     }
-    return geometry
+    console.info('geometryGraphhopper:', geometry) //! New content
+    console.info('valhallaGeometry:', valhallaGeometry) //! New content
+    // return geometry; //! Changed content
+    return valhallaGeometry //! New content
   } catch (e) {
     console.log(e)
     return null
   }
 }
 
-export async function getSegment (
-  points: Coordinates,
-  followRoad: boolean,
-  defaultToStraightLine: boolean = true,
-  avoidMotorways: boolean = false
-): Promise<?{
-  coordinates: Coordinates,
-  type: 'LineString'
-}> {
+export async function getSegment (points, followRoad, defaultToStraightLine = true, avoidMotorways = false) {
   // Store geometry to be returned here.
+  // console.info(2, "points:", points, { avoidMotorways });
   let geometry
   if (followRoad) {
     // if snapping to streets, use routing service.
-    const coordinates = await polyline(
-      points.map(p => ({lng: p[0], lat: p[1]})),
-      false,
-      avoidMotorways
-    )
+    const coordinates = await polyline(points.map((p) => ({ lng: p[0], lat: p[1] })), false, avoidMotorways)
     if (!coordinates) {
       // If routing was unsuccessful, default to straight line (if desired by
       // caller).
@@ -201,12 +139,9 @@ export async function getSegment (
   return geometry
 }
 
-/**
- * Call GraphHopper routing service with lat/lng coordinates.
- *
- * Example URL: https://graphhopper.com/api/1/route?point=49.932707,11.588051&point=50.3404,11.64705&vehicle=car&debug=true&&type=json
- */
-export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: boolean): ?Promise<GraphHopperResponse> {
+// Fetch Data
+export function routeWithGraphHopper (points, avoidMotorways) {
+  // console.info({ avoidMotorways });
   if (points.length < 2) {
     console.warn('need at least two points to route with graphhopper', points)
     return null
@@ -221,9 +156,9 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
 
   if (process.env.GRAPH_HOPPER_ALTERNATES) {
     // $FlowFixMe This is a bit of a hack and now how env variables are supposed to work, but the yaml loader supports it.
-    const alternates: Array<GraphHopperAlternateServer> = process.env.GRAPH_HOPPER_ALTERNATES
-    alternates.forEach(alternative => {
-      const {BBOX} = alternative
+    const alternates = process.env.GRAPH_HOPPER_ALTERNATES
+    alternates.forEach((alternative) => {
+      const { BBOX } = alternative
       if (BBOX.length !== 4) {
         console.warn('Invalid BBOX for GRAPH_HOPPER_ALTERNATIVE')
         return
@@ -238,10 +173,7 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
           (point) =>
             !coordIsOutOfBounds(
               point,
-              L.latLngBounds(
-                [alternative.BBOX[1], alternative.BBOX[0]],
-                [alternative.BBOX[3], alternative.BBOX[2]]
-              )
+              L.latLngBounds([alternative.BBOX[1], alternative.BBOX[0]], [alternative.BBOX[3], alternative.BBOX[2]])
             )
         )
       ) {
@@ -261,30 +193,181 @@ export function routeWithGraphHopper (points: Array<LatLng>, avoidMotorways?: bo
     debug: true,
     type: 'json'
   }
-  const locations = points.map(p => (`point=${p.lat},${p.lng}`)).join('&')
+  const locations = points.map((p) => `point=${p.lat},${p.lng}`).join('&')
   // Avoiding motorways requires a POST request with a formatted body
+  //! Changed content
   const graphHopperRequest = avoidMotorways
-    ? fetch(`${graphHopperUrl}route?key=${params.key}`,
-      {
-        body: JSON.stringify({
-          'ch.disable': true,
-          // Custom model disincentives motorways
-          custom_model: {
-            'priority': [{
-              'if': 'road_class == MOTORWAY',
-              'multiply_by': 0.1
-            }]
-          },
-          debug: params.debug,
-          points: points.map(p => [p.lng, p.lat]),
-          profile: params.vehicle
-        }),
-        headers: {
-          'Content-Type': 'application/json'
+    ? isomorphicFetch(`${graphHopperUrl}route?key=${params.key}`, {
+      body: JSON.stringify({
+        'ch.disable': true,
+        // Custom model disincentives motorways
+        custom_model: {
+          priority: [
+            {
+              if: 'road_class == MOTORWAY',
+              multiply_by: 0.1
+            }
+          ]
         },
-        method: 'POST'
-      })
-    : fetch(`${graphHopperUrl}route?${locations}&${qs.stringify(params)}`)
+        debug: params.debug,
+        points: points.map((p) => [p.lng, p.lat]),
+        profile: params.vehicle
+      }),
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
+    })
+    : isomorphicFetch(`${graphHopperUrl}route?${locations}&${qs.stringify(params)}`) //! Changed content
 
-  return graphHopperRequest.then(res => res.json())
+  const response = graphHopperRequest.then((res) => res.json())
+  return response
+}
+
+//* ---------------------------------------------------------------------------------------------------------------------------
+//! New content!!!
+//* 1. Base function
+const getValhallaData = async (points, individualLegs, avoidMotorways) => {
+  //* Temporally disabled removeDuplicates function
+  const shallRemoveDuplicates = false
+
+  // console.info({ points, individualLegs, avoidMotorways });
+  const encodedData = await fetchValhallaData(points, avoidMotorways)
+  // console.info("encodedData:", encodedData);
+
+  const decodedData = encodedData.shapes.map((shape) => decodeValhallaPolyline(shape, 6))
+  // console.info("decodedData:", decodedData);
+
+  const decodedDataConverted = decodedData.map((data) => convertLatLon(data))
+  // console.info("decodedDataConverted:", decodedDataConverted);
+
+  const decodedDataConvertedFlat = shallRemoveDuplicates
+    ? removeDuplicates(decodedDataConverted.flat(1))
+    : decodedDataConverted.flat(1)
+  // console.info("decodedDataConvertedFlat:", decodedDataConvertedFlat);
+
+  const dataToReturn = individualLegs ? decodedDataConverted : decodedDataConvertedFlat
+  // console.info({ dataToReturn });
+  return dataToReturn
+}
+
+//* 2. Fetch Valhalla data
+const fetchValhallaData = async (points, avoidMotorways) => {
+  // console.info("points:", points);
+  const preparedPoints = preparePoints(points)
+  // console.info("preparedPoints:", preparedPoints);
+  // console.info({ avoidMotorways });
+
+  const dataToFetch = {
+    locations: preparedPoints,
+    costing_options: {
+      auto: {
+        avoid_motorways: avoidMotorways
+      }
+    },
+    costing: 'bus',
+    units: 'kilometers'
+  }
+
+  const baseUrl = process.env.VALHALLA_URL
+  const params = {
+    json: JSON.stringify(dataToFetch)
+  }
+
+  try {
+    //* V1 -> GET
+    const response = await fetch(`${baseUrl}?${new URLSearchParams(params)}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+    //* V2 -> POST
+    // const response = await fetch(baseUrl, {
+    //   method: "POST", // Change to POST
+    //   headers: {
+    //     "Content-Type": "application/json",
+    //   },
+    //   body: JSON.stringify(dataToFetch), // Send data in body
+    // });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+
+    const data = await response.json()
+    const {
+      trip: { legs }
+    } = data
+
+    const shapes = legs.map((leg) => leg.shape)
+    // console.info({ shapes });
+    return { shapes }
+  } catch (error) {
+    console.error('Error fetching directions:', error)
+    return null
+  }
+}
+
+//* 3. Prepare point data
+const preparePoints = (points) => {
+  const reversedPoints = points.map((point) => {
+    return { lat: point.lat, lon: point.lng }
+  })
+  return reversedPoints
+}
+
+//* 4. Decode Valhalla Polyline string
+const decodeValhallaPolyline = (encoded, precision = 6) => {
+  const factor = Math.pow(10, precision)
+  let index = 0
+  let lat = 0
+  let lng = 0
+  const coordinates = []
+
+  while (index < encoded.length) {
+    let result = 0
+    let shift = 0
+    let byte
+
+    // Decode latitude
+    do {
+      byte = encoded.charCodeAt(index++) - 63
+      result |= (byte & 0x1f) << shift
+      shift += 5
+    } while (byte >= 0x20)
+
+    const latitudeChange = result & 1 ? ~(result >> 1) : result >> 1
+    lat += latitudeChange
+
+    result = 0
+    shift = 0
+
+    // Decode longitude
+    do {
+      byte = encoded.charCodeAt(index++) - 63
+      result |= (byte & 0x1f) << shift
+      shift += 5
+    } while (byte >= 0x20)
+
+    const longitudeChange = result & 1 ? ~(result >> 1) : result >> 1
+    lng += longitudeChange
+
+    // Store the decoded coordinates
+    coordinates.push([lat / factor, lng / factor])
+  }
+
+  return coordinates
+}
+
+//* 4. Remove coordinates in coordinates data
+export const removeDuplicates = (dataToFilter) => {
+  const filteredData = Array.from(new Set(dataToFilter.map((elem) => JSON.stringify(elem)))).map((str) => JSON.parse(str))
+  return filteredData
+}
+
+//* 5. Conversion [lat, lon] -> [lon, lat] and Vice Versa
+const convertLatLon = (points) => {
+  const changedPoints = points.map((point) => [point[1], point[0]])
+  return changedPoints
 }

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -288,7 +288,7 @@ const fetchValhallaData = async (points, avoidMotorways) => {
     //   headers: {
     //     "Content-Type": "application/json",
     //   },
-    //   body: JSON.stringify(dataToFetch), // Send data in body
+    //   body: JSON.stringify(dataToFetch),
     // });
 
     if (!response.ok) {
@@ -360,7 +360,7 @@ const decodeValhallaPolyline = (encoded, precision = 6) => {
   return coordinates
 }
 
-//* 4. Remove coordinates in coordinates data
+//* 4. Remove duplicates in coordinates data
 export const removeDuplicates = (dataToFilter) => {
   const filteredData = Array.from(new Set(dataToFilter.map((elem) => JSON.stringify(elem)))).map((str) => JSON.parse(str))
   return filteredData

--- a/lib/scenario-editor/utils/valhalla.js
+++ b/lib/scenario-editor/utils/valhalla.js
@@ -73,6 +73,7 @@ export async function polyline (points, individualLegs = false, avoidMotorways =
       const endIndex = i + chunk + offset
       const chunkedPoints = points.slice(beginIndex, endIndex)
 
+      //* The main function
       const valhallaData = await getValhallaData(points, individualLegs, avoidMotorways) //! New content
       valhallaGeometry.push(...valhallaData) //! New content
 


### PR DESCRIPTION
Modified for testing (didn't use Flow framework) to use Valhalla routing instead of Graphhopper.
To configure, in configurations/default/env.yml add:
VALHALLA_URL: "https://valhalla1.openstreetmap.de/route"


This will work with the stock Valhalla demo - please don't use in production.

When you replace this URL with your own hosted version of Valhalla (either in docker from https://github.com/gis-ops/docker-valhalla or standard, compiled from here: https://github.com/valhalla/valhalla) and run Datatools docker with this url, it will end up with CORS errors.

My setup for either Apache or Nginx is using following header set:

```
location / {
        proxy_pass http://127.0.0.1:8002; // set to your valhalla instance
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;

        add_header 'Access-Control-Allow-Origin' '*';
        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
        add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';

    if ($request_method = 'OPTIONS') {
        add_header 'Access-Control-Allow-Origin' 'https://datatools.goeuropa.net';
        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
        add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
        return 204;
    }
```