### PR TITLE
feat: support overriding feed filenames

### DIFF
--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -675,7 +675,7 @@ components:
     rename: Rename
     save: Save
     title: Settings
-    invalidFilename: Filename contains invalid characters (e.g., / \ : * ? " < > | space) or ends with .zip.
+    invalidFilename: "Filename contains invalid characters (e.g., / \ : * ? " < > | space) or ends with .zip."
     filenamePlaceholder: e.g., agency_bundle
   GtfsIcons:
     agency:

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -661,6 +661,8 @@ components:
         title: Updates
     labels:
       title: Labels
+    bundleFilename: Override filename for GTFS bundle
+    bundleFilenameHint: Optional. Define a custom filename (without .zip) for this feed source when included in a GTFS bundle. The .zip extension is added automatically.
     make:
       private: Make private
       privateDesc: Make this feed source private.
@@ -673,6 +675,8 @@ components:
     rename: Rename
     save: Save
     title: Settings
+    invalidFilename: Filename contains invalid characters (e.g., / \ : * ? " < > | space) or ends with .zip.
+    filenamePlaceholder: e.g., agency_bundle
   GtfsIcons:
     agency:
       title: Edit agencies

--- a/i18n/english.yml
+++ b/i18n/english.yml
@@ -319,6 +319,7 @@ components:
   FeedInfo:
     autoFetch: Auto fetch
     autoPublish: Auto publish
+    bundleFilename: Bundle Filename
     dateFormat: MMM D, YYYY 
     deployable: Deployable
     edit: Edit
@@ -675,7 +676,7 @@ components:
     rename: Rename
     save: Save
     title: Settings
-    invalidFilename: "Filename contains invalid characters (e.g., / \ : * ? " < > | space) or ends with .zip."
+    invalidFilename: "Filename contains invalid characters (e.g., / \ : * ? \" < > | space) or ends with .zip."
     filenamePlaceholder: e.g., agency_bundle
   GtfsIcons:
     agency:
@@ -763,6 +764,7 @@ components:
     title: Log in
   ManagerHeader:
     noUpdateYet: n/a
+    bundleFilename: Bundle Filename
     noUrl: (none)
     private: This feed source and all its versions are private.
   ManagerPage:

--- a/i18n/german.yml
+++ b/i18n/german.yml
@@ -342,6 +342,7 @@ components:
   FeedInfo:
     autoFetch: Automatischer Abruf
     autoPublish: Automatische Veröffentlichung
+    bundleFilename: Bundle Filename
     dateFormat: DD.MM.YYYY
     deployable: Deploybar
     edit: Bearbeiten
@@ -676,6 +677,10 @@ components:
         title: Aktualisierungen
     labels:
       title: Ettiketten
+    bundleFilename: Override filename for GTFS bundle
+    bundleFilenameHint: Optional. Define a custom filename (without .zip) for this feed source when included in a GTFS bundle. The .zip extension is added automatically.
+    invalidFilename: "Filename contains invalid characters (e.g., / \ : * ? \" < > | space) or ends with .zip."
+    filenamePlaceholder: e.g., agency_bundle
     make:
       private: Privat setzen
       privateDesc: Setzt diese Feed-Quelle auf Privat.
@@ -769,6 +774,7 @@ components:
     title: Anmelden
   ManagerHeader:
     noUpdateYet: keine
+    bundleFilename: Bundle Filename
     noUrl: (keine URL)
     private: Diese Feed-Quelle und all ihre Versionen sind privat.
   ManagerPage:

--- a/i18n/polish.yml
+++ b/i18n/polish.yml
@@ -339,6 +339,7 @@ components:
   FeedInfo:
     autoFetch: Automatyczne pobieranie
     autoPublish: Automatycznie publikuj
+    bundleFilename: Bundle Filename
     dateFormat: MMM D, YYYY
     deployable: Rozmieszczany
     edit: Edytować
@@ -599,6 +600,8 @@ components:
       title: Automatic Fetch
       url: Feed source fetch URL
       urlButton: Change URL
+    bundleFilename: Override filename for GTFS bundle
+    bundleFilenameHint: Optional. Define a custom filename (without .zip) for this feed source when included in a GTFS bundle. The .zip extension is added automatically.
     confirmDelete: Are you sure you want to delete this project? This action cannot
       be undone and all feed sources and their versions will be permanently deleted.
     dangerZone: Danger Zone
@@ -668,6 +671,8 @@ components:
         title: Updates
     labels:
       title: Labels
