### PR TITLE
change input type of leg_group_id

### DIFF
--- a/gtfs.yml
+++ b/gtfs.yml
@@ -1169,7 +1169,7 @@
   fields:
     - name: leg_group_id
       required: false
-      inputType: GTFS_ID
+      inputType: TEXT
       columnWidth: 12
     - name: network_id
       required: false

--- a/gtfs.yml
+++ b/gtfs.yml
@@ -1169,7 +1169,7 @@
   fields:
     - name: leg_group_id
       required: false
-      inputType: TEXT
+      inputType: TEXT # FARE-TODO: Needs to reference fare_transfer_rules.to/from_leg_group_id
       columnWidth: 12
     - name: network_id
       required: false


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] e2e tests are all passing _(remove this if not merging to master)_

### Description

Change the inputType of leg_group_id from GTFS_ID to TEXT. A TODO has been added to address the reference to fare_transfer_rule.
