### PR TITLE
Fix dist folder layout

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -45,14 +45,13 @@ const config = getProcessEnvEntries('YAML_CONFIG')
 
 export default defineConfig({
   build: {
-    // Flatten the output for mastarm deploy (mastarm doesn't support uploading subfolders).
     assetsDir: '',
     rollupOptions: {
       // Specifying output file names is a bit arcane, the link below helped:
       // https://stackoverflow.com/questions/74228325/how-to-set-a-custom-output-name-for-script-with-vite-build
       output: {
-        assetFileNames: '[name][extname]',
-        entryFileNames: 'index.js'
+        assetFileNames: 'dist/[name][extname]',
+        entryFileNames: 'dist/index.js'
       },
       // Setting treeshake = true causes the build process to hang.
       // Thank you https://stackoverflow.com/a/79401432


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR tweaks the layout in the `/dist` folder, so that when deployed on datatools servers, the fonts and graphics are correctly referenced.