+    invalidFilename: "Filename contains invalid characters (e.g., / \ : * ? \" < > | space) or ends with .zip."
+    filenamePlaceholder: e.g., agency_bundle
     make:
       private: Make private
       privateDesc: Make this feed source private.
@@ -760,6 +765,7 @@ components:
     title: Log in
   ManagerHeader:
     noUpdateYet: n/a
+    bundleFilename: Bundle Filename
     noUrl: (none)
     private: This feed source and all its versions are private.
   ManagerPage:

--- a/lib/manager/components/CreateFeedSource.js
+++ b/lib/manager/components/CreateFeedSource.js
@@ -23,6 +23,7 @@ import Loading from '../../common/components/Loading'
 import {FREQUENCY_INTERVALS} from '../../common/constants'
 import {isExtensionEnabled} from '../../common/util/config'
 import {validationState} from '../util'
+import {isValidFilename} from '../util/validation'
 import type {FetchFrequency, NewFeed} from '../../types'
 
 import FeedFetchFrequency from './FeedFetchFrequency'
@@ -78,16 +79,16 @@ export default class CreateFeedSource extends Component<Props, State> {
         deployable: false,
         fetchFrequency: 'DAYS',
         fetchInterval: 1,
+        filename: '',
         name: '',
         projectId: props.projectId,
-        url: '',
-        filename: ''
+        url: ''
       },
       validation: {
         _form: false,
+        filename: true,
         name: true,
-        url: true,
-        filename: true
+        url: true
       }
     })
   }
