### PR TITLE
Deployment Viewer: Remove Duplicate Fetch

### DIFF
--- a/lib/manager/components/deployment/CurrentDeploymentPanel.js
+++ b/lib/manager/components/deployment/CurrentDeploymentPanel.js
@@ -43,17 +43,6 @@ export default class CurrentDeploymentPanel extends Component<Props, State> {
     activeSummaryIndex: 0
   }
 
-  componentDidMount () {
-    // Fetch single deployment. This JSON response will contain the #ec2Instances
-    // field. The deployment prop that this component originally mounts with
-    // is not guaranteed to come with this field because it was likely fetched
-    // with the collection of all deployments for the project. We removed the
-    // #ec2Instances field from that response because it was causing very slow
-    // server responses (i.e., greater than 1 minute) and potentially the root of
-    // some server memory issues.
-    this.props.fetchDeployment(this.props.deployment.id)
-  }
-
   componentWillReceiveProps (nextProps: Props) {
     // If status message changes while deployment job is in progress, re-fetch
     // deployment to update EC2 instance status.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR removes a duplicate deployment fetch happening when opening/navigating to a deployment page.
The deployment box retains the ability to refetch the deployment when a job status gets updated.
