### PR TITLE
Don't Publish Expired Feeds

### DIFF
--- a/lib/manager/components/version/FeedVersionActionsMTC.js
+++ b/lib/manager/components/version/FeedVersionActionsMTC.js
@@ -3,11 +3,7 @@
 import Icon from '@conveyal/woonerf/components/icon'
 import moment from 'moment'
 import React, { Component } from 'react'
-import {
-  Button,
-  ButtonToolbar,
-  MenuItem
-} from 'react-bootstrap'
+import { Button, ButtonToolbar, MenuItem } from 'react-bootstrap'
 import { Link } from 'react-router'
 
 import * as versionsActions from '../../actions/versions'
@@ -27,44 +23,55 @@ export type Props = {
   version: FeedVersion
 }
 
+function mergeItemFormatter (
+  v: FeedVersionSummary,
+  activeVersion: ?FeedVersionSummary
+): React$Element<any> {
+  let name = v.name
+  let disabled = false
+  if (v.retrievalMethod === 'SERVICE_PERIOD_MERGE') {
+    name = '(Cannot re-merge feed)'
+    disabled = true
+  }
+  if (activeVersion && v.id === activeVersion.id) {
+    name = '(Cannot merge with self)'
+    disabled = true
+  }
+  return (
+    <MenuItem
+      disabled={disabled}
+      eventKey={disabled ? null : v.id}
+      key={v.id}
+    >
+      {v.version}. {name}{' '}
+      <VersionRetrievalBadge version={v} />
+    </MenuItem>
+  )
+}
+
+// Refactor opportunity wirg FeedSourceTableRow
+function userCanManageFeed (user: ManagerUserState, version: FeedVersion): boolean {
+  return !!user.permissions &&
+    user.permissions.hasFeedPermission(
+      version.feedSource.organizationId,
+      version.feedSource.projectId,
+      version.feedSource.id,
+      'manage-feed'
+    ) !== null
+}
+
+/**
+  * Check that the validation did not encounter any fatal exception or blocking
+  * errors.
+  */
+function checkBlockingIssue (version: FeedVersion): boolean {
+  if (version.validationResult.fatalException) return true
+  const errorCounts = version.validationResult.error_counts
+  return !!errorCounts &&
+    !!(errorCounts.find(ec => BLOCKING_ERROR_TYPES.indexOf(ec.type) !== -1))
+}
+
 export default class FeedVersionActionsMTC extends Component<Props> {
-  /**
-   * Check that the validation did not encounter any fatal exception or blocking
-   * errors.
-   */
-  _checkBlockingIssue: ((version: FeedVersion) => boolean) = (version: FeedVersion) => {
-    if (version.validationResult.fatalException) return true
-    const errorCounts = version.validationResult.error_counts
-    return !!errorCounts &&
-      !!(errorCounts.find(ec => BLOCKING_ERROR_TYPES.indexOf(ec.type) !== -1))
-  }
-
-  _mergeItemFormatter: ((
-    v: FeedVersionSummary,
-    activeVersion: ?FeedVersionSummary
-  ) => React$Element<any>) = (v: FeedVersionSummary, activeVersion: ?FeedVersionSummary) => {
-    let name = v.name
-    let disabled = false
-    if (v.retrievalMethod === 'SERVICE_PERIOD_MERGE') {
-      name = '(Cannot re-merge feed)'
-      disabled = true
-    }
-    if (activeVersion && v.id === activeVersion.id) {
-      name = '(Cannot merge with self)'
-      disabled = true
-    }
-    return (
-      <MenuItem
-        key={v.id}
-        disabled={disabled}
-        eventKey={disabled ? null : v.id}
-      >
-        {v.version}. {name}{' '}
-        <VersionRetrievalBadge version={v} />
-      </MenuItem>
-    )
-  }
-
   _handleMergeVersion: ((versionId: string) => void) = (versionId: string) => {
     // Note: service period feed merge has only been extensively tested with
     // MTC-specific logic.
@@ -89,25 +96,16 @@ export default class FeedVersionActionsMTC extends Component<Props> {
     // source, but has not been processed yet.
     const processing = version.sentToExternalPublisher &&
       !version.processedByExternalPublisher
-    const userCanManageFeed = user.permissions &&
-      user.permissions.hasFeedPermission(
-        version.feedSource.organizationId,
-        version.feedSource.projectId,
-        version.feedSource.id,
-        'manage-feed'
-      )
-    const hasBlockingIssue = this._checkBlockingIssue(version)
+    const hasBlockingIssue = checkBlockingIssue(version)
     const hasGtfsPlusBlockingIssue = gtfsPlusValidation && gtfsPlusValidation.issues.length > 0
     const isMergedServicePeriods = version.retrievalMethod === 'SERVICE_PERIOD_MERGE'
 
-    let publishButtonDisabled
-    let publishWarningMessage
-    let expired
+    // Refactor opportunity with VersionDateLabel and versionHasExpired.
     const now = +moment().startOf('day')
     const end = +moment(summary.endDate)
-    expired = end < now
+    const expired = end < now
 
-    publishButtonDisabled = !gtfsPlusValidation ||
+    const publishButtonDisabled = !gtfsPlusValidation ||
       hasGtfsPlusBlockingIssue ||
       !gtfsPlusValidation.published ||
       expired ||
@@ -116,8 +114,9 @@ export default class FeedVersionActionsMTC extends Component<Props> {
       hasBlockingIssue ||
       isPublished ||
       processing ||
-      !userCanManageFeed
+      !userCanManageFeed(user, version)
 
+    let publishWarningMessage
     if (hasBlockingIssue || hasGtfsPlusBlockingIssue) {
       publishWarningMessage = (
         <span>
@@ -126,7 +125,8 @@ export default class FeedVersionActionsMTC extends Component<Props> {
           blocking issue.
           (See{' '}
           <Link
-            to={`/feed/${feedSource.id}/version/${version.version}/${hasGtfsPlusBlockingIssue ? 'gtfsplus' : 'issues'}`}>
+            to={`/feed/${feedSource.id}/version/${version.version}/${hasGtfsPlusBlockingIssue ? 'gtfsplus' : 'issues'}`}
+          >
             {hasGtfsPlusBlockingIssue ? 'GTFS+' : 'validation'} issues
           </Link>.)
         </span>
@@ -142,23 +142,24 @@ export default class FeedVersionActionsMTC extends Component<Props> {
         <ButtonToolbar className='pull-right' style={{ marginTop: '2px' }}>
           <VersionSelectorDropdown
             dropdownProps={{
-              id: 'merge-versions-dropdown',
               disabled: isMergedServicePeriods,
+              id: 'merge-versions-dropdown',
               onSelect: this._handleMergeVersion
             }}
+            itemFormatter={mergeItemFormatter}
             title={<span><Icon type='code-fork' />{' '}
               {isMergedServicePeriods
                 ? 'Cannot re-merge feed'
                 : 'Merge with version'
               }</span>}
-            itemFormatter={this._mergeItemFormatter}
             version={version}
             versions={feedSource.feedVersionSummaries}
           />
           <Button
-            disabled={publishButtonDisabled}
             bsStyle={isPublished ? 'success' : 'warning'}
-            onClick={this._onClickPublish}>
+            disabled={publishButtonDisabled}
+            onClick={this._onClickPublish}
+          >
             {isPublished
               ? <span><Icon type='check-circle' /> Published</span>
               : processing

--- a/lib/manager/components/version/FeedVersionActionsMTC.js
+++ b/lib/manager/components/version/FeedVersionActionsMTC.js
@@ -1,0 +1,185 @@
+// @flow
+
+import Icon from '@conveyal/woonerf/components/icon'
+import moment from 'moment'
+import React, { Component } from 'react'
+import {
+  Button,
+  ButtonToolbar,
+  MenuItem
+} from 'react-bootstrap'
+import { Link } from 'react-router'
+
+import * as versionsActions from '../../actions/versions'
+import { BLOCKING_ERROR_TYPES } from '../../util/version'
+import type { Feed, FeedVersion, FeedVersionSummary, GtfsPlusValidation } from '../../../types'
+import type { ManagerUserState } from '../../../types/reducers'
+
+import VersionRetrievalBadge from './VersionRetrievalBadge'
+import VersionSelectorDropdown from './VersionSelectorDropdown'
+
+type Props = {
+  feedSource: Feed,
+  gtfsPlusValidation: GtfsPlusValidation,
+  mergeVersions: typeof versionsActions.mergeVersions,
+  publishFeedVersion: typeof versionsActions.publishFeedVersion,
+  user: ManagerUserState,
+  version: FeedVersion
+}
+
+export default class FeedVersionActionsMTC extends Component<Props> {
+  /**
+   * Check that the validation did not encounter any fatal exception or blocking
+   * errors.
+   */
+  _checkBlockingIssue: ((version: FeedVersion) => boolean) = (version: FeedVersion) => {
+    if (version.validationResult.fatalException) return true
+    const errorCounts = version.validationResult.error_counts
+    return !!errorCounts &&
+      !!(errorCounts.find(ec => BLOCKING_ERROR_TYPES.indexOf(ec.type) !== -1))
+  }
+
+  _mergeItemFormatter: ((
+    v: FeedVersionSummary,
+    activeVersion: ?FeedVersionSummary
+  ) => React$Element<any>) = (v: FeedVersionSummary, activeVersion: ?FeedVersionSummary) => {
+    let name = v.name
+    let disabled = false
+    if (v.retrievalMethod === 'SERVICE_PERIOD_MERGE') {
+      name = '(Cannot re-merge feed)'
+      disabled = true
+    }
+    if (activeVersion && v.id === activeVersion.id) {
+      name = '(Cannot merge with self)'
+      disabled = true
+    }
+    return (
+      <MenuItem
+        key={v.id}
+        disabled={disabled}
+        eventKey={disabled ? null : v.id}
+      >
+        {v.version}. {name}{' '}
+        <VersionRetrievalBadge version={v} />
+      </MenuItem>
+    )
+  }
+
+  _handleMergeVersion: ((versionId: string) => void) = (versionId: string) => {
+    // Note: service period feed merge has only been extensively tested with
+    // MTC-specific logic.
+    this.props.mergeVersions(this.props.version.id, versionId, 'SERVICE_PERIOD')
+  }
+
+  _onClickPublish: (() => any) = () => this.props.publishFeedVersion(this.props.version)
+
+  render (): React$Element<"div"> {
+    const {
+      feedSource,
+      gtfsPlusValidation,
+      user,
+      version
+    } = this.props
+    const {validationSummary: summary} = version
+    // We must check the version ID against the feed source in props (not the
+    // feed source nested underneath version) because this is the only place the
+    // published version is updated.
+    const isPublished = version.namespace === feedSource.publishedVersionId
+    // Version is in the "processing" state if it has been sent to external
+    // source, but has not been processed yet.
+    const processing = version.sentToExternalPublisher &&
+      !version.processedByExternalPublisher
+    const userCanManageFeed = user.permissions &&
+      user.permissions.hasFeedPermission(
+        version.feedSource.organizationId,
+        version.feedSource.projectId,
+        version.feedSource.id,
+        'manage-feed'
+      )
+    const hasBlockingIssue = this._checkBlockingIssue(version)
+    const hasGtfsPlusBlockingIssue = gtfsPlusValidation && gtfsPlusValidation.issues.length > 0
+    const isMergedServicePeriods = version.retrievalMethod === 'SERVICE_PERIOD_MERGE'
+
+    let publishButtonDisabled
+    let publishWarningMessage
+    let expired
+    const now = +moment().startOf('day')
+    const end = +moment(summary.endDate)
+    expired = end < now
+
+    publishButtonDisabled = !gtfsPlusValidation ||
+      hasGtfsPlusBlockingIssue ||
+      !gtfsPlusValidation.published ||
+      expired ||
+      !version.validationResult ||
+      !version.validationResult.error_counts ||
+      hasBlockingIssue ||
+      isPublished ||
+      processing ||
+      !userCanManageFeed
+
+    if (hasBlockingIssue || hasGtfsPlusBlockingIssue) {
+      publishWarningMessage = (
+        <span>
+          Cannot publish version because it has a{' '}
+          {hasGtfsPlusBlockingIssue ? 'GTFS+ ' : ''}
+          blocking issue.
+          (See{' '}
+          <Link
+            to={`/feed/${feedSource.id}/version/${version.version}/${hasGtfsPlusBlockingIssue ? 'gtfsplus' : 'issues'}`}>
+            {hasGtfsPlusBlockingIssue ? 'GTFS+' : 'validation'} issues
+          </Link>.)
+        </span>
+      )
+    } else if (expired) {
+      publishWarningMessage = 'Cannot publish version because it has expired.'
+    } else if (feedSource.autoPublish) {
+      publishWarningMessage = 'Reminder: this feed is already set to be auto-published after auto-fetch!'
+    }
+
+    return (
+      <div>
+        <ButtonToolbar className='pull-right' style={{ marginTop: '2px' }}>
+          <VersionSelectorDropdown
+            dropdownProps={{
+              id: 'merge-versions-dropdown',
+              disabled: isMergedServicePeriods,
+              onSelect: this._handleMergeVersion
+            }}
+            title={<span><Icon type='code-fork' />{' '}
+              {isMergedServicePeriods
+                ? 'Cannot re-merge feed'
+                : 'Merge with version'
+              }</span>}
+            itemFormatter={this._mergeItemFormatter}
+            version={version}
+            versions={feedSource.feedVersionSummaries}
+          />
+          <Button
+            disabled={publishButtonDisabled}
+            bsStyle={isPublished ? 'success' : 'warning'}
+            onClick={this._onClickPublish}>
+            {isPublished
+              ? <span><Icon type='check-circle' /> Published</span>
+              : processing
+                ? <span>Processing...</span>
+                : <span>Publish to MTC</span>
+            }
+          </Button>
+        </ButtonToolbar>
+        <div
+          className='pull-right text-danger'
+          style={{
+            clear: 'right',
+            fontSize: 'x-small',
+            marginLeft: '5px',
+            textAlign: 'right',
+            width: '180px'
+          }}
+        >
+          {publishWarningMessage}
+        </div>
+      </div>
+    )
+  }
+}

--- a/lib/manager/components/version/FeedVersionActionsMTC.js
+++ b/lib/manager/components/version/FeedVersionActionsMTC.js
@@ -49,7 +49,7 @@ function mergeItemFormatter (
   )
 }
 
-// Refactor opportunity wirg FeedSourceTableRow
+// TODO: Refactor with many similar calls
 function userCanManageFeed (user: ManagerUserState, version: FeedVersion): boolean {
   return !!user.permissions &&
     user.permissions.hasFeedPermission(
@@ -100,7 +100,7 @@ export default class FeedVersionActionsMTC extends Component<Props> {
     const hasGtfsPlusBlockingIssue = gtfsPlusValidation && gtfsPlusValidation.issues.length > 0
     const isMergedServicePeriods = version.retrievalMethod === 'SERVICE_PERIOD_MERGE'
 
-    // Refactor opportunity with VersionDateLabel and versionHasExpired.
+    // Expiry is computed same as with VersionDateLabel (TODO: refactor and reconcile with versionHasExpired).
     const now = +moment().startOf('day')
     const end = +moment(summary.endDate)
     const expired = end < now

--- a/lib/manager/components/version/FeedVersionActionsMTC.js
+++ b/lib/manager/components/version/FeedVersionActionsMTC.js
@@ -18,7 +18,7 @@ import type { ManagerUserState } from '../../../types/reducers'
 import VersionRetrievalBadge from './VersionRetrievalBadge'
 import VersionSelectorDropdown from './VersionSelectorDropdown'
 
-type Props = {
+export type Props = {
   feedSource: Feed,
   gtfsPlusValidation: GtfsPlusValidation,
   mergeVersions: typeof versionsActions.mergeVersions,

--- a/lib/manager/components/version/FeedVersionDetails.js
+++ b/lib/manager/components/version/FeedVersionDetails.js
@@ -6,22 +6,14 @@ import { ListGroupItem } from 'react-bootstrap'
 import area from 'turf-area'
 import bboxPoly from 'turf-bbox-polygon'
 
-import * as versionsActions from '../../actions/versions'
 import { getConfigProperty, isExtensionEnabled } from '../../../common/util/config'
-import type { Bounds, Feed, FeedVersion, GtfsPlusValidation } from '../../../types'
-import type { ManagerUserState } from '../../../types/reducers'
+import type { Bounds, FeedVersion } from '../../../types'
 
-import FeedVersionActionsMTC from './FeedVersionActionsMTC'
+import FeedVersionActionsMTC, { type Props as ActionsMTCProps } from './FeedVersionActionsMTC'
 import FeedVersionSpanChart from './FeedVersionSpanChart'
 
-type Props = {
+type Props = ActionsMTCProps & {
   comparedVersion: ?FeedVersion,
-  feedSource: Feed,
-  gtfsPlusValidation: GtfsPlusValidation,
-  mergeVersions: typeof versionsActions.mergeVersions,
-  publishFeedVersion: typeof versionsActions.publishFeedVersion,
-  user: ManagerUserState,
-  version: FeedVersion
 }
 
 export default class FeedVersionDetails extends Component<Props> {

--- a/lib/manager/components/version/FeedVersionDetails.js
+++ b/lib/manager/components/version/FeedVersionDetails.js
@@ -1,27 +1,18 @@
 // @flow
 
 import Icon from '@conveyal/woonerf/components/icon'
-import moment from 'moment'
-import React, {Component} from 'react'
-import {
-  Button,
-  ButtonToolbar,
-  ListGroupItem,
-  MenuItem
-} from 'react-bootstrap'
-import {Link} from 'react-router'
+import React, { Component } from 'react'
+import { ListGroupItem } from 'react-bootstrap'
 import area from 'turf-area'
 import bboxPoly from 'turf-bbox-polygon'
 
 import * as versionsActions from '../../actions/versions'
-import {getConfigProperty, isExtensionEnabled} from '../../../common/util/config'
-import {BLOCKING_ERROR_TYPES} from '../../util/version'
-import type {FeedVersion, FeedVersionSummary, GtfsPlusValidation, Bounds, Feed} from '../../../types'
-import type {ManagerUserState} from '../../../types/reducers'
+import { getConfigProperty, isExtensionEnabled } from '../../../common/util/config'
+import type { Bounds, Feed, FeedVersion, GtfsPlusValidation } from '../../../types'
+import type { ManagerUserState } from '../../../types/reducers'
 
+import FeedVersionActionsMTC from './FeedVersionActionsMTC'
 import FeedVersionSpanChart from './FeedVersionSpanChart'
-import VersionRetrievalBadge from './VersionRetrievalBadge'
-import VersionSelectorDropdown from './VersionSelectorDropdown'
 
 type Props = {
   comparedVersion: ?FeedVersion,
@@ -40,117 +31,10 @@ export default class FeedVersionDetails extends Component<Props> {
     return poly ? area(poly) : 0
   }
 
-  /**
-   * Check that the validation did not encounter any fatal exception or blocking
-   * errors.
-   */
-  _checkBlockingIssue = (version: FeedVersion) => {
-    if (version.validationResult.fatalException) return true
-    const errorCounts = version.validationResult.error_counts
-    return errorCounts &&
-      !!(errorCounts.find(ec => BLOCKING_ERROR_TYPES.indexOf(ec.type) !== -1))
-  }
-
-  _mergeItemFormatter = (v: FeedVersionSummary, activeVersion: ?FeedVersionSummary) => {
-    let name = v.name
-    let disabled = false
-    if (v.retrievalMethod === 'SERVICE_PERIOD_MERGE') {
-      name = '(Cannot re-merge feed)'
-      disabled = true
-    }
-    if (activeVersion && v.id === activeVersion.id) {
-      name = '(Cannot merge with self)'
-      disabled = true
-    }
-    return (
-      <MenuItem
-        key={v.id}
-        disabled={disabled}
-        eventKey={disabled ? null : v.id}
-      >
-        {v.version}. {name}{' '}
-        <VersionRetrievalBadge version={v} />
-      </MenuItem>
-    )
-  }
-
-  _handleMergeVersion = (versionId: string) => {
-    // Note: service period feed merge has only been extensively tested with
-    // MTC-specific logic.
-    this.props.mergeVersions(this.props.version.id, versionId, 'SERVICE_PERIOD')
-  }
-
-  _onClickPublish = () => this.props.publishFeedVersion(this.props.version)
-
-  render () {
-    const {
-      comparedVersion,
-      feedSource,
-      gtfsPlusValidation,
-      user,
-      version
-    } = this.props
-    const {validationSummary: summary} = version
-    // We must check the version ID against the feed source in props (not the
-    // feed source nested underneath version) because this is the only place the
-    // published version is updated.
-    const isPublished = version.namespace === feedSource.publishedVersionId
-    // Version is in the "processing" state if it has been sent to external
-    // source, but has not been processed yet.
-    const processing = version.sentToExternalPublisher &&
-      !version.processedByExternalPublisher
-    const userCanManageFeed = user.permissions &&
-      user.permissions.hasFeedPermission(
-        version.feedSource.organizationId,
-        version.feedSource.projectId,
-        version.feedSource.id,
-        'manage-feed'
-      )
-    const hasBlockingIssue = this._checkBlockingIssue(version)
-    const hasGtfsPlusBlockingIssue = gtfsPlusValidation && gtfsPlusValidation.issues.length > 0
-    const isMergedServicePeriods = version.retrievalMethod === 'SERVICE_PERIOD_MERGE'
-    const mergeButtonLabel = isMergedServicePeriods
-      ? 'Cannot re-merge feed'
-      : 'Merge with version'
-
+  render (): React$Element<any> {
+    const { comparedVersion, version } = this.props
+    const { validationSummary: summary } = version
     const hasMtcExtension = isExtensionEnabled('mtc')
-    let publishWarningMessage
-    let expired
-    if (hasMtcExtension) {
-      const now = +moment().startOf('day')
-      const end = +moment(summary.endDate)
-      expired = end < now
-
-      if (hasBlockingIssue || hasGtfsPlusBlockingIssue) {
-        publishWarningMessage = (
-          <span>
-            Cannot publish version because it has a{' '}
-            {hasGtfsPlusBlockingIssue ? 'GTFS+ ' : ''}
-            blocking issue.
-            (See{' '}
-            <Link
-              to={`/feed/${feedSource.id}/version/${version.version}/${hasGtfsPlusBlockingIssue ? 'gtfsplus' : 'issues'}`}>
-              {hasGtfsPlusBlockingIssue ? 'GTFS+' : 'validation'} issues
-            </Link>.)
-          </span>
-        )
-      } else if (expired) {
-        publishWarningMessage = 'Cannot publish version because it has expired.'
-      } else if (feedSource.autoPublish) {
-        publishWarningMessage = 'Reminder: this feed is already set to be auto-published after auto-fetch!'
-      }
-    }
-
-    const publishButtonDisabled = !gtfsPlusValidation ||
-      hasGtfsPlusBlockingIssue ||
-      !gtfsPlusValidation.published ||
-      expired ||
-      !version.validationResult ||
-      !version.validationResult.error_counts ||
-      hasBlockingIssue ||
-      isPublished ||
-      processing ||
-      !userCanManageFeed
 
     return (
       <ListGroupItem>
@@ -160,46 +44,7 @@ export default class FeedVersionDetails extends Component<Props> {
             Feed validity dates
           </span>
         </h4>
-        {hasMtcExtension &&
-          <ButtonToolbar className='pull-right' style={{ marginTop: '2px' }}>
-            <VersionSelectorDropdown
-              dropdownProps={{
-                id: 'merge-versions-dropdown',
-                disabled: isMergedServicePeriods,
-                onSelect: this._handleMergeVersion
-              }}
-              title={<span><Icon type='code-fork' /> {mergeButtonLabel}</span>}
-              itemFormatter={this._mergeItemFormatter}
-              version={version}
-              versions={feedSource.feedVersionSummaries}
-            />
-            <Button
-              disabled={publishButtonDisabled}
-              bsStyle={isPublished ? 'success' : 'warning'}
-              onClick={this._onClickPublish}>
-              {isPublished
-                ? <span><Icon type='check-circle' /> Published</span>
-                : processing
-                  ? <span>Processing...</span>
-                  : <span>Publish to MTC</span>
-              }
-            </Button>
-          </ButtonToolbar>
-        }
-        {hasMtcExtension && (
-          <div
-            className='pull-right text-danger'
-            style={{
-              clear: 'right',
-              fontSize: 'x-small',
-              marginLeft: '5px',
-              textAlign: 'right',
-              width: '180px'
-            }}
-          >
-            {publishWarningMessage}
-          </div>
-        )}
+        {hasMtcExtension && <FeedVersionActionsMTC {...this.props} />}
 
         <FeedVersionSpanChart
           activeVersion={version}

--- a/lib/manager/components/version/FeedVersionDetails.js
+++ b/lib/manager/components/version/FeedVersionDetails.js
@@ -1,6 +1,7 @@
 // @flow
 
 import Icon from '@conveyal/woonerf/components/icon'
+import moment from 'moment'
 import React, {Component} from 'react'
 import {
   Button,
@@ -114,7 +115,12 @@ export default class FeedVersionDetails extends Component<Props> {
 
     const hasMtcExtension = isExtensionEnabled('mtc')
     let publishWarningMessage
+    let expired
     if (hasMtcExtension) {
+      const now = +moment().startOf('day')
+      const end = +moment(summary.endDate)
+      expired = end < now
+
       if (hasBlockingIssue || hasGtfsPlusBlockingIssue) {
         publishWarningMessage = (
           <span>
@@ -128,10 +134,23 @@ export default class FeedVersionDetails extends Component<Props> {
             </Link>.)
           </span>
         )
+      } else if (expired) {
+        publishWarningMessage = 'Cannot publish version because it has expired.'
       } else if (feedSource.autoPublish) {
         publishWarningMessage = 'Reminder: this feed is already set to be auto-published after auto-fetch!'
       }
     }
+
+    const publishButtonDisabled = !gtfsPlusValidation ||
+      hasGtfsPlusBlockingIssue ||
+      !gtfsPlusValidation.published ||
+      expired ||
+      !version.validationResult ||
+      !version.validationResult.error_counts ||
+      hasBlockingIssue ||
+      isPublished ||
+      processing ||
+      !userCanManageFeed
 
     return (
       <ListGroupItem>
@@ -155,17 +174,7 @@ export default class FeedVersionDetails extends Component<Props> {
               versions={feedSource.feedVersionSummaries}
             />
             <Button
-              disabled={
-                !gtfsPlusValidation ||
-                hasGtfsPlusBlockingIssue ||
-                !gtfsPlusValidation.published ||
-                !version.validationResult ||
-                !version.validationResult.error_counts ||
-                hasBlockingIssue ||
-                isPublished ||
-                processing ||
-                !userCanManageFeed
-              }
+              disabled={publishButtonDisabled}
               bsStyle={isPublished ? 'success' : 'warning'}
               onClick={this._onClickPublish}>
               {isPublished


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected => this targets the mtc-deploy UI branch.
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Small MTC UI tweak to disable the "Publish to MTC" button if a feed version is expired.
I have added notes for project-wide permissions refactoring and left those out to avoid touching too many files.
