### PR TITLE
Fix public feed page URL

### DIFF
--- a/lib/manager/components/ProjectViewer.js
+++ b/lib/manager/components/ProjectViewer.js
@@ -99,7 +99,7 @@ export default class ProjectViewer extends Component<Props, State> {
   _renderPublicFeeds = () => {
     const s3Bucket = getConfigProperty('application.data.gtfs_s3_bucket')
     const publicFeedsLink = s3Bucket &&
-      `https://s3.amazonaws.com/${s3Bucket}/public/index.html`
+      `https://${s3Bucket}.s3.amazonaws.com/public/index.html`
     return isModuleEnabled('enterprise') && !this._isProjectEditDisabled() &&
       <div style={{marginBottom: '20px'}}>
         <Button

--- a/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
+++ b/lib/manager/containers/__tests__/__snapshots__/ActiveProjectViewer.js.snap
@@ -4184,7 +4184,7 @@ exports[`lib > manager > ActiveProjectViewer should render with newly created pr
                                                          
                                                         Public feeds page can be viewed 
                                                         <a
-                                                          href="https://s3.amazonaws.com/bucket-name/public/index.html"
+                                                          href="https://bucket-name.s3.amazonaws.com/public/index.html"
                                                           target="_blank"
                                                         >
                                                           here


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR updates the S3 URL scheme ({bucket}.s3.amazonaws.com/item) for the public feed page. While old S3 buckets can still be accessed with the old URL scheme (s3.amazonaws.com/{bucket}/item), that scheme triggers a redirect response on newer buckets.
