### PR TITLE
fix(FeedVersionActionsMTC): disable publish button if current feed version is being processed by server

### DIFF
--- a/lib/manager/components/version/FeedVersionActionsMTC.js
+++ b/lib/manager/components/version/FeedVersionActionsMTC.js
@@ -18,7 +18,7 @@ import VersionSelectorDropdown from './VersionSelectorDropdown'
 export type Props = {
   feedSource: Feed,
   gtfsPlusValidation: GtfsPlusValidation,
-  jobs: Array<ServerJob>,
+  jobs?: Array<ServerJob>,
   mergeVersions: typeof versionsActions.mergeVersions,
   publishFeedVersion: typeof versionsActions.publishFeedVersion,
   user: ManagerUserState,
@@ -108,7 +108,7 @@ class FeedVersionActionsMTC extends Component<Props> {
     const end = +moment(summary.endDate)
     const expired = end < now
 
-    const jobsProcessingThisVersion = jobs.some(job => job.feedVersionId === version.id)
+    const jobsProcessingThisVersion = jobs && jobs.some(job => job.feedVersionId === version.id)
 
     const publishButtonDisabled = !gtfsPlusValidation ||
       hasGtfsPlusBlockingIssue ||

--- a/lib/manager/components/version/FeedVersionActionsMTC.js
+++ b/lib/manager/components/version/FeedVersionActionsMTC.js
@@ -5,10 +5,11 @@ import moment from 'moment'
 import React, { Component } from 'react'
 import { Button, ButtonToolbar, MenuItem } from 'react-bootstrap'
 import { Link } from 'react-router'
+import { connect } from 'react-redux'
 
 import * as versionsActions from '../../actions/versions'
 import { BLOCKING_ERROR_TYPES } from '../../util/version'
-import type { Feed, FeedVersion, FeedVersionSummary, GtfsPlusValidation } from '../../../types'
+import type { Feed, FeedVersion, FeedVersionSummary, GtfsPlusValidation, ServerJob } from '../../../types'
 import type { ManagerUserState } from '../../../types/reducers'
 
 import VersionRetrievalBadge from './VersionRetrievalBadge'
@@ -17,6 +18,7 @@ import VersionSelectorDropdown from './VersionSelectorDropdown'
 export type Props = {
   feedSource: Feed,
   gtfsPlusValidation: GtfsPlusValidation,
+  jobs: Array<ServerJob>,
   mergeVersions: typeof versionsActions.mergeVersions,
   publishFeedVersion: typeof versionsActions.publishFeedVersion,
   user: ManagerUserState,
@@ -71,7 +73,7 @@ function checkBlockingIssue (version: FeedVersion): boolean {
     !!(errorCounts.find(ec => BLOCKING_ERROR_TYPES.indexOf(ec.type) !== -1))
 }
 
-export default class FeedVersionActionsMTC extends Component<Props> {
+class FeedVersionActionsMTC extends Component<Props> {
   _handleMergeVersion: ((versionId: string) => void) = (versionId: string) => {
     // Note: service period feed merge has only been extensively tested with
     // MTC-specific logic.
@@ -84,6 +86,7 @@ export default class FeedVersionActionsMTC extends Component<Props> {
     const {
       feedSource,
       gtfsPlusValidation,
+      jobs,
       user,
       version
     } = this.props
@@ -105,6 +108,8 @@ export default class FeedVersionActionsMTC extends Component<Props> {
     const end = +moment(summary.endDate)
     const expired = end < now
 
+    const jobsProcessingThisVersion = jobs.some(job => job.feedVersionId === version.id)
+
     const publishButtonDisabled = !gtfsPlusValidation ||
       hasGtfsPlusBlockingIssue ||
       !gtfsPlusValidation.published ||
@@ -114,7 +119,8 @@ export default class FeedVersionActionsMTC extends Component<Props> {
       hasBlockingIssue ||
       isPublished ||
       processing ||
-      !userCanManageFeed(user, version)
+      !userCanManageFeed(user, version) ||
+      jobsProcessingThisVersion
 
     let publishWarningMessage
     if (hasBlockingIssue || hasGtfsPlusBlockingIssue) {
@@ -184,3 +190,9 @@ export default class FeedVersionActionsMTC extends Component<Props> {
     )
   }
 }
+
+const mapStateToProps = state => ({
+  jobs: state.status.jobMonitor.jobs
+})
+
+export default connect(mapStateToProps)(FeedVersionActionsMTC)

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -1030,6 +1030,7 @@ export type MergeFeedsResult = {
 export type ServerJob = {
   deploymentId: ?string,
   feedSourceId: ?string,
+  feedVersionId: ?string,
   instanceId: ?string,
   jobId: string,
   mergeFeedsResult?: MergeFeedsResult,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

Adds a check if the current feed version is being processed by any server jobs. If so, then the publish button will be disabled until the jobs are completed.