@@ -148,8 +149,7 @@ export default class CreateFeedSource extends Component<Props, State> {
   _validateModel (model: NewFeed) {
     const validation: Validation = {
       _form: false,
-      // Check if filename is valid and does not end with .zip
-      filename: !model.filename || (/^[^<>:"/\\|?* ]*$/.test(model.filename) && !/\.zip$/i.test(model.filename || '')),
+      filename: isValidFilename(model.filename),
       name: !!model.name && model.name.length > 0,
       url: !model.url || validator.isURL(model.url)
     }
@@ -199,16 +199,13 @@ export default class CreateFeedSource extends Component<Props, State> {
                     individually.
                   </small>
                 </FormGroup>
-              </ListGroupItem>
-              <ListGroupItem>
                 <FormGroup validationState={validationState(validation.filename)}>
                   <ControlLabel>Override filename for bundle (optional)</ControlLabel>
-                  {/* Disable field if not deployable */}
                   <FormControl
                     disabled={!model.deployable}
                     name={'filename'}
-                    placeholder='e.g., agency_bundle.zip'
                     onChange={this._onInputChange('filename')}
+                    placeholder='e.g., agency_bundle.zip'
                     value={model.filename}
                   />
                   <FormControl.Feedback />

--- a/lib/manager/components/CreateFeedSource.js
+++ b/lib/manager/components/CreateFeedSource.js
@@ -205,7 +205,7 @@ export default class CreateFeedSource extends Component<Props, State> {
                     disabled={!model.deployable}
                     name={'filename'}
                     onChange={this._onInputChange('filename')}
-                    placeholder='e.g., agency_bundle.zip'
+                    placeholder='e.g., agency_bundle'
                     value={model.filename}
                   />
                   <FormControl.Feedback />

--- a/lib/manager/components/CreateFeedSource.js
+++ b/lib/manager/components/CreateFeedSource.js
@@ -148,9 +148,10 @@ export default class CreateFeedSource extends Component<Props, State> {
   _validateModel (model: NewFeed) {
     const validation: Validation = {
       _form: false,
+      // Check if filename is valid and does not end with .zip
+      filename: !model.filename || (/^[^<>:"/\\|?* ]*$/.test(model.filename) && !/\.zip$/i.test(model.filename || '')),
       name: !!model.name && model.name.length > 0,
-      url: !model.url || validator.isURL(model.url),
-      filename: !model.filename || (/^[^<>:"/\\|?* ]*$/.test(model.filename) && !/\.zip$/i.test(model.filename))
+      url: !model.url || validator.isURL(model.url)
     }
     validation._form = !!(validation.name && validation.url && validation.filename)
     this.setState({ validation })
@@ -211,7 +212,7 @@ export default class CreateFeedSource extends Component<Props, State> {
                     value={model.filename}
                   />
                   <FormControl.Feedback />
-                  {!validation.filename && <HelpBlock>{this.messages('invalidFilename')}</HelpBlock>}
+                  {!validation.filename && <HelpBlock>Invalid filename</HelpBlock>}
                 </FormGroup>
               </ListGroupItem>
             </ListGroup>

--- a/lib/manager/components/CreateFeedSource.js
+++ b/lib/manager/components/CreateFeedSource.js
@@ -35,6 +35,7 @@ type Props = {
 
 type Validation = {
   _form: boolean,
+  filename?: boolean,
   name?: boolean,
   url?: boolean
 }
@@ -79,12 +80,14 @@ export default class CreateFeedSource extends Component<Props, State> {
         fetchInterval: 1,
         name: '',
         projectId: props.projectId,
-        url: ''
+        url: '',
+        filename: ''
       },
       validation: {
         _form: false,
         name: true,
-        url: true
+        url: true,
+        filename: true
       }
     })
   }
@@ -145,10 +148,11 @@ export default class CreateFeedSource extends Component<Props, State> {
   _validateModel (model: NewFeed) {
     const validation: Validation = {
       _form: false,
-      name: !(!model.name || model.name.length === 0),
-      url: !model.url || validator.isURL(model.url)
+      name: !!model.name && model.name.length > 0,
+      url: !model.url || validator.isURL(model.url),
+      filename: !model.filename || (/^[^<>:"/\\|?* ]*$/.test(model.filename) && !/\.zip$/i.test(model.filename))
     }
-    validation._form = !!(validation.name && validation.url)
+    validation._form = !!(validation.name && validation.url && validation.filename)
     this.setState({ validation })
   }
 
@@ -193,6 +197,21 @@ export default class CreateFeedSource extends Component<Props, State> {
                     settings) as part of a collection of feed sources or
                     individually.
                   </small>
+                </FormGroup>
+              </ListGroupItem>
+              <ListGroupItem>
+                <FormGroup validationState={validationState(validation.filename)}>
+                  <ControlLabel>Override filename for bundle (optional)</ControlLabel>
+                  {/* Disable field if not deployable */}
+                  <FormControl
+                    disabled={!model.deployable}
+                    name={'filename'}
+                    placeholder='e.g., agency_bundle.zip'
+                    onChange={this._onInputChange('filename')}
+                    value={model.filename}
+                  />
+                  <FormControl.Feedback />
+                  {!validation.filename && <HelpBlock>{this.messages('invalidFilename')}</HelpBlock>}
                 </FormGroup>
               </ListGroupItem>
             </ListGroup>

--- a/lib/manager/components/FeedSourceTableRow.js
+++ b/lib/manager/components/FeedSourceTableRow.js
@@ -299,6 +299,15 @@ class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user:
               {this.messages('autoPublish')}
             </Col>
           )}
+          {feedSource.filename && (
+            <Col xs={12}>
+              <Row>
+                <Col xs={12}>
+                  <Icon type='file-text-o' /> Bundle Filename: {feedSource.filename}.zip
+                </Col>
+              </Row>
+            </Col>
+          )}
           <Col xs={12}>
             <div className='feedSourceLabelRow'>
               {project.labels.length > 0 && (

--- a/lib/manager/components/FeedSourceTableRow.js
+++ b/lib/manager/components/FeedSourceTableRow.js
@@ -303,7 +303,7 @@ class FeedInfo extends PureComponent<{ feedSource: Feed, project: Project, user:
             <Col xs={12}>
               <Row>
                 <Col xs={12}>
-                  <Icon type='file-text-o' /> Bundle Filename: {feedSource.filename}.zip
+                  <Icon type='file-text-o' />{this.messages('bundleFilename')}: {feedSource.filename}.zip
                 </Col>
               </Row>
             </Col>

--- a/lib/manager/components/GeneralSettings.js
+++ b/lib/manager/components/GeneralSettings.js
@@ -44,16 +44,19 @@ type State = {
 
 export default class GeneralSettings extends Component<Props, State> {
   messages = getComponentMessages('GeneralSettings')
-  state = {
+  state: State = {
+    filename: undefined,
+    filenameError: null,
     filenameValidationState: null,
-    filenameError: null
+    name: undefined,
+    url: undefined
   }
 
   _onChange = ({target}: SyntheticInputEvent<HTMLInputElement>) => {
     // Change empty string to null to avoid setting URL to empty string value.
     let value = target.value || null
     if (target.name === 'url' && value) value = value.trim()
-    const newState = {[target.name]: value}
+    const newState: State = {[target.name]: value}
     // Validate filename if changed
     if (target.name === 'filename') {
       // Check for invalid characters and ensure it doesn't end with .zip (case-insensitive)

--- a/lib/manager/components/GeneralSettings.js
+++ b/lib/manager/components/GeneralSettings.js
@@ -9,16 +9,17 @@ import {
   ControlLabel,
   FormControl,
   FormGroup,
+  HelpBlock,
   InputGroup,
   ListGroup,
   ListGroupItem,
-  Panel,
-  HelpBlock
+  Panel
 } from 'react-bootstrap'
 
 import * as feedsActions from '../actions/feeds'
 import { FREQUENCY_INTERVALS } from '../../common/constants'
 import {getComponentMessages} from '../../common/util/config'
+import {isValidFilename} from '../util/validation'
 import LabelAssigner from '../components/LabelAssigner'
 import type { Feed, FetchFrequency, Project } from '../../types'
 import type { ManagerUserState } from '../../types/reducers'
@@ -60,7 +61,7 @@ export default class GeneralSettings extends Component<Props, State> {
     // Validate filename if changed
     if (target.name === 'filename') {
       // Check for invalid characters and ensure it doesn't end with .zip (case-insensitive)
-      const isValid = !value || (/^[^<>:"/\\|?* ]*$/.test(value) && !/\.zip$/i.test(value))
+      const isValid = isValidFilename(value)
       newState.filenameValidationState = isValid ? 'success' : 'error'
       newState.filenameError = isValid ? null : this.messages('invalidFilename')
     }

--- a/lib/manager/components/GeneralSettings.js
+++ b/lib/manager/components/GeneralSettings.js
@@ -12,7 +12,8 @@ import {
   InputGroup,
   ListGroup,
   ListGroupItem,
-  Panel
+  Panel,
+  HelpBlock
 } from 'react-bootstrap'
 
 import * as feedsActions from '../actions/feeds'
@@ -34,19 +35,33 @@ type Props = {
 }
 
 type State = {
+  filename?: ?string,
+  filenameError?: ?string,
+  filenameValidationState?: ?string,
   name?: ?string,
   url?: ?string
 }
 
 export default class GeneralSettings extends Component<Props, State> {
   messages = getComponentMessages('GeneralSettings')
-  state = {}
+  state = {
+    filenameValidationState: null,
+    filenameError: null
+  }
 
   _onChange = ({target}: SyntheticInputEvent<HTMLInputElement>) => {
     // Change empty string to null to avoid setting URL to empty string value.
     let value = target.value || null
     if (target.name === 'url' && value) value = value.trim()
-    this.setState({[target.name]: value})
+    const newState = {[target.name]: value}
+    // Validate filename if changed
+    if (target.name === 'filename') {
+      // Check for invalid characters and ensure it doesn't end with .zip (case-insensitive)
+      const isValid = !value || (/^[^<>:"/\\|?* ]*$/.test(value) && !/\.zip$/i.test(value))
+      newState.filenameValidationState = isValid ? 'success' : 'error'
+      newState.filenameError = isValid ? null : this.messages('invalidFilename')
+    }
+    this.setState(newState)
   }
 
   _onToggleDeployable = () => {
@@ -54,7 +69,7 @@ export default class GeneralSettings extends Component<Props, State> {
     updateFeedSource(feedSource, {deployable: !feedSource.deployable})
   }
 
-  _getFormValue = (key: 'name' | 'url') => {
+  _getFormValue = (key: 'name' | 'url' | 'filename') => {
     // If state value does not exist (i.e., form is unedited), revert to value
     // from props.
     const value = typeof this.state[key] === 'undefined'
@@ -108,6 +123,11 @@ export default class GeneralSettings extends Component<Props, State> {
     updateFeedSource(feedSource, {url: this.state.url})
   }
 
+  _onSaveFilename = () => {
+    const {feedSource, updateFeedSource} = this.props
+    updateFeedSource(feedSource, {filename: this.state.filename})
+  }
+
   render () {
     const {
       confirmDeleteFeedSource,
@@ -117,7 +137,8 @@ export default class GeneralSettings extends Component<Props, State> {
     } = this.props
     const {
       name,
-      url
+      url,
+      filename
     } = this.state
     const autoFetchFeed = feedSource.retrievalMethod === 'FETCHED_AUTOMATICALLY'
     return (
@@ -155,6 +176,29 @@ export default class GeneralSettings extends Component<Props, State> {
                   <strong>{this.messages('makeDeployable')}</strong>
                 </Checkbox>
                 <small>{this.messages('makeDeployableHint')}</small>
+              </FormGroup>
+            </ListGroupItem>
+            <ListGroupItem>
+              <FormGroup validationState={this.state.filenameValidationState}>
+                <ControlLabel>{this.messages('bundleFilename')}</ControlLabel>
+                <InputGroup>
+                  <FormControl
+                    disabled={disabled || !feedSource.deployable}
+                    placeholder={this.messages('filenamePlaceholder')}
+                    name={'filename'}
+                    onChange={this._onChange}
+                    value={this._getFormValue('filename')} />
+                  <InputGroup.Button>
+                    <Button
+                      // disable if no change or value is unchanged
+                      disabled={disabled || typeof filename === 'undefined' || filename === feedSource.filename || this.state.filenameValidationState === 'error'}
+                      onClick={this._onSaveFilename}>
+                      {this.messages('save')}
+                    </Button>
+                  </InputGroup.Button>
+                </InputGroup>
+                <small>{this.messages('bundleFilenameHint')}</small>
+                {this.state.filenameError && <HelpBlock>{this.state.filenameError}</HelpBlock>}
               </FormGroup>
             </ListGroupItem>
           </ListGroup>

--- a/lib/manager/components/ManagerHeader.js
+++ b/lib/manager/components/ManagerHeader.js
@@ -100,6 +100,11 @@ export default class ManagerHeader extends Component<Props> {
               <Icon type='file-archive-o' />{' '}
               {this.getAverageFileSize(feedSource.feedVersionSummaries)}
             </li>
+            {feedSource.filename && (
+              <li>
+                <Icon type='file-text-o' /> Bundle Filename: {feedSource.filename}.zip
+              </li>
+            )}
           </ul>
         </Col>
       </Row>

--- a/lib/manager/components/ManagerHeader.js
+++ b/lib/manager/components/ManagerHeader.js
@@ -102,7 +102,7 @@ export default class ManagerHeader extends Component<Props> {
             </li>
             {feedSource.filename && (
               <li>
-                <Icon type='file-text-o' /> Bundle Filename: {feedSource.filename}.zip
+                <Icon type='file-text-o' /> {this.messages('bundleFilename')}: {feedSource.filename}.zip
               </li>
             )}
           </ul>

--- a/lib/manager/util/validation.js
+++ b/lib/manager/util/validation.js
@@ -6,5 +6,6 @@
  * An empty or null/undefined filename is also considered valid.
  */
 export function isValidFilename (filename: ?string): boolean {
-  return !filename || (/^[^<>:"/\\|?* ]*$/.test(filename) && !/\.zip$/i.test(filename))
+  // Ensure only valid characters (no ., <>,:"/\\|?*, or space) are used
+  return !filename || /^[^<>:"/\\|?* .]*$/.test(filename)
 }

--- a/lib/manager/util/validation.js
+++ b/lib/manager/util/validation.js
@@ -1,0 +1,10 @@
+// @flow
+
+/**
+ * Checks if a filename is valid.
+ * A valid filename does not contain <>:"/\|?* characters and does not end with .zip (case-insensitive).
+ * An empty or null/undefined filename is also considered valid.
+ */
+export function isValidFilename (filename: ?string): boolean {
+  return !filename || (/^[^<>:"/\\|?* ]*$/.test(filename) && !/\.zip$/i.test(filename))
+}

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -441,10 +441,11 @@ export type NewFeed = {
   deployable?: boolean,
   fetchFrequency: FetchFrequency,
   fetchInterval: number,
+  filename?: string,
   name?: string,
   projectId: string,
   retrievalMethod?: string,
-  url?: string
+  url?: string,
 }
 
 type ValidationErrorPriority = 'HIGH' | 'MEDIUM' | 'LOW' | 'UNKNOWN'

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -416,10 +416,11 @@ export type Feed = FeedSourceSummary & {
   feedVersions?: Array<FeedVersion>,
   fetchFrequency?: FetchFrequency,
   fetchInterval?: number,
+  filename?: ?string,
   isCreating?: boolean,
   lastFetched?: ?number,
-  latestVersionId?: ?string,
-  name: string, // Flow throws an error if we don't duplicate this property in the types here.
+  latestVersionId?: ?string, // Flow throws an error if we don't duplicate this property in the types here.
+  name: string,
   noteCount: number,
   notes?: Array<Note>,
   organizationId: ?string,


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description
This PR adds support for overriding the feed filenames that will be used in the bundle. This feature allows us to override feed specific build settings in the build config.